### PR TITLE
static: load vfio-pci module

### DIFF
--- a/static/etc/modules-load.d/vdsm.conf
+++ b/static/etc/modules-load.d/vdsm.conf
@@ -2,3 +2,4 @@
 bonding
 bridge
 8021q
+vfio-pci


### PR DESCRIPTION
When PCI pass-through is used and vfio-pci module is employed for the
devices it is useful to pre-load the module and don't wait for something
else to load it. Without the module engine does not show any module in
PCI devices list which is not too user friendly.

Change-Id: Ia3dd2fd01e87a847eb6d19d6b6f15ea1d327be24
Bug-Url: https://bugzilla.redhat.com/1960808
Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>