### PR TITLE
lvm devices file configuration

### DIFF
--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -441,6 +441,16 @@ parameters = [
             'after rescan or connecting to a new server (default 10).'),
     ]),
 
+    # Section: [lvm]
+    ('lvm', [
+
+        ('config_method', 'filter',
+            'Method how to specify devices which LVM can use. Possible values'
+            'are either "filter" or "devices". Filter method will use LVM '
+            'filter, while device will use LVM devices file. The default '
+            'value is "filter".'),
+    ]),
+
     # Section: [sanlock]
     ('sanlock', [
 

--- a/lib/vdsm/storage/Makefile.am
+++ b/lib/vdsm/storage/Makefile.am
@@ -63,6 +63,7 @@ dist_vdsmstorage_PYTHON = \
 	localFsSD.py \
 	lvm.py \
 	lvmconf.py \
+	lvmdevices.py \
 	lvmfilter.py \
 	lsof.py \
 	mailbox.py \

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -53,6 +53,24 @@ def is_configured():
     return _enabled() and _devices_file_exists()
 
 
+def configure(vgs):
+    """
+    Configure lvm to use devices file and create initial system devices file.
+    """
+    # Always configure devices file. File maybe be empty or not up to date.
+    # On the other hand configuring correct devices file doesn't cause any
+    # harm.
+    try:
+        _create_system_devices(vgs)
+    except cmdutils.Error:
+        log.warning("Failed to create system devices file.")
+        raise
+
+    # Devices file was created, enable devices/use_devicesfile in lvm config.
+    log.debug("Enabling lvm devices/use_devicesfile.")
+    _configure_devices_file(enable=True)
+
+
 def _enabled():
     """
     Return True if lvm is configured to use devices file. Devices file itself

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -37,6 +37,7 @@ import subprocess
 from vdsm.common import cmdutils
 from vdsm.common import commands
 from vdsm.storage import lvmconf
+from vdsm.storage import lvmfilter
 
 LVM = "/usr/sbin/lvm"
 _LVM_SYSTEM_DEVICES_PATH = "/etc/lvm/devices/system.devices"
@@ -56,6 +57,8 @@ def is_configured():
 def configure(vgs):
     """
     Configure lvm to use devices file and create initial system devices file.
+    When we succeed, remove lvm filter if there is any, as it's not needed
+    any more.
     """
     # Always configure devices file. File maybe be empty or not up to date.
     # On the other hand configuring correct devices file doesn't cause any
@@ -73,6 +76,10 @@ def configure(vgs):
     # Devices file is now configured and enabled, check if it's valid and
     # inform the user if it's not.
     _run_check()
+
+    # We are done with configuration of lvm devices file and lvm filter is not
+    # needed/used any more. Remove it, if there is any.
+    lvmfilter.remove_filter()
 
 
 def _enabled():

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -64,3 +64,13 @@ def _devices_file_exists():
     exists, lvm disables whole devices file functionality.
     """
     return os.path.exists(_LVM_SYSTEM_DEVICES_PATH)
+
+
+def _configure_devices_file(enable=True):
+    """
+    Configure lvm to use devices file or disable it.
+    """
+    enabled = 1 if enable else 0
+    with lvmconf.LVMConfig() as config:
+        config.setint("devices", "use_devicesfile", enabled)
+        config.save()

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+"""
+Manage LVM devices and LVM devices file.
+
+This module provides the infrastructure for configuring LVM devices on a
+host, ensuring that LVM can access only the devices needed by the host
+mounted filesystems, and cannot access logical volumes on shared
+storage, which are owned by vdsm. This is going to be replacement of LVM
+filter.
+
+The module should be used from command line running as root such as
+vdsm-tool.
+"""
+
+import logging
+import os
+
+from vdsm.storage import lvmconf
+
+_LVM_SYSTEM_DEVICES_PATH = "/etc/lvm/devices/system.devices"
+
+log = logging.getLogger("lvmdevices")
+
+
+def is_configured():
+    """
+    Return True if lvm is configured to use devices file, which means that it's
+    enabled in lvm configuration and devices file must exists.
+    """
+    return _enabled() and _devices_file_exists()
+
+
+def _enabled():
+    """
+    Return True if lvm is configured to use devices file. Devices file itself
+    is not needed to be configured as it has predefined value by lvm.
+    """
+    with lvmconf.LVMConfig() as config:
+        use_devicesfile = config.getint("devices", "use_devicesfile") == 1
+        return use_devicesfile
+
+
+def _devices_file_exists():
+    """
+    Returns True if default lvm devices file exists. If the file doesn't
+    exists, lvm disables whole devices file functionality.
+    """
+    return os.path.exists(_LVM_SYSTEM_DEVICES_PATH)

--- a/lib/vdsm/storage/lvmfilter.py
+++ b/lib/vdsm/storage/lvmfilter.py
@@ -64,7 +64,8 @@ WWID_ATTRIBUTE = {
 log = logging.getLogger("lvmfilter")
 
 
-MountInfo = collections.namedtuple("MountInfo", "lv,mountpoint,devices")
+MountInfo = collections.namedtuple(
+    "MountInfo", "lv,mountpoint,vg_name,devices")
 FilterItem = collections.namedtuple("FilterItem", "action,path")
 Advice = collections.namedtuple("Advice", "action,filter,wwids")
 
@@ -172,7 +173,7 @@ def find_lvm_mounts():
             log.debug("Skipping oVirt logical volume %r", name)
             continue
         devices = vg_devices(vg_name)
-        mounts.append(MountInfo(name, mountpoint, devices))
+        mounts.append(MountInfo(name, mountpoint, vg_name, devices))
 
     # Keep sorted for easy testing.
     return sorted(mounts)

--- a/lib/vdsm/storage/lvmfilter.py
+++ b/lib/vdsm/storage/lvmfilter.py
@@ -49,6 +49,7 @@ import re
 from vdsm.common import errors
 from vdsm.common import udevadm
 from vdsm.common.compat import subprocess
+from vdsm.storage import lvmconf
 
 LSBLK = "/usr/bin/lsblk"
 LVM = "/usr/sbin/lvm"
@@ -536,6 +537,17 @@ def resolve_devices(filter_items):
             resolved_items.append(FilterItem(r.action, r.path))
 
     return normalize_items(resolved_items)
+
+
+def remove_filter():
+    """
+    Remove LVM filter from LVM configuration file.
+    """
+    with lvmconf.LVMConfig() as config:
+        current_filter = config.getlist("devices", "filter")
+        if current_filter:
+            config.remove("devices", "filter")
+            config.save()
 
 
 def _run(args):

--- a/lib/vdsm/storage/lvmfilter.py
+++ b/lib/vdsm/storage/lvmfilter.py
@@ -461,8 +461,11 @@ def vg_info(lv_path):
         "--readonly",
         # If the host was already configured, the lvm filter hides the devices
         # of the mounted master lv, and lvs will fail. Use a permissive filter
-        # to avoid this.
-        "--config", 'devices {filter=["a|.*|"]}',
+        # to avoid this. Also, run lvs with devices file disabled. This allows
+        # us to avoid warnings that filter should be used while devices file is
+        # enabled. This can happen when lvm is configured to use devices file,
+        # but vdsm is configured to use filter.
+        "--config", 'devices {use_devicesfile = 0 filter=["a|.*|"]}',
         "--options", "vg_name,vg_tags",
         lv_path
     ])
@@ -484,8 +487,12 @@ def vg_devices(vg_name):
         "--noheadings",
         "--readonly",
         # If the host has an incorrect filter, some devices needed by the host
-        # may be hidden, preventing creating of a new correct filter.
-        "--config", 'devices {filter=["a|.*|"]}',
+        # may be hidden, preventing creating of a new correct filter. Also, run
+        # lvs with devices file disabled. This allows us to avoid warnings that
+        # filter should be used while devices file is enabled. This can happen
+        # when lvm is configured to use devices file, but vdsm is configured to
+        # use filter.
+        "--config", 'devices {use_devicesfile = 0 filter=["a|.*|"]}',
         "--options", "pv_name",
         vg_name
     ])

--- a/lib/vdsm/tool/config_lvm_filter.py
+++ b/lib/vdsm/tool/config_lvm_filter.py
@@ -101,14 +101,7 @@ def config_with_filter(
 
     # We need to configure LVM filter.
 
-    _print_mounts(mounts)
-    _print_recommended_filter(wanted_filter)
-
-    if current_filter:
-        _print_current_filter(current_filter)
-
-    if advice.wwids:
-        _print_wanted_blacklist(advice.wwids)
+    _print_summary(mounts, current_filter, wanted_filter, advice.wwids)
 
     if advice.action == lvmfilter.CONFIGURE:
 
@@ -199,3 +192,14 @@ recommended 'blacklist' section.
 
 It is recommended to reboot to verify the new configuration.
     """)
+
+
+def _print_summary(mounts, current_filter, wanted_filter, advice_wwids):
+    _print_mounts(mounts)
+    _print_recommended_filter(wanted_filter)
+
+    if current_filter:
+        _print_current_filter(current_filter)
+
+    if advice_wwids:
+        _print_wanted_blacklist(advice_wwids)

--- a/lib/vdsm/tool/config_lvm_filter.py
+++ b/lib/vdsm/tool/config_lvm_filter.py
@@ -109,6 +109,7 @@ def config_with_filter(args):
 
         with lvmconf.LVMConfig() as config:
             config.setlist("devices", "filter", advice.filter)
+            config.setint("devices", "use_devicesfile", 0)
             config.save()
 
         _print_success()
@@ -213,7 +214,8 @@ WARNING: The current LVM filter does not match the recommended filter,
 Vdsm cannot configure the filter automatically.
 
 Please edit /etc/lvm/lvm.conf and set the 'filter' option in the
-'devices' section to the recommended value.
+'devices' section to the recommended value. Also make sure that
+'use_devicesfile' in this section is set to 0.
 
 Make sure /etc/multipath/conf.d/vdsm_blacklist.conf is set with the
 recommended 'blacklist' section.

--- a/tests/storage/lvmfilter_test.py
+++ b/tests/storage/lvmfilter_test.py
@@ -98,14 +98,14 @@ def fake_sys_block_info(monkeypatch, tmpdir):
 
 @pytest.mark.parametrize("plat,expected", [
     ("rhel74", [
-        MountInfo("/dev/mapper/vg0-lv_home", "/home", FAKE_DEVICES),
-        MountInfo("/dev/mapper/vg0-lv_root", "/", FAKE_DEVICES),
-        MountInfo("/dev/mapper/vg0-lv_swap", "[SWAP]", FAKE_DEVICES),
+        MountInfo("/dev/mapper/vg0-lv_home", "/home", "vg0", FAKE_DEVICES),
+        MountInfo("/dev/mapper/vg0-lv_root", "/", "vg0", FAKE_DEVICES),
+        MountInfo("/dev/mapper/vg0-lv_swap", "[SWAP]", "vg0", FAKE_DEVICES),
     ]),
     ("fedora", [
-        MountInfo("/dev/mapper/fedora-home", "/home", FAKE_DEVICES),
-        MountInfo("/dev/mapper/fedora-root", "/", FAKE_DEVICES),
-        MountInfo("/dev/mapper/fedora-swap", "[SWAP]", FAKE_DEVICES),
+        MountInfo("/dev/mapper/fedora-home", "/home", "vg0", FAKE_DEVICES),
+        MountInfo("/dev/mapper/fedora-root", "/", "vg0", FAKE_DEVICES),
+        MountInfo("/dev/mapper/fedora-swap", "[SWAP]", "vg0", FAKE_DEVICES),
     ]),
 ])
 def test_find_lvm_mounts(monkeypatch, plat, expected):
@@ -119,9 +119,9 @@ def test_find_lvm_mounts(monkeypatch, plat, expected):
 
     def fake_vg_info(lv_path):
         if lv_path.endswith("-master"):
-            return "vg_name", ["tag", lvmfilter.OVIRT_VG_TAG, "another"]
+            return "vg0", ["tag", lvmfilter.OVIRT_VG_TAG, "another"]
         else:
-            return "vg_name", ["no,ovirt,tag"]
+            return "vg0", ["no,ovirt,tag"]
 
     monkeypatch.setattr(lvmfilter, "vg_info", fake_vg_info)
     monkeypatch.setattr(lvmfilter, "vg_devices", lambda x: FAKE_DEVICES)
@@ -135,12 +135,15 @@ def test_build_filter():
     mounts = [
         MountInfo("/dev/mapper/vg0-lv_home",
                   "/home",
+                  "vg0",
                   ["/dev/sda2", "/dev/sdb2"]),
         MountInfo("/dev/mapper/vg0-lv_root",
                   "/",
+                  "vg0",
                   ["/dev/sda2"]),
         MountInfo("/dev/mapper/vg0-lv_swap",
                   "[SWAP]",
+                  "vg0",
                   ["/dev/sda2"]),
     ]
     lvm_filter = lvmfilter.build_filter(mounts)
@@ -590,6 +593,7 @@ def test_find_wwids(monkeypatch, fake_sys_block_info):
     mounts = [
         MountInfo("/dev/mapper/vg0-lv_root",
                   "/",
+                  "vg0",
                   ["/dev/sda2"]),
     ]
 


### PR DESCRIPTION
[LVM devices](https://man7.org/linux/man-pages/man8/lvmdevices.8.html) file is a new way how specify devices which should be used by LVM and is a replacement for LVM filter. LVM devides file is optional on RHEL 8.5 and the default on RHEL 9. However, LVM filter can still be used if needed. Once LVM is configured to use devices file, LVM filter is ignored, even if explicitly specified.

This enhancement will implement LVM devices file configuration and usage in vdsm and is tracked by [BZ #2012830](https://bugzilla.redhat.com/2012830).
As it's very hard to configure the LVM filter in vdsm and in some case we have to ask user to do it manually, using devices files allows us to simplify host configuration and upgrade flows and therefore is preferred way how to specify LVM devices. As mentioned above, LVM filter still can be used, but to simplify the code, vdsm will require to use LVM devices file instead of LVM filter. To make transition more smooth and to have an option how to switch back to LVM fitler when needed, new configuration option will be added into vdsm config. This option will specify, if the LVM should use filter or devices file. This information is also important for executing LVM commands as vdsm uses defensive approach and for each LVM command limits the command scope by specifying the device(s) on which command should be executed. To continue with it, vdsm has to know if it should use filter or devices file.

Host subsystems are configured during installation of upgrade by vdsm configurators. The only exception is LVM filter, which is for historical reasons configured by `vdsm-tool config-lvm-filter` called directly from Ansible playbook. The required order of operations is as follows:

* configure multipath blacklist
* configure LVM filter of devices file
* configure remaining subsystems

The important point here is to configure LVM devices files before configuring and starting multipath. If we fail to do that, multipath can grab local device and use show them as iSCSI devices in engine. This flow can be implemented using vdsm configurators, but to lower number of changes, current approach is reused and LVM devices configuration is done in `config-lvm-filter`.

This PR introduces LVM devices configuration:

* adding new vdsm configuration option, which determines if LVM should use filter or devices file
* enabling LVM devices file in LVM configuration
* checking mounted devices on given host and detecting VGs which use these devices
* creating initial LVM devices file from these VGs
* removing LVM fitler from LVM configuration, if there is any

Next steps:

* As mentioned above, vdsm specifies device for each command, using LVM filter. This needs to be replaced by using devices file if vdsm is configured to use devices file.
* Check existing code and remove unneeded stuf related to LVM filter.