### PR TITLE
Fix build status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vdsm: Virtual Desktop Server Manager
 
-[![Build Status](https://travis-ci.org/nirs/vdsm.svg?branch=master)]
-(https://travis-ci.org/nirs/vdsm)
+[![Build Status](https://travis-ci.org/ovirt/vdsm.svg?branch=master)]
+(https://travis-ci.org/ovirt/vdsm)
 
 The Vdsm service exposes an API for managing virtualization
 hosts running the KVM hypervisor technology. Vdsm manages and monitors

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vdsm: Virtual Desktop Server Manager
 
-[![Build Status](https://travis-ci.org/ovirt/vdsm.svg?branch=master)]
-(https://travis-ci.org/ovirt/vdsm)
+[![Build Status](https://travis-ci.org/oVirt/vdsm.svg?branch=master)]
+(https://travis-ci.org/oVirt/vdsm)
 
 The Vdsm service exposes an API for managing virtualization
 hosts running the KVM hypervisor technology. Vdsm manages and monitors


### PR DESCRIPTION
Previously we pointed to Nir's private fork, now that ovirt's github is
triggering builds we should point to the correct builds.