### PR TITLE
vm: Fix VM._amend_block_info()

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -1305,7 +1305,7 @@ class Vm(object):
                 replica["poolID"],
                 replica["imageID"],
                 replica["volumeID"])
-            block_info._replace(physical=volsize.apparentsize)
+            block_info = block_info._replace(physical=volsize.apparentsize)
 
         if block_info != drive.blockinfo:
             drive.blockinfo = block_info


### PR DESCRIPTION
In commit c63867bbd416f5b52cd8cc27a3e3557dc558394a

    vm: Replace blockInfo with block stats

We introduced a regression, using the wrong physical size from the
source drive instead of the apparentsize of the replica disk. This may
cause to register wrong block threshold, which will cause a VM to pause
during disk replication.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>