### PR TITLE
tests: Skip test if veth_pair cannot be created

### DIFF
--- a/tests/network/nettestlib.py
+++ b/tests/network/nettestlib.py
@@ -327,9 +327,10 @@ def veth_pair(prefix='veth_', max_length=15):
     try:
         linkAdd(left_side, linkType='veth',
                 args=('peer', 'name', right_side))
+    except IPRoute2Error as e:
+        raise SkipTest('Failed to create a veth pair: %s', e)
+    try:
         yield left_side, right_side
-    except IPRoute2Error:
-        raise SkipTest('Failed to create a veth pair.')
     finally:
         # the peer device is removed by the kernel
         linkDel(left_side)


### PR DESCRIPTION
The context manager used try-except-finally in the wrong way, always
deleting the interface, even when we failed to create it.

Change-Id: I2f59fe4686df6ec2f7c081ee182fada19fc4cb63
Signed-off-by: Nir Soffer <nsoffer@redhat.com>