### PR TITLE
image,blockSD,fileSD: add is_block()

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -1576,6 +1576,10 @@ class BlockStorageDomain(sd.StorageDomain):
                     # Forcibly rebooting the SPM host would be safer. ???
                     raise se.StorageDomainMasterUnmountError(masterdir, 1)
 
+    @classmethod
+    def is_block(cls):
+        return True
+
     def unmountMaster(self):
         """
         Unmount the master metadata file system. Should be called only by SPM.

--- a/lib/vdsm/storage/fileSD.py
+++ b/lib/vdsm/storage/fileSD.py
@@ -644,6 +644,10 @@ class FileStorageDomain(sd.StorageDomain):
 
         return True
 
+    @classmethod
+    def is_block(cls):
+        return False
+
     def getRemotePath(self):
         return self._manifest.remotePath
 

--- a/lib/vdsm/storage/image.py
+++ b/lib/vdsm/storage/image.py
@@ -462,8 +462,7 @@ class Image:
                         preallocation=preallocation,
                         unordered_writes=destDom.recommends_unordered_writes(
                             dstVol.getFormat()),
-                        create=(destDom.getStorageType() not in
-                                sd.BLOCK_DOMAIN_TYPES)
+                        create=not destDom.is_block(),
                     )
                     with utils.stopwatch("Copy volume %s"
                                          % srcVol.volUUID):
@@ -754,8 +753,7 @@ class Image:
                         preallocation=preallocation,
                         unordered_writes=destDom.recommends_unordered_writes(
                             dstVolFormat),
-                        create=(destDom.getStorageType() not in
-                                sd.BLOCK_DOMAIN_TYPES)
+                        create=not destDom.is_block(),
                     )
                     with utils.stopwatch("Copy volume %s"
                                          % srcVol.volUUID):


### PR DESCRIPTION
is_block will provide a cleaner way to check the
type of the storage domain

Change-Id: I934fbff94060e3f3c52463a02e13a5f7610759c5
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>