### PR TITLE
automation: Add network tests

### DIFF
--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -1,0 +1,34 @@
+name: Network CI
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'lib/vdsm/network/**'
+      - 'lib/vdsm/common/**'
+      - 'tests/network/**'
+      - '.github/workflows/network.yml'
+  pull_request:
+    paths:
+      - 'lib/vdsm/network/**'
+      - 'lib/vdsm/common/**'
+      - 'tests/network/**'
+      - '.github/workflows/network.yml'
+
+jobs:
+  tests:
+    env:
+      IMAGE_TAG: ${{ matrix.tag }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        type: [ unit, integration, functional ]
+        tag: [ centos-8, centos-9 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Run ${{ matrix.type }} tests
+        run: sudo -E ./tests/network/${{ matrix.type }}/run-tests.sh

--- a/tests/network/nettestlib.py
+++ b/tests/network/nettestlib.py
@@ -214,8 +214,8 @@ class Dummy(Interface):
     def create(self):
         try:
             linkAdd(self.dev_name, linkType='dummy')
-            self.set_managed()
             self.up()
+            self.set_managed()
         except IPRoute2Error as e:
             pytest.skip(
                 f'Failed to create a dummy interface {self.dev_name}: {e}'


### PR DESCRIPTION
Add network tests that will be triggered only when
something in network code changes, there is no need
to run them with every vdsm change as the functional
tests can take a while.
