### PR TITLE
hooks: added satabus hook.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -468,6 +468,7 @@ AC_OUTPUT([
 	vdsm_hooks/promisc/Makefile
 	vdsm_hooks/qemucmdline/Makefile
 	vdsm_hooks/qos/Makefile
+	vdsm_hooks/satabus/Makefile
 	vdsm_hooks/scratchpad/Makefile
 	vdsm_hooks/smbios/Makefile
 	vdsm_hooks/spiceoptions/Makefile

--- a/vdsm.spec.in
+++ b/vdsm.spec.in
@@ -574,6 +574,13 @@ BuildArch:      noarch
 %description hook-qos
 Hook adds QoS in/out traffic to VMs interfaces
 
+%package hook-satabus
+Summary:        Set SATA bus for disk drive
+BuildArch:      noarch
+
+%description hook-satabus
+VDSM hook allow to set SATA bus for disk devices.
+
 %package hook-scratchpad
 Summary:        One time disk creation for VDSM
 BuildArch:      noarch
@@ -1497,6 +1504,9 @@ exit 0
 
 %files hook-qos
 %{_libexecdir}/%{vdsm_name}/hooks/before_vm_start/50_qos
+
+%files hook-satabus
+%{_libexecdir}/%{vdsm_name}/hooks/before_vm_start/50_satabus
 
 %files hook-scratchpad
 %{_libexecdir}/%{vdsm_name}/hooks/before_vm_start/50_scratchpad

--- a/vdsm_hooks/satabus/Makefile.am
+++ b/vdsm_hooks/satabus/Makefile.am
@@ -1,0 +1,31 @@
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+#
+EXTRA_DIST = \
+	before_vm_start.py
+
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(vdsmhooksdir)/before_vm_start
+	$(INSTALL_SCRIPT) $(srcdir)/before_vm_start.py \
+		$(DESTDIR)$(vdsmhooksdir)/before_vm_start/50_satabus
+
+uninstall-local:
+	$(RM) $(DESTDIR)$(vdsmhooksdir)/before_vm_start/50_satabus
+

--- a/vdsm_hooks/satabus/README
+++ b/vdsm_hooks/satabus/README
@@ -1,0 +1,28 @@
+satabus vdsm hook:
+====================
+Hook set sata bus to disk drive, this may be useful for very old kernels,
+where kernel upgrade is impossible. For example: some special versions of
+"Cisco Virtual Wireless Controller" is unusable with iscsi bus.
+
+Syntax:
+  satabus=(off|on)
+
+Where:
+  'on' is sata bus enabled and off (default) is disabled.
+
+Example:
+   satabus=on
+
+Installation:
+===============
+
+  - Use the engine-config to append the proper custom property:
+      $ sudo engine-config -s UserDefinedVMProperties='satabus=^(off|on)$'
+  - Verify that the satabus custom property was properly added:
+      $ sudo engine-config -g UserDefinedVMProperties
+
+Usage:
+=======
+
+  In the VM configuration window, open the custom properites tab, select
+  satabus and select 'on'.

--- a/vdsm_hooks/satabus/before_vm_start.py
+++ b/vdsm_hooks/satabus/before_vm_start.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python2
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+
+
+'''
+Hook set sata bus to disk drive.
+
+Syntax:
+   satabus=(off|on)
+
+Example:
+   satabus=on
+'''
+
+import os
+import sys
+import traceback
+from xml.dom import minidom
+import hooking
+
+
+def addSataBus(domxml):
+    for disk in domxml.getElementsByTagName('disk'):
+        device = disk.getAttribute('device')
+        target = disk.getElementsByTagName('target')[0]
+        bus = target.getAttribute('bus')
+        if device == 'disk' and (bus in ['scsi', 'ide', 'virtio']):
+            target.setAttribute('bus', 'sata')
+
+
+def main():
+    if 'satabus' in os.environ:
+        sataConfig = os.environ['satabus']
+        domxml = hooking.read_domxml()
+        if sataConfig == 'on':
+            addSataBus(domxml)
+            hooking.write_domxml(domxml)
+
+
+def test():
+    text = """<disk device="disk" snapshot="no" type="network">
+<address bus="0" controller="0" target="0" type="drive" unit="1"/>
+<source name="rbd/volume-813b3e01-74e9-4e5b-a411-18854c21eff5" protocol="rbd">
+<host name="172.16.16.2" port="6789" transport="tcp"/>
+<host name="172.16.16.3" port="6789" transport="tcp"/>
+<host name="172.16.16.4" port="6789" transport="tcp"/>
+</source>
+<auth username="cinder">
+<secret type="ceph" uuid="e0828f39-2832-4d82-90ee-23b26fc7b20a"/>
+</auth>
+<target bus="scsi" dev="sda"/>
+<driver cache="none" error_policy="stop" io="threads" name="qemu" type="raw"/>
+</disk>"""
+
+    xmldom = minidom.parseString(text)
+
+    disk = xmldom.getElementsByTagName('disk')[0]
+    print("\nDisk device definition before execution: \n{0}".format(
+          disk.toxml(encoding='UTF-8')))
+
+    addSataBus(xmldom)
+
+    print("\nDisk device after set SATA attribute: \n{0}".format(
+          disk.toxml(encoding='UTF-8')))
+
+
+if __name__ == '__main__':
+    try:
+        if '--test' in sys.argv:
+            test()
+        else:
+            main()
+    except:
+        hooking.exit_hook(' satabus hook: [unexpected error]: {0}\n'.format(
+                          traceback.format_exc()))


### PR DESCRIPTION
Hook set sata bus to disk drive, this may be useful for very old kernels,
where kernel upgrade is impossible. For example: some special versions of
"Cisco Virtual Wireless Controller" is unusable with iscsi bus.

Signed-off-by: Konstantin Shalygin <k0ste@k0ste.ru>