### PR TITLE
Modify support for cluster level 4.7

### DIFF
--- a/lib/vdsm/common/dsaversion.py.in
+++ b/lib/vdsm/common/dsaversion.py.in
@@ -48,7 +48,7 @@ def version_info():
     cluster_levels = ['4.2', '4.3', '4.4', '4.5', '4.6']
     libvirt_version = _get_libvirt_version()
 
-    if libvirt_version >= (7, 10):
+    if libvirt_version >= (8, 0):
         cluster_levels.append('4.7')
 
     return {


### PR DESCRIPTION
As a part of 05eefda9703ec21a87428d4c8a552eb019f28101 we have introduced
cluster level 4.7, which requires libvirt >= 7.10.

But recently libvirt has been updated to 8.0, which should be the version
included in RHEL 8.6 and CentOS Stream 9. So we are bumping cluster level
4.7 to require libvirt >= 8.0

Bug-Url: https://bugzilla.redhat.com/2021545
Signed-off-by: Martin Perina <mperina@redhat.com>
