### PR TITLE
Add support for disk conversion

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -842,14 +842,15 @@ class Volume(APIBase):
 
     def create(self, size, volFormat, preallocate, diskType, desc,
                srcImgUUID, srcVolUUID, initialSize=None, addBitmaps=False,
-               legal=True):
+               legal=True, sequence=0):
         return self._irs.createVolume(self._sdUUID, self._spUUID,
                                       self._imgUUID, size, volFormat,
                                       preallocate, diskType, self._UUID, desc,
                                       srcImgUUID, srcVolUUID,
                                       initialSize=initialSize,
                                       addBitmaps=addBitmaps,
-                                      legal=legal)
+                                      legal=legal,
+                                      sequence=sequence)
 
     def delete(self, postZero, force, discard=False):
         return self._irs.deleteVolume(self._sdUUID, self._spUUID,

--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -841,13 +841,15 @@ class Volume(APIBase):
                                    discard)
 
     def create(self, size, volFormat, preallocate, diskType, desc,
-               srcImgUUID, srcVolUUID, initialSize=None, addBitmaps=False):
+               srcImgUUID, srcVolUUID, initialSize=None, addBitmaps=False,
+               legal=True):
         return self._irs.createVolume(self._sdUUID, self._spUUID,
                                       self._imgUUID, size, volFormat,
                                       preallocate, diskType, self._UUID, desc,
                                       srcImgUUID, srcVolUUID,
                                       initialSize=initialSize,
-                                      addBitmaps=addBitmaps)
+                                      addBitmaps=addBitmaps,
+                                      legal=legal)
 
     def delete(self, postZero, force, discard=False):
         return self._irs.deleteVolume(self._sdUUID, self._spUUID,

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -11874,6 +11874,13 @@ Volume.create:
         name: legal
         type: boolean
         added: '4.5'
+
+    -   defaultvalue: 0
+        description: The sequence number of the volume. Newer volume will have
+            a higher number.
+        name: sequence
+        type: int
+        added: '4.5'
     return:
         description: A task UUID
         type: *UUID

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -11866,6 +11866,14 @@ Volume.create:
         name: addBitmaps
         type: boolean
         added: '4.4'
+
+    -   defaultvalue: true
+        description: Create legal volume that can be used by the system
+            immediately. Set to false to create illegal volume that cannot
+            be used by the system. To use the volume it must be set to legal.
+        name: legal
+        type: boolean
+        added: '4.5'
     return:
         description: A task UUID
         type: *UUID

--- a/lib/vdsm/storage/constants.py
+++ b/lib/vdsm/storage/constants.py
@@ -214,6 +214,7 @@ DESCRIPTION = "DESCRIPTION"
 LEGALITY = "LEGALITY"
 MTIME = "MTIME"
 GENERATION = "GEN"  # Added in 4.1
+SEQUENCE = "SEQ"  # Added in 4.5
 
 # In block storage, metadata size is limited to BLOCK_SIZE (512), to
 # ensure that metadata is written atomically. This is big enough for the
@@ -242,6 +243,7 @@ GENERATION = "GEN"  # Added in 4.1
 # TYPE=PREALLOCATED                           # PREALLOCATED|UNKNOWN|SPARSE
 # VOLTYPE=INTERNAL                            # INTERNAL|SHARED|LEAF
 # GEN=999                                     # int
+# SEQ=4294967295                              # int
 # EOF
 #
 # For more info why this is the worst possible case, see
@@ -268,6 +270,10 @@ DESCRIPTION_SIZE = 210
 # after reaching its maximum value.
 DEFAULT_GENERATION = 0
 MAX_GENERATION = 999  # Since this is represented in ASCII, limit to 3 places
+
+# The SEQUENCE metadata may be missing, as it was added only in 4.5.
+DEFAULT_SEQUENCE = 0
+MAX_SEQUENCE = 2**32 - 1
 
 # Block volume metadata tags
 TAG_PREFIX_MD = "MD_"

--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -1253,7 +1253,8 @@ class HSM(object):
                      preallocate, diskType, volUUID, desc,
                      srcImgUUID=sc.BLANK_UUID,
                      srcVolUUID=sc.BLANK_UUID,
-                     initialSize=None, addBitmaps=False):
+                     initialSize=None, addBitmaps=False,
+                     legal=True):
         """
         Create a new volume
             Function Type: SPM
@@ -1290,7 +1291,7 @@ class HSM(object):
         self._spmSchedule(spUUID, "createVolume", pool.createVolume, sdUUID,
                           imgUUID, capacity, volFormat, preallocate, diskType,
                           volUUID, desc, srcImgUUID, srcVolUUID, initial_size,
-                          addBitmaps)
+                          addBitmaps, legal)
 
     @public
     def deleteVolume(self, sdUUID, spUUID, imgUUID, volumes, postZero=False,

--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -1254,7 +1254,8 @@ class HSM(object):
                      srcImgUUID=sc.BLANK_UUID,
                      srcVolUUID=sc.BLANK_UUID,
                      initialSize=None, addBitmaps=False,
-                     legal=True):
+                     legal=True,
+                     sequence=0):
         """
         Create a new volume
             Function Type: SPM
@@ -1263,10 +1264,11 @@ class HSM(object):
         """
         argsStr = ("sdUUID=%s, spUUID=%s, imgUUID=%s, size=%s, volFormat=%s, "
                    "preallocate=%s, diskType=%s, volUUID=%s, desc=%s, "
-                   "srcImgUUID=%s, srcVolUUID=%s, initialSize=%s" %
+                   "srcImgUUID=%s, srcVolUUID=%s, initialSize=%s, "
+                   "sequence=%s" %
                    (sdUUID, spUUID, imgUUID, size, volFormat, preallocate,
                     diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-                    initialSize))
+                    initialSize, sequence))
         vars.task.setDefaultException(se.VolumeCreationError(argsStr))
         # Validates that the pool is connected. WHY?
         pool = self.getPool(spUUID)
@@ -1291,7 +1293,7 @@ class HSM(object):
         self._spmSchedule(spUUID, "createVolume", pool.createVolume, sdUUID,
                           imgUUID, capacity, volFormat, preallocate, diskType,
                           volUUID, desc, srcImgUUID, srcVolUUID, initial_size,
-                          addBitmaps, legal)
+                          addBitmaps, legal, sequence)
 
     @public
     def deleteVolume(self, sdUUID, spUUID, imgUUID, volumes, postZero=False,

--- a/lib/vdsm/storage/sd.py
+++ b/lib/vdsm/storage/sd.py
@@ -1206,14 +1206,16 @@ class StorageDomain(object):
 
     def createVolume(self, imgUUID, capacity, volFormat, preallocate, diskType,
                      volUUID, desc, srcImgUUID, srcVolUUID,
-                     initial_size=None, add_bitmaps=False, legal=True):
+                     initial_size=None, add_bitmaps=False, legal=True,
+                     sequence=0):
         """
         Create a new volume
         """
         return self.getVolumeClass().create(
             self._getRepoPath(), self.sdUUID, imgUUID, capacity, volFormat,
             preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-            initial_size=initial_size, add_bitmaps=add_bitmaps, legal=legal)
+            initial_size=initial_size, add_bitmaps=add_bitmaps, legal=legal,
+            sequence=sequence)
 
     def getMDPath(self):
         return self._manifest.getMDPath()

--- a/lib/vdsm/storage/sd.py
+++ b/lib/vdsm/storage/sd.py
@@ -1206,14 +1206,14 @@ class StorageDomain(object):
 
     def createVolume(self, imgUUID, capacity, volFormat, preallocate, diskType,
                      volUUID, desc, srcImgUUID, srcVolUUID,
-                     initial_size=None, add_bitmaps=False):
+                     initial_size=None, add_bitmaps=False, legal=True):
         """
         Create a new volume
         """
         return self.getVolumeClass().create(
             self._getRepoPath(), self.sdUUID, imgUUID, capacity, volFormat,
             preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-            initial_size=initial_size, add_bitmaps=add_bitmaps)
+            initial_size=initial_size, add_bitmaps=add_bitmaps, legal=legal)
 
     def getMDPath(self):
         return self._manifest.getMDPath()

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -1888,7 +1888,8 @@ class StoragePool(object):
                      srcVolUUID=sc.BLANK_UUID,
                      initialSize=None,
                      addBitmaps=False,
-                     legal=True):
+                     legal=True,
+                     sequence=0):
         """
         Creates a new volume.
 
@@ -1929,6 +1930,9 @@ class StoragePool(object):
         :param legal: If true, create the volume as legal.
         :type legal: boolean
 
+        :type sequence: int
+        :param sequence: The sequence number of the volume.
+
         :returns: a dict with the UUID of the new volume.
         :rtype: dict
         """
@@ -1953,7 +1957,8 @@ class StoragePool(object):
                 imgUUID=imgUUID, capacity=size, volFormat=volFormat,
                 preallocate=preallocate, diskType=diskType, volUUID=volUUID,
                 desc=desc, srcImgUUID=srcImgUUID, srcVolUUID=srcVolUUID,
-                initial_size=initialSize, add_bitmaps=addBitmaps, legal=legal)
+                initial_size=initialSize, add_bitmaps=addBitmaps, legal=legal,
+                sequence=sequence)
         return dict(uuid=newVolUUID)
 
     def deleteVolume(self, sdUUID, imgUUID, volumes, postZero, force, discard):

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -1887,7 +1887,8 @@ class StoragePool(object):
                      srcImgUUID=sc.BLANK_UUID,
                      srcVolUUID=sc.BLANK_UUID,
                      initialSize=None,
-                     addBitmaps=False):
+                     addBitmaps=False,
+                     legal=True):
         """
         Creates a new volume.
 
@@ -1925,6 +1926,8 @@ class StoragePool(object):
         :param addBitmaps: If true, add source volume bitmaps to the
                            created volume.
         :type addBitmaps: boolean
+        :param legal: If true, create the volume as legal.
+        :type legal: boolean
 
         :returns: a dict with the UUID of the new volume.
         :rtype: dict
@@ -1950,7 +1953,7 @@ class StoragePool(object):
                 imgUUID=imgUUID, capacity=size, volFormat=volFormat,
                 preallocate=preallocate, diskType=diskType, volUUID=volUUID,
                 desc=desc, srcImgUUID=srcImgUUID, srcVolUUID=srcVolUUID,
-                initial_size=initialSize, add_bitmaps=addBitmaps)
+                initial_size=initialSize, add_bitmaps=addBitmaps, legal=legal)
         return dict(uuid=newVolUUID)
 
     def deleteVolume(self, sdUUID, imgUUID, volumes, postZero, force, discard):

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -1138,7 +1138,7 @@ class Volume(object):
     @classmethod
     def create(cls, repoPath, sdUUID, imgUUID, capacity, volFormat,
                preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-               initial_size=None, add_bitmaps=False):
+               initial_size=None, add_bitmaps=False, legal=True):
         """
         Create a new volume with given size or snapshot
             'capacity' - in bytes
@@ -1150,6 +1150,8 @@ class Volume(object):
             'initial_size' - initial volume size in bytes,
                              in case of thin provisioning
             'add_bitmaps' - add all the bitmaps from source volume
+            'legal' - create the volume as legal if true,
+                      otherwise create as illegal.
         """
         # Do the input values validation first.
         if initial_size is not None:
@@ -1282,9 +1284,10 @@ class Volume(object):
                               [str(x) for x in metaId])
             )
 
+            legality = sc.LEGAL_VOL if legal else sc.ILLEGAL_VOL
             cls.newMetadata(metaId, sdUUID, imgUUID, srcVolUUID, capacity,
                             sc.type2name(volFormat), sc.type2name(preallocate),
-                            volType, diskType, desc, sc.LEGAL_VOL)
+                            volType, diskType, desc, legality)
 
             if dom.hasVolumeLeases():
                 cls.newVolumeLease(metaId, sdUUID, volUUID)

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -594,18 +594,22 @@ class VolumeManifest(object):
         return None
 
     def prepare(self, rw=True, justme=False,
-                chainrw=False, setrw=False, force=False):
+                chainrw=False, setrw=False, force=False,
+                allow_illegal=False):
         """
         Prepare volume for use by consumer.
         If justme is false, the entire COW chain is prepared.
         Note: setrw arg may be used only by SPM flows.
         """
-        self.log.info("Volume: preparing volume %s/%s",
-                      self.sdUUID, self.volUUID)
+        self.log.info("Preparing volume %s/%s with parameters:"
+                      "justme=%s, rw=%s, setrw=%s, chainrw=%s, force=%s,"
+                      "allow_illegal=%s",
+                      self.sdUUID, self.volUUID, justme, rw, setrw, chainrw,
+                      force, allow_illegal)
 
         if not force:
-            # Cannot prepare ILLEGAL volume
-            if not self.isLegal():
+            # Cannot prepare ILLEGAL volume when allow_illegal is not True
+            if not self.isLegal() and not allow_illegal:
                 raise se.prepareIllegalVolumeError(self.volUUID)
 
             if rw and self.isShared():

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -228,7 +228,8 @@ class VolumeManifest(object):
             "ctime": meta.get(sc.CTIME, ""),
             "mtime": "0",
             "legality": meta.get(sc.LEGALITY, ""),
-            "generation": meta.get(sc.GENERATION, sc.DEFAULT_GENERATION)
+            "generation": meta.get(sc.GENERATION, sc.DEFAULT_GENERATION),
+            "sequence": meta.get(sc.SEQUENCE, sc.DEFAULT_SEQUENCE)
         }
 
     def getInfo(self):
@@ -567,9 +568,21 @@ class VolumeManifest(object):
 
     @classmethod
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, capacity, format,
-                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL):
-        meta = VolumeMetadata(sdUUID, imgUUID, puuid, capacity, format, type,
-                              voltype, disktype, desc, legality)
+                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL,
+                    sequence=0):
+        meta = VolumeMetadata(
+            domain=sdUUID,
+            image=imgUUID,
+            parent=puuid,
+            capacity=capacity,
+            format=format,
+            type=type,
+            voltype=voltype,
+            disktype=disktype,
+            description=desc,
+            legality=legality,
+            sequence=sequence,
+        )
         cls.createMetadata(metaId, meta)
         return meta
 
@@ -1142,7 +1155,8 @@ class Volume(object):
     @classmethod
     def create(cls, repoPath, sdUUID, imgUUID, capacity, volFormat,
                preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-               initial_size=None, add_bitmaps=False, legal=True):
+               initial_size=None, add_bitmaps=False, legal=True,
+               sequence=0):
         """
         Create a new volume with given size or snapshot
             'capacity' - in bytes
@@ -1156,6 +1170,7 @@ class Volume(object):
             'add_bitmaps' - add all the bitmaps from source volume
             'legal' - create the volume as legal if true,
                       otherwise create as illegal.
+            'sequence' - the sequence number of the volume in the metadata
         """
         # Do the input values validation first.
         if initial_size is not None:
@@ -1291,7 +1306,8 @@ class Volume(object):
             legality = sc.LEGAL_VOL if legal else sc.ILLEGAL_VOL
             cls.newMetadata(metaId, sdUUID, imgUUID, srcVolUUID, capacity,
                             sc.type2name(volFormat), sc.type2name(preallocate),
-                            volType, diskType, desc, legality)
+                            volType, diskType, desc, legality,
+                            sequence)
 
             if dom.hasVolumeLeases():
                 cls.newVolumeLease(metaId, sdUUID, volUUID)
@@ -1508,10 +1524,11 @@ class Volume(object):
 
     @classmethod
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, capacity, format,
-                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL):
+                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL,
+                    sequence=0):
         return cls.manifestClass.newMetadata(
             metaId, sdUUID, imgUUID, puuid, capacity, format, type, voltype,
-            disktype, desc, legality)
+            disktype, desc, legality, sequence)
 
     def getInfo(self):
         return self._manifest.getInfo()

--- a/lib/vdsm/storage/volumemetadata.py
+++ b/lib/vdsm/storage/volumemetadata.py
@@ -348,5 +348,5 @@ class VolumeMetadata(object):
             "legality": self.legality,
             "parent": self.parent,
             "type": self.type,
-            "voltype": self.voltype
+            "voltype": self.voltype,
         }

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1425,6 +1425,33 @@ def test_dump_sd_metadata(
         }
 
 
+@pytest.mark.parametrize("domain_version", [5])
+def test_create_illegal_volume(domain_factory, domain_version, fake_task,
+                               fake_sanlock):
+    sd_uuid = str(uuid.uuid4())
+    dom = domain_factory.create_domain(sd_uuid=sd_uuid, version=domain_version)
+
+    img_uuid = str(uuid.uuid4())
+    vol_id = str(uuid.uuid4())
+    vol_capacity = 10 * GiB
+
+    dom.createVolume(
+        imgUUID=img_uuid,
+        capacity=vol_capacity,
+        volFormat=sc.COW_FORMAT,
+        preallocate=sc.SPARSE_VOL,
+        diskType=sc.DATA_DISKTYPE,
+        volUUID=vol_id,
+        desc="Base volume",
+        srcImgUUID=sc.BLANK_UUID,
+        srcVolUUID=sc.BLANK_UUID,
+        legal=False)
+
+    vol = dom.produceVolume(img_uuid, vol_id)
+
+    assert vol.getLegality() == sc.ILLEGAL_VOL
+
+
 LVM_TAG_CHARS = string.ascii_letters + "0123456789_+.-/=!:#"
 
 LVM_TAGS = [

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1229,7 +1229,8 @@ def test_dump_sd_metadata(
             srcImgUUID=sc.BLANK_UUID,
             srcVolUUID=sc.BLANK_UUID,
             volFormat=sc.COW_FORMAT,
-            volUUID=vol_uuid)
+            volUUID=vol_uuid,
+            sequence=42)
 
     # Create external lease.
     dom.create_lease(vol_uuid)
@@ -1241,6 +1242,8 @@ def test_dump_sd_metadata(
             "updating": False
         }
     }
+
+    expected_sequence = sc.DEFAULT_SEQUENCE if domain_version == 4 else 42
 
     vol = dom.produceVolume(img_uuid, vol_uuid)
     mdslot = vol.getMetaSlot()
@@ -1254,6 +1257,7 @@ def test_dump_sd_metadata(
             'disktype': sc.DATA_DISKTYPE,
             'format': 'COW',
             'generation': 0,
+            'sequence': expected_sequence,
             'image': img_uuid,
             'legality': sc.LEGAL_VOL,
             'mdslot': mdslot,
@@ -1309,6 +1313,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1335,6 +1340,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1379,6 +1385,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1406,6 +1413,7 @@ def test_dump_sd_metadata(
                 "mdslot": mdslot,
                 "truesize": vol_size.truesize,
                 "generation": sc.DEFAULT_GENERATION,
+                "sequence": sc.DEFAULT_SEQUENCE,
             }
         }
     }
@@ -1420,6 +1428,7 @@ def test_dump_sd_metadata(
                     "parent": sc.BLANK_UUID,
                     "mdslot": mdslot,
                     "generation": sc.DEFAULT_GENERATION,
+                    "sequence": sc.DEFAULT_SEQUENCE,
                 }
             }
         }

--- a/tests/storage/localfssd_test.py
+++ b/tests/storage/localfssd_test.py
@@ -1165,6 +1165,27 @@ def test_dump_sd_volumes_removed_image(
     }
 
 
+def test_create_illegal_volume(user_domain, local_fallocate):
+    image_id = str(uuid.uuid4())
+    vol_id = str(uuid.uuid4())
+    user_domain.createVolume(
+        imgUUID=image_id,
+        capacity=SPARSE_VOL_SIZE,
+        volFormat=sc.COW_FORMAT,
+        preallocate=sc.SPARSE_VOL,
+        diskType="DATA",
+        volUUID=vol_id,
+        desc="test",
+        srcImgUUID=sc.BLANK_UUID,
+        srcVolUUID=sc.BLANK_UUID,
+        legal=False)
+
+    vol = user_domain.produceVolume(
+        image_id, vol_id)
+
+    assert vol.getLegality() == sc.ILLEGAL_VOL
+
+
 def test_create_volume_with_bitmaps(user_domain, local_fallocate):
     if user_domain.getVersion() == 3:
         pytest.skip("Bitmaps operations not supported in v3 domains")

--- a/tests/storage/localfssd_test.py
+++ b/tests/storage/localfssd_test.py
@@ -864,7 +864,9 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=sc.DEFAULT_SEQUENCE,
+        )
 
     expected_metadata = {
         "alignment": user_domain.alignment,
@@ -889,6 +891,7 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": 0,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_OK,
@@ -927,7 +930,9 @@ def test_dump_sd_volumes_invalid_md(
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=0,
+        )
 
     # Corrupt the metadata of the volume.
     vol = user_domain.produceVolume(img_uuid, vol_uuid)
@@ -956,6 +961,7 @@ def test_dump_sd_volumes_invalid_md(
             "truesize": vol_size.truesize,
             "status": sc.VOL_STATUS_INVALID,
             "generation": sc.DEFAULT_GENERATION,
+            "sequence": 0,
             "image": img_uuid
         }
     }
@@ -1080,6 +1086,7 @@ def test_dump_sd_volumes_failed_size_query(
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": 0,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_INVALID,
@@ -1117,7 +1124,9 @@ def test_dump_sd_volumes_removed_image(
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=0,
+        )
 
     # Mark the volume image as removed.
     vol = user_domain.produceVolume(img_uuid, vol_uuid)
@@ -1149,6 +1158,7 @@ def test_dump_sd_volumes_removed_image(
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": 0,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_REMOVED,

--- a/tests/storage/sdm_indirection_test.py
+++ b/tests/storage/sdm_indirection_test.py
@@ -32,6 +32,8 @@ from testlib import VdsmTestCase
 from testlib import permutations, expandPermutations
 from testlib import recorded
 
+import uuid
+
 
 class FakeDomainManifest(object):
     def __init__(self):
@@ -337,7 +339,7 @@ class FakeVolumeManifest(object):
     @classmethod
     @recorded
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, size, format, type,
-                    voltype, disktype, desc="", legality=None):
+                    voltype, disktype, desc="", legality=None, sequence=0):
         pass
 
     @recorded
@@ -843,10 +845,27 @@ class VolumeTestMixin(object):
     def test_functions(self, fn, nargs):
         self.checker.check_method_call(fn, nargs)
 
+    def test_newmetadata(self):
+        args = (
+            1,             # metaId
+            uuid.uuid4(),  # sdUUID
+            uuid.uuid4(),  # imgUUID
+            uuid.uuid4(),  # puuid
+            1000,          # capacity
+            1,             # format
+            2,             # type
+            sc.LEAF_VOL,   # voltype
+            'file',        # disktype
+            '',            # description
+            sc.LEGAL_VOL,
+            0)
+        self.checker.check_classmethod_call_args_kwargs(
+            "newMetadata",
+            *args)
+
     @permutations([
         ['_putMetadata', 2],
         ['createMetadata', 2],
-        ['newMetadata', 11],
         ['newVolumeLease', 3],
         ['getImageVolumes', 2],
         ['teardown', 3],

--- a/tests/storage/storagetestlib.py
+++ b/tests/storage/storagetestlib.py
@@ -97,10 +97,11 @@ class FakeFileEnv(object):
     def make_volume(self, size, imguuid, voluuid, parent_vol_id=sc.BLANK_UUID,
                     vol_format=sc.RAW_FORMAT, vol_type=sc.LEAF_VOL,
                     prealloc=sc.SPARSE_VOL, disk_type=sc.DATA_DISKTYPE,
-                    desc='fake volume', qcow2_compat='0.10'):
+                    desc='fake volume', qcow2_compat='0.10', legal=True):
         return make_file_volume(self.sd_manifest, size, imguuid, voluuid,
                                 parent_vol_id, vol_format, vol_type,
-                                prealloc, disk_type, desc, qcow2_compat)
+                                prealloc, disk_type, desc, qcow2_compat,
+                                legal)
 
 
 class FakeBlockEnv(object):
@@ -186,11 +187,12 @@ def fake_env(storage_type, sd_version=3, data_center=None,
 
 
 @contextmanager
-def fake_volume(storage_type='file', size=MiB, format=sc.RAW_FORMAT):
+def fake_volume(storage_type='file', size=MiB, format=sc.RAW_FORMAT,
+                legal=True):
     img_id = make_uuid()
     vol_id = make_uuid()
     with fake_env(storage_type) as env:
-        env.make_volume(size, img_id, vol_id, vol_format=format)
+        env.make_volume(size, img_id, vol_id, vol_format=format, legal=legal)
         vol = env.sd_manifest.produceVolume(img_id, vol_id)
         yield vol
 
@@ -322,7 +324,8 @@ def make_file_volume(sd_manifest, size, imguuid, voluuid,
                      vol_type=sc.LEAF_VOL,
                      prealloc=sc.SPARSE_VOL,
                      disk_type=sc.DATA_DISKTYPE,
-                     desc='fake volume', qcow2_compat='0.10'):
+                     desc='fake volume', qcow2_compat='0.10',
+                     legal=True):
     volpath = os.path.join(sd_manifest.domaindir, "images", imguuid, voluuid)
 
     # Create needed path components.
@@ -376,7 +379,7 @@ def make_file_volume(sd_manifest, size, imguuid, voluuid,
         sc.type2name(vol_type),
         disk_type,
         desc,
-        sc.LEGAL_VOL)
+        sc.LEGAL_VOL if legal else sc.ILLEGAL_VOL)
 
 
 def make_block_volume(lvm, sd_manifest, size, imguuid, voluuid,
@@ -385,7 +388,7 @@ def make_block_volume(lvm, sd_manifest, size, imguuid, voluuid,
                       vol_type=sc.LEAF_VOL,
                       prealloc=sc.PREALLOCATED_VOL,
                       disk_type=sc.DATA_DISKTYPE,
-                      desc='fake volume', qcow2_compat='0.10'):
+                      desc='fake volume', qcow2_compat='0.10', legal=True):
     sduuid = sd_manifest.sdUUID
     imagedir = sd_manifest.getImageDir(imguuid)
     if not os.path.exists(imagedir):
@@ -446,7 +449,7 @@ def make_block_volume(lvm, sd_manifest, size, imguuid, voluuid,
         sc.type2name(vol_type),
         disk_type,
         desc,
-        sc.LEGAL_VOL)
+        sc.LEGAL_VOL if legal else sc.ILLEGAL_VOL)
 
 
 def write_qemu_chain(vol_list):

--- a/tests/storage/volume_metadata_test.py
+++ b/tests/storage/volume_metadata_test.py
@@ -51,7 +51,8 @@ def make_init_params(**kwargs):
         disktype=sc.DATA_DISKTYPE,
         description="",
         legality=sc.LEGAL_VOL,
-        generation=sc.DEFAULT_GENERATION)
+        generation=sc.DEFAULT_GENERATION,
+        sequence=42)
     res.update(kwargs)
     return res
 
@@ -207,6 +208,11 @@ class TestVolumeMetadata:
         assert FAKE_TIME == md.ctime
         assert data['legality'] == md.legality
         assert int(data['generation']) == md.generation
+
+        if version == 5:
+            assert int(data['sequence']) == md.sequence
+        if version == 4:
+            assert 0 == md.sequence
 
     def test_from_lines_v5(self):
         data = make_init_params()
@@ -485,6 +491,7 @@ class TestDictInterface:
             'disktype': params['disktype'],
             'format': params['format'],
             'generation': params['generation'],
+            'sequence': params['sequence'],
             'image': params['image'],
             'legality': params['legality'],
             'parent': params['parent'],

--- a/tests/storage/volume_test.py
+++ b/tests/storage/volume_test.py
@@ -185,6 +185,16 @@ class TestVolumeManifest:
         # writing the new generation.
         assert "description" == vol.getMetaParam(sc.DESCRIPTION)
 
+    def test_prepare_illegal_volume_fails(self):
+        with fake_volume('file', legal=False) as vol:
+            with pytest.raises(se.prepareIllegalVolumeError):
+                vol.prepare()
+
+    def test_prepare_illegal_volume_allowed(self):
+        with fake_volume('file', legal=False) as vol:
+            vol.prepare(allow_illegal=True)
+            assert vol.getMetaParam(sc.LEGALITY) == sc.ILLEGAL_VOL
+
 
 class TestVolumeSize:
 


### PR DESCRIPTION
This PR adds support for disk conversion, engine uses the copy_data verb to perform this operation and the changes include:
* Support for working with illegal volumes
* Support for copying volumes within the same image
* Support for a sequence number in volumes