### PR TITLE
sanlock: do not abort if groups is empty

### DIFF
--- a/lib/vdsm/tool/configurators/sanlock.py
+++ b/lib/vdsm/tool/configurators/sanlock.py
@@ -75,7 +75,7 @@ def isconfigured():
                     if status_line.startswith(proc_status_group_prefix):
                         groups = [int(x) for x in status_line[
                             len(proc_status_group_prefix):]
-                            .strip().split(" ")]
+                            .strip().split(" ") if x]
                         break
                 else:
                     raise InvalidConfig(


### PR DESCRIPTION
File "/usr/lib/python2.6/site-packages/vdsm/tool/configurators/sanlock.py", line 87, in isconfigured
    .strip().split(" ")]
    ValueError: invalid literal for int() with base 10: ''

Signed-off-by: Germano Veit Michel <germano@redhat.com>