### PR TITLE
Bug 977778: Introduce volume sequence

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -842,14 +842,16 @@ class Volume(APIBase):
 
     def create(self, size, volFormat, preallocate, diskType, desc,
                srcImgUUID, srcVolUUID, initialSize=None, addBitmaps=False,
-               legal=True):
+               legal=True,
+               sequence=0):
         return self._irs.createVolume(self._sdUUID, self._spUUID,
                                       self._imgUUID, size, volFormat,
                                       preallocate, diskType, self._UUID, desc,
                                       srcImgUUID, srcVolUUID,
                                       initialSize=initialSize,
                                       addBitmaps=addBitmaps,
-                                      legal=legal)
+                                      legal=legal,
+                                      sequence=sequence)
 
     def delete(self, postZero, force, discard=False):
         return self._irs.deleteVolume(self._sdUUID, self._spUUID,

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -11880,6 +11880,12 @@ Volume.create:
             be used by the system. To use the volume it must be set to legal.
         name: legal
         type: boolean
+
+    -   defaultvalue: 0
+        description: The sequence number of the volume. Newer volume will have
+            a higher number.
+        name: sequence
+        type: int
         added: '4.5'
     return:
         description: A task UUID

--- a/lib/vdsm/storage/constants.py
+++ b/lib/vdsm/storage/constants.py
@@ -214,6 +214,7 @@ DESCRIPTION = "DESCRIPTION"
 LEGALITY = "LEGALITY"
 MTIME = "MTIME"
 GENERATION = "GEN"  # Added in 4.1
+SEQUENCE = "SEQ"  # Added in 4.5
 
 # In block storage, metadata size is limited to BLOCK_SIZE (512), to
 # ensure that metadata is written atomically. This is big enough for the
@@ -242,6 +243,7 @@ GENERATION = "GEN"  # Added in 4.1
 # TYPE=PREALLOCATED                           # PREALLOCATED|UNKNOWN|SPARSE
 # VOLTYPE=INTERNAL                            # INTERNAL|SHARED|LEAF
 # GEN=999                                     # int
+# SEQ=4294967295                              # int
 # EOF
 #
 # For more info why this is the worst possible case, see
@@ -250,7 +252,7 @@ GENERATION = "GEN"  # Added in 4.1
 # On V4 This content requires up to 276 bytes, leaving 236 bytes for the
 # description.
 #
-# On V5 this content requires 270 bytes, leaving 242 bytes for the description
+# On V5 this content requires 285 bytes, leaving 227 bytes for the description
 # field.
 #
 # OVF_STORE JSON description format needs up to 175 bytes.
@@ -268,6 +270,10 @@ DESCRIPTION_SIZE = 210
 # after reaching its maximum value.
 DEFAULT_GENERATION = 0
 MAX_GENERATION = 999  # Since this is represented in ASCII, limit to 3 places
+
+# The SEQUENCE metadata may be missing, as it was added only in 4.5.
+DEFAULT_SEQUENCE = 0
+MAX_SEQUENCE = 2**32 - 1
 
 # Block volume metadata tags
 TAG_PREFIX_MD = "MD_"

--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -1254,7 +1254,8 @@ class HSM(object):
                      srcImgUUID=sc.BLANK_UUID,
                      srcVolUUID=sc.BLANK_UUID,
                      initialSize=None, addBitmaps=False,
-                     legal=True):
+                     legal=True,
+                     sequence=0):
         """
         Create a new volume
             Function Type: SPM
@@ -1263,10 +1264,11 @@ class HSM(object):
         """
         argsStr = ("sdUUID=%s, spUUID=%s, imgUUID=%s, size=%s, volFormat=%s, "
                    "preallocate=%s, diskType=%s, volUUID=%s, desc=%s, "
-                   "srcImgUUID=%s, srcVolUUID=%s, initialSize=%s" %
+                   "srcImgUUID=%s, srcVolUUID=%s, initialSize=%s, "
+                   "sequence=%s" %
                    (sdUUID, spUUID, imgUUID, size, volFormat, preallocate,
                     diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-                    initialSize))
+                    initialSize, sequence))
         vars.task.setDefaultException(se.VolumeCreationError(argsStr))
         # Validates that the pool is connected. WHY?
         pool = self.getPool(spUUID)
@@ -1291,7 +1293,7 @@ class HSM(object):
         self._spmSchedule(spUUID, "createVolume", pool.createVolume, sdUUID,
                           imgUUID, capacity, volFormat, preallocate, diskType,
                           volUUID, desc, srcImgUUID, srcVolUUID, initial_size,
-                          addBitmaps, legal)
+                          addBitmaps, legal, sequence)
 
     @public
     def deleteVolume(self, sdUUID, spUUID, imgUUID, volumes, postZero=False,

--- a/lib/vdsm/storage/sd.py
+++ b/lib/vdsm/storage/sd.py
@@ -1206,14 +1206,16 @@ class StorageDomain(object):
 
     def createVolume(self, imgUUID, capacity, volFormat, preallocate, diskType,
                      volUUID, desc, srcImgUUID, srcVolUUID,
-                     initial_size=None, add_bitmaps=False, legal=True):
+                     initial_size=None, add_bitmaps=False, legal=True,
+                     sequence=0):
         """
         Create a new volume
         """
         return self.getVolumeClass().create(
             self._getRepoPath(), self.sdUUID, imgUUID, capacity, volFormat,
             preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-            initial_size=initial_size, add_bitmaps=add_bitmaps, legal=legal)
+            initial_size=initial_size, add_bitmaps=add_bitmaps, legal=legal,
+            sequence=sequence)
 
     def getMDPath(self):
         return self._manifest.getMDPath()

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -1888,7 +1888,8 @@ class StoragePool(object):
                      srcVolUUID=sc.BLANK_UUID,
                      initialSize=None,
                      addBitmaps=False,
-                     legal=True):
+                     legal=True,
+                     sequence=0):
         """
         Creates a new volume.
 
@@ -1929,6 +1930,9 @@ class StoragePool(object):
         :param legal: If true, create the volume as legal.
         :type legal: boolean
 
+        :type sequence: int
+        :param sequence: The sequence number of the volume.
+
         :returns: a dict with the UUID of the new volume.
         :rtype: dict
         """
@@ -1953,7 +1957,9 @@ class StoragePool(object):
                 imgUUID=imgUUID, capacity=size, volFormat=volFormat,
                 preallocate=preallocate, diskType=diskType, volUUID=volUUID,
                 desc=desc, srcImgUUID=srcImgUUID, srcVolUUID=srcVolUUID,
-                initial_size=initialSize, add_bitmaps=addBitmaps, legal=legal)
+                initial_size=initialSize, add_bitmaps=addBitmaps, legal=legal,
+                sequence=sequence)
+
         return dict(uuid=newVolUUID)
 
     def deleteVolume(self, sdUUID, imgUUID, volumes, postZero, force, discard):

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -228,7 +228,8 @@ class VolumeManifest(object):
             "ctime": meta.get(sc.CTIME, ""),
             "mtime": "0",
             "legality": meta.get(sc.LEGALITY, ""),
-            "generation": meta.get(sc.GENERATION, sc.DEFAULT_GENERATION)
+            "generation": meta.get(sc.GENERATION, sc.DEFAULT_GENERATION),
+            "sequence": meta.get(sc.SEQUENCE, sc.DEFAULT_SEQUENCE)
         }
 
     def getInfo(self):
@@ -567,9 +568,21 @@ class VolumeManifest(object):
 
     @classmethod
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, capacity, format,
-                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL):
-        meta = VolumeMetadata(sdUUID, imgUUID, puuid, capacity, format, type,
-                              voltype, disktype, desc, legality)
+                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL,
+                    sequence=0):
+        meta = VolumeMetadata(
+            domain=sdUUID,
+            image=imgUUID,
+            parent=puuid,
+            capacity=capacity,
+            format=format,
+            type=type,
+            voltype=voltype,
+            disktype=disktype,
+            description=desc,
+            legality=legality,
+            sequence=sequence,
+        )
         cls.createMetadata(metaId, meta)
         return meta
 
@@ -1142,7 +1155,8 @@ class Volume(object):
     @classmethod
     def create(cls, repoPath, sdUUID, imgUUID, capacity, volFormat,
                preallocate, diskType, volUUID, desc, srcImgUUID, srcVolUUID,
-               initial_size=None, add_bitmaps=False, legal=True):
+               initial_size=None, add_bitmaps=False, legal=True,
+               sequence=0):
         """
         Create a new volume with given size or snapshot
             'capacity' - in bytes
@@ -1156,6 +1170,7 @@ class Volume(object):
             'add_bitmaps' - add all the bitmaps from source volume
             'legal' - create the volume as legal if true,
                       otherwise create as illegal.
+            'sequence' - the sequence number of the volume in the metadata
         """
         # Do the input values validation first.
         if initial_size is not None:
@@ -1291,7 +1306,8 @@ class Volume(object):
             legality = sc.LEGAL_VOL if legal else sc.ILLEGAL_VOL
             cls.newMetadata(metaId, sdUUID, imgUUID, srcVolUUID, capacity,
                             sc.type2name(volFormat), sc.type2name(preallocate),
-                            volType, diskType, desc, legality)
+                            volType, diskType, desc, legality,
+                            sequence=sequence)
 
             if dom.hasVolumeLeases():
                 cls.newVolumeLease(metaId, sdUUID, volUUID)
@@ -1508,10 +1524,11 @@ class Volume(object):
 
     @classmethod
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, capacity, format,
-                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL):
+                    type, voltype, disktype, desc="", legality=sc.ILLEGAL_VOL,
+                    sequence=0):
         return cls.manifestClass.newMetadata(
             metaId, sdUUID, imgUUID, puuid, capacity, format, type, voltype,
-            disktype, desc, legality)
+            disktype, desc, legality, sequence=sequence)
 
     def getInfo(self):
         return self._manifest.getInfo()

--- a/lib/vdsm/storage/volumemetadata.py
+++ b/lib/vdsm/storage/volumemetadata.py
@@ -46,7 +46,8 @@ ATTRIBUTES = {
     sc.DESCRIPTION: ("description", str),
     sc.LEGALITY: ("legality", str),
     sc.CTIME: ("ctime", int),
-    sc.GENERATION: ("generation", int)
+    sc.GENERATION: ("generation", int),
+    sc.SEQUENCE: ("sequence", int),
 }
 
 
@@ -96,6 +97,9 @@ def parse(lines):
     if sc.GENERATION not in md:
         md[sc.GENERATION] = sc.DEFAULT_GENERATION
 
+    if sc.SEQUENCE not in md:
+        md[sc.SEQUENCE] = sc.DEFAULT_SEQUENCE
+
     for key, (name, validate) in ATTRIBUTES.items():
         try:
             # FIXME: remove pylint skip when bug fixed:
@@ -130,7 +134,8 @@ class VolumeMetadata(object):
 
     def __init__(self, domain, image, parent, capacity, format, type, voltype,
                  disktype, description="", legality=sc.ILLEGAL_VOL, ctime=None,
-                 generation=sc.DEFAULT_GENERATION):
+                 generation=sc.DEFAULT_GENERATION,
+                 sequence=sc.DEFAULT_SEQUENCE):
         # Storage domain UUID
         self.domain = domain
         # Image UUID
@@ -155,6 +160,9 @@ class VolumeMetadata(object):
         self.ctime = int(time.time()) if ctime is None else ctime
         # Generation increments each time certain operations complete
         self.generation = generation
+        # Sequence number of the volume, increased every time a new volume is
+        # created in an image.
+        self.sequence = sequence
 
     @classmethod
     def from_lines(cls, lines):
@@ -203,6 +211,14 @@ class VolumeMetadata(object):
     @generation.setter
     def generation(self, value):
         self._generation = self._validate_integer("generation", value)
+
+    @property
+    def sequence(self):
+        return self._sequence
+
+    @sequence.setter
+    def sequence(self, value):
+        self._sequence = self._validate_integer("sequence", value)
 
     @classmethod
     def _validate_integer(cls, property, value):
@@ -262,6 +278,7 @@ class VolumeMetadata(object):
             info[_SIZE] = self.capacity // sc.BLOCK_SIZE_512
         else:
             info[sc.CAPACITY] = self.capacity
+            info[sc.SEQUENCE] = self.sequence
 
         info.update(overrides)
 
@@ -295,6 +312,7 @@ class VolumeMetadata(object):
         sc.PUUID: 'parent',
         sc.LEGALITY: 'legality',
         sc.GENERATION: 'generation',
+        sc.SEQUENCE: "sequence",
     }
 
     def __getitem__(self, item):
@@ -325,9 +343,10 @@ class VolumeMetadata(object):
             "disktype": self.disktype,
             "format": self.format,
             "generation": self.generation,
+            "sequence": self.sequence,
             "image": self.image,
             "legality": self.legality,
             "parent": self.parent,
             "type": self.type,
-            "voltype": self.voltype
+            "voltype": self.voltype,
         }

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1229,7 +1229,8 @@ def test_dump_sd_metadata(
             srcImgUUID=sc.BLANK_UUID,
             srcVolUUID=sc.BLANK_UUID,
             volFormat=sc.COW_FORMAT,
-            volUUID=vol_uuid)
+            volUUID=vol_uuid,
+            sequence=42)
 
     # Create external lease.
     dom.create_lease(vol_uuid)
@@ -1241,6 +1242,8 @@ def test_dump_sd_metadata(
             "updating": False
         }
     }
+
+    expected_sequence = 42 if domain_version == 5 else sc.DEFAULT_SEQUENCE
 
     vol = dom.produceVolume(img_uuid, vol_uuid)
     mdslot = vol.getMetaSlot()
@@ -1254,7 +1257,7 @@ def test_dump_sd_metadata(
             'disktype': sc.DATA_DISKTYPE,
             'format': 'COW',
             'generation': 0,
-            'sequence': sc.DEFAULT_SEQUENCE,
+            'sequence': expected_sequence,
             'image': img_uuid,
             'legality': sc.LEGAL_VOL,
             'mdslot': mdslot,
@@ -1310,7 +1313,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
-                    'sequence': sc.DEFAULT_SEQUENCE,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1337,7 +1340,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
-                    'sequence': sc.DEFAULT_SEQUENCE,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1382,7 +1385,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
-                    'sequence': sc.DEFAULT_SEQUENCE,
+                    'sequence': expected_sequence,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1254,6 +1254,7 @@ def test_dump_sd_metadata(
             'disktype': sc.DATA_DISKTYPE,
             'format': 'COW',
             'generation': 0,
+            'sequence': sc.DEFAULT_SEQUENCE,
             'image': img_uuid,
             'legality': sc.LEGAL_VOL,
             'mdslot': mdslot,
@@ -1309,6 +1310,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': sc.DEFAULT_SEQUENCE,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1335,6 +1337,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': sc.DEFAULT_SEQUENCE,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1379,6 +1382,7 @@ def test_dump_sd_metadata(
                     'disktype': sc.DATA_DISKTYPE,
                     'format': 'COW',
                     'generation': 0,
+                    'sequence': sc.DEFAULT_SEQUENCE,
                     'image': img_uuid,
                     'legality': sc.LEGAL_VOL,
                     'mdslot': mdslot,
@@ -1406,6 +1410,7 @@ def test_dump_sd_metadata(
                 "mdslot": mdslot,
                 "truesize": vol_size.truesize,
                 "generation": sc.DEFAULT_GENERATION,
+                "sequence": sc.DEFAULT_SEQUENCE,
             }
         }
     }
@@ -1420,6 +1425,7 @@ def test_dump_sd_metadata(
                     "parent": sc.BLANK_UUID,
                     "mdslot": mdslot,
                     "generation": sc.DEFAULT_GENERATION,
+                    "sequence": sc.DEFAULT_SEQUENCE,
                 }
             }
         }

--- a/tests/storage/localfssd_test.py
+++ b/tests/storage/localfssd_test.py
@@ -889,6 +889,7 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": sc.DEFAULT_SEQUENCE,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_OK,
@@ -956,6 +957,7 @@ def test_dump_sd_volumes_invalid_md(
             "truesize": vol_size.truesize,
             "status": sc.VOL_STATUS_INVALID,
             "generation": sc.DEFAULT_GENERATION,
+            "sequence": sc.DEFAULT_SEQUENCE,
             "image": img_uuid
         }
     }
@@ -1080,6 +1082,7 @@ def test_dump_sd_volumes_failed_size_query(
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": sc.DEFAULT_SEQUENCE,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_INVALID,
@@ -1149,6 +1152,7 @@ def test_dump_sd_volumes_removed_image(
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
+            "sequence": sc.DEFAULT_SEQUENCE,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_REMOVED,

--- a/tests/storage/localfssd_test.py
+++ b/tests/storage/localfssd_test.py
@@ -864,7 +864,9 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=42,
+        )
 
     expected_metadata = {
         "alignment": user_domain.alignment,
@@ -879,6 +881,11 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
         "version": str(user_domain.getVersion())
     }
 
+    if user_domain.getVersion() >= 5:
+        expected_sequence = 42
+    else:
+        expected_sequence = sc.DEFAULT_SEQUENCE
+
     vol_size = user_domain.getVolumeSize(img_uuid, vol_uuid)
     expected_volumes_metadata = {
         vol_uuid: {
@@ -889,7 +896,7 @@ def test_dump_sd_volumes(monkeypatch, tmp_repo, user_mount, user_domain):
             "disktype": sc.DATA_DISKTYPE,
             "format": "RAW",
             "generation": 0,
-            "sequence": sc.DEFAULT_SEQUENCE,
+            "sequence": expected_sequence,
             "image": img_uuid,
             "legality": sc.LEGAL_VOL,
             "status": sc.VOL_STATUS_OK,
@@ -928,7 +935,9 @@ def test_dump_sd_volumes_invalid_md(
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=sc.DEFAULT_SEQUENCE,
+        )
 
     # Corrupt the metadata of the volume.
     vol = user_domain.produceVolume(img_uuid, vol_uuid)
@@ -1120,7 +1129,9 @@ def test_dump_sd_volumes_removed_image(
             volUUID=vol_uuid,
             desc="test",
             srcImgUUID=sc.BLANK_UUID,
-            srcVolUUID=sc.BLANK_UUID)
+            srcVolUUID=sc.BLANK_UUID,
+            sequence=sc.DEFAULT_SEQUENCE,
+        )
 
     # Mark the volume image as removed.
     vol = user_domain.produceVolume(img_uuid, vol_uuid)

--- a/tests/storage/sdm_indirection_test.py
+++ b/tests/storage/sdm_indirection_test.py
@@ -32,6 +32,8 @@ from testlib import VdsmTestCase
 from testlib import permutations, expandPermutations
 from testlib import recorded
 
+import uuid
+
 
 class FakeDomainManifest(object):
     def __init__(self):
@@ -337,7 +339,7 @@ class FakeVolumeManifest(object):
     @classmethod
     @recorded
     def newMetadata(cls, metaId, sdUUID, imgUUID, puuid, size, format, type,
-                    voltype, disktype, desc="", legality=None):
+                    voltype, disktype, desc="", legality=None, sequence=0):
         pass
 
     @recorded
@@ -843,10 +845,29 @@ class VolumeTestMixin(object):
     def test_functions(self, fn, nargs):
         self.checker.check_method_call(fn, nargs)
 
+    def test_newmetadata(self):
+        args = (
+            1,             # metaId
+            uuid.uuid4(),  # sdUUID
+            uuid.uuid4(),  # imgUUID
+            uuid.uuid4(),  # puuid
+            1000,          # capacity
+            1,             # format
+            2,             # type
+            sc.LEAF_VOL,   # voltype
+            'file',        # disktype
+            '',            # description
+            sc.LEGAL_VOL,
+        )
+        kwargs = {"sequence": 0}
+        self.checker.check_classmethod_call_args_kwargs(
+            "newMetadata",
+            *args,
+            **kwargs)
+
     @permutations([
         ['_putMetadata', 2],
         ['createMetadata', 2],
-        ['newMetadata', 11],
         ['newVolumeLease', 3],
         ['getImageVolumes', 2],
         ['teardown', 3],


### PR DESCRIPTION
This PR adds the new sequence field to a volume's metadata. This value will be increased for every volume created in an image and will be used to determine which volume is the correct leaf when multiple leaves are present (In operations like snapshot preview and disk convert). 

Depends on https://github.com/oVirt/vdsm/pull/33