### PR TITLE
automation: Automatically build network containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,36 @@
+name: Containers
+on:
+  # Be able to run the job manually when needed
+  # (Actions -> Containers -> Run workflow)
+  workflow_dispatch:
+  # Build every week on Sunday 00:00
+  schedule:
+    - cron:  '0 0 * * 0'
+env:
+  IMAGE_REGISTRY: quay.io
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: [ functional, integration, unit ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Build container images
+        working-directory: docker/network
+        run: make ${{ matrix.container }}
+      - name: Push to Quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ovirt/vdsm-network-tests-${{ matrix.container }}
+          tags: centos-8 centos-9
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME  }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/docker/network/functional/Dockerfile.centos-8
+++ b/docker/network/functional/Dockerfile.centos-8
@@ -1,11 +1,7 @@
-FROM centos/centos:stream8
+FROM quay.io/ovirt/buildcontainer:stream8
 
 # Add runtime dependencies.
-RUN dnf install -y \
-        http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    # Make NM upgrade available
-    dnf -y install dnf-plugins-core \
+RUN dnf -y install dnf-plugins-core \
     && \
     dnf update -y \
     && \
@@ -13,8 +9,6 @@ RUN dnf install -y \
         autoconf \
         automake \
         dnsmasq \
-        git \
-        make \
         python3 \
         python3-devel \
         python3-pip \

--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -1,11 +1,7 @@
-FROM centos/centos:stream9-development
+FROM quay.io/ovirt/buildcontainer:stream9
 
 # Add runtime dependencies.
-RUN dnf install -y \
-        http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    # Make NM upgrade available
-    dnf -y install dnf-plugins-core \
+RUN dnf -y install dnf-plugins-core \
     && \
     dnf update -y \
     && \
@@ -17,8 +13,6 @@ RUN dnf install -y \
         autoconf \
         automake \
         dnsmasq \
-        git \
-        make \
         python3 \
         python3-devel \
         python3-pip \

--- a/docker/network/integration/Dockerfile.centos-8
+++ b/docker/network/integration/Dockerfile.centos-8
@@ -1,17 +1,12 @@
-FROM centos/centos:stream8
+FROM quay.io/ovirt/buildcontainer:stream8
 
 # Add runtime dependencies.
-RUN dnf install -y \
-    http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    dnf update -y \
+RUN dnf update -y \
     && \
     dnf install -y \
         autoconf \
         automake \
         dnsmasq \
-        git \
-        make \
         python3-devel \
         python3-pip \
         # Install vdsm-network for its dependencies

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -1,10 +1,7 @@
-FROM centos/centos:stream9-development
+FROM quay.io/ovirt/buildcontainer:stream9
 
 # Add runtime dependencies.
-RUN dnf install -y \
-    http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    dnf update -y \
+RUN dnf update -y \
     && \
     # Without it the ovirt-openvswitch fails to install
     # It seems that the el8s container has systemd installed by default
@@ -14,8 +11,6 @@ RUN dnf install -y \
         autoconf \
         automake \
         dnsmasq \
-        git \
-        make \
         python3-devel \
         python3-pip \
         # Install vdsm-network for its dependencies

--- a/docker/network/unit/Dockerfile.centos-8
+++ b/docker/network/unit/Dockerfile.centos-8
@@ -1,10 +1,7 @@
-FROM centos/centos:stream8
+FROM quay.io/ovirt/buildcontainer:stream8
 
 # Add runtime dependencies.
-RUN  dnf install -y \
-    http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    dnf update -y \
+RUN dnf update -y \
     && \
     dnf install -y \
         iproute-tc \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -1,10 +1,7 @@
-FROM centos/centos:stream9-development
+FROM quay.io/ovirt/buildcontainer:stream9
 
 # Add runtime dependencies.
-RUN  dnf install -y \
-    http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
-    && \
-    dnf update -y \
+RUN dnf update -y \
     && \
     # el9s does not have modprobe installed by default
     dnf install -y kmod \


### PR DESCRIPTION
In order to be up to date with centos changes, build
the containers every automatically every Monday on midnight.
Add also manual trigger for the build so the containers
can be rebuild manually if needed.

Signed-off-by: Ales Musil <amusil@redhat.com>