### PR TITLE
storageServer: Added validation for gluster volume type

### DIFF
--- a/lib/vdsm/storage/storageServer.py
+++ b/lib/vdsm/storage/storageServer.py
@@ -298,6 +298,11 @@ class GlusterFSConnection(MountConnection):
         if not self.volinfo:
             return
 
+        if "Disperse" in self.volinfo['volumeType']:
+            self.log.warning("Unsupported volume type for volume %r "
+                             , self._volname)
+            return
+
         replicaCount = self.volinfo['replicaCount']
         if replicaCount not in self.ALLOWED_REPLICA_COUNTS:
             self.log.warning("Unsupported replica count (%s) for volume %r, "


### PR DESCRIPTION
storageServer: Added validation for gluster volume type for disperse volume. As disperse volumes are unsupported

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1940118