### PR TITLE
Fixed bug caused by hostId received as str

### DIFF
--- a/vdsm/storage/monitor.py
+++ b/vdsm/storage/monitor.py
@@ -169,7 +169,7 @@ class MonitorThread(object):
         self.stopEvent = threading.Event()
         self.domain = None
         self.sdUUID = sdUUID
-        self.hostId = hostId
+        self.hostId = int(hostId)
         self.interval = interval
         self.nextStatus = Status(actual=False)
         self.status = FrozenStatus(self.nextStatus)


### PR DESCRIPTION
Thread-25::ERROR::2015-04-20 07:18:20,537::monitor::366::Storage.Monitor::(_rele
aseHostId) Error releasing host id 2 for domain c54f691c-fc83-4a74-9c02-a68ef87e
68b3
Traceback (most recent call last):
  File "/usr/share/vdsm/storage/monitor.py", line 363, in _releaseHostId
    self.domain.releaseHostId(self.hostId, unused=True)
  File "/usr/share/vdsm/storage/sd.py", line 480, in releaseHostId
    self._clusterLock.releaseHostId(hostId, async, unused)
  File "/usr/share/vdsm/storage/clusterlock.py", line 249, in releaseHostId
    async=async, unused=unused)
TypeError: argument 2 must be integer<k>, not str
