### PR TITLE
github: Add experimental OST workflow

### DIFF
--- a/.github/workflows/ost.yml
+++ b/.github/workflows/ost.yml
@@ -1,0 +1,10 @@
+name: OST
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  ost:
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/ost'}}
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}


### PR DESCRIPTION
Start OST run for current pull request when adding a comment like:

    /ost

We need to improve this later so only maintainers can start OST or
starting OST is possible only if the patch is approved.