### PR TITLE
github: Add storage tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,3 +8,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run linters
       run: ./automation/lint.sh
+  test-storage:
+    env:
+      TRAVIS_CI: 1
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/ovirt/vdsm-test-centos-8
+      # Required to create loop devices.
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run storage tests
+      run: ./automation/tests-storage.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Virtual Desktop Server Manager
 
-[![Build Status](https://travis-ci.org/oVirt/vdsm.svg?branch=master)](https://travis-ci.org/oVirt/vdsm)
+[![CI Status](https://github.com/oVirt/vdsm/actions/workflows/ci.yml/badge.svg)](https://github.com/oVirt/vdsm/actions)
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/package/vdsm/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/package/vdsm/)
 
 Welcome to the Vdsm source repository.

--- a/automation/tests-storage.sh
+++ b/automation/tests-storage.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+
+create_loop_devices() {
+    local last=$(($1-1))
+    local min
+    for min in `seq 0 $last`; do
+        local name=/dev/loop$min
+        if [ ! -e "$name" ]; then
+            mknod --mode 0666 $name b 7 $min
+        fi
+    done
+}
+
+setup_storage() {
+    python3 tests/storage/userstorage.py setup
+}
+
+teardown_storage() {
+    python3 tests/storage/userstorage.py teardown \
+        || echo "WARNING: Ingoring error while tearing down user storage"
+}
+
+# Configure lvm to ignore udev events, otherwise some lvm tests hang.
+mkdir -p /etc/lvm
+cp docker/lvmlocal.conf /etc/lvm/
+
+# Make sure we have enough loop device nodes. Using 16 devices since with 8
+# devices we have random mount failures.
+create_loop_devices 16
+
+# Build vdsm.
+./autogen.sh --system
+make
+
+# Setup user stoage during the tests.
+trap teardown_storage EXIT
+setup_storage
+
+make tests-storage


### PR DESCRIPTION
Add job running "make tests-storage".

We use --privileged option since creating loop devices in the container
does not work without this option in github actions. This works in
gitlab CI, so we probably have a better way to do this, but lets start
with something that works on github.

Change-Id: I791b9a2dbcfbef9797da55a3e9aff12450ceb1b9
Signed-off-by: Nir Soffer <nsoffer@redhat.com>