### PR TITLE
virt: Don't assume that VM is UP after a failed migration

### DIFF
--- a/lib/vdsm/virt/migration.py
+++ b/lib/vdsm/virt/migration.py
@@ -352,10 +352,10 @@ class SourceThread(object):
         # either way, migration has finished
         self._switch_state(State.FAILED)
         if self._recovery:
-            self._vm.set_last_status(vmstatus.UP, vmstatus.MIGRATION_SOURCE)
             self._recovery = False
-        else:
-            self._vm.lastStatus = vmstatus.UP
+        self._vm.recover_status()
+        # Escape from MIGRATION_SOURCE if we're still there
+        self._vm.set_last_status(vmstatus.UP, vmstatus.MIGRATION_SOURCE)
         self._vm.send_status_event()
         if (self._vm.lastStatus == vmstatus.PAUSED and
                 self._vm.resume_postponed):

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -961,7 +961,7 @@ class Vm(object):
                     self.set_last_status(vmstatus.DOWN,
                                          vmstatus.WAIT_FOR_LAUNCH)
                 else:
-                    self._recover_status()
+                    self.recover_status()
                     if self._lastStatus == vmstatus.MIGRATION_DESTINATION:
                         self._wait_for_incoming_postcopy_migration()
                         self.lastStatus = vmstatus.UP
@@ -1016,7 +1016,7 @@ class Vm(object):
                 self.log.debug('Releasing incoming migration semaphore')
                 migration.incomingMigrations.release()
 
-    def _recover_status(self):
+    def recover_status(self):
         try:
             state, reason = self._dom.state(0)
         except (libvirt.libvirtError, virdomain.NotConnectedError,):


### PR DESCRIPTION
Current migration code switches VM status to UP
unconditionally (unless in recovery) after a failed migration.  But
this is wrong, the migrated VM could be paused initially, it could be
paused due to a storage error, it could crash, etc.

Tracking these somewhat corner case during migration would be
difficult.  The migration either succeeds and then the VM is simply
down or it fails.  In the latter case, it's easiest to use our status
recovery routine and ask libvirt about the true status of the VM.
We additionally ensure that we won't get stuck in the
MIGRATION_SOURCE status by still switching to UP in such a case.

Change-Id: I30fbbf71dea9c32cb0af8910111c7483d2475144
Signed-off-by: Milan Zamazal <mzamazal@redhat.com>