### PR TITLE
Update for qemu 6.2

### DIFF
--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -446,14 +446,18 @@ def start_transient_service(server_id, config):
         # "nbd:unix:/path:exportname=name".
         "--export-name=",
 
-        # Enable detection of unallocated extents in qcow2 images. Required for
-        # downloading single volume with backing_chain=False. Always enable it
-        # so NBD client can inspect image allocation.
-        "--allocation-depth",
-
         "--cache=none",
         "--aio=native",
     ]
+
+    if config.format != "raw":
+        # Enable detection of unallocated extents in qcow2 images. Required for
+        # downloading single volume with backing_chain=False. Always enable it
+        # so NBD client can inspect image allocation.
+        # For raw images allocation depth is not useful, and also triggers a
+        # bug in qemu-nbd 6.2 breaking extents reporting in some cases.
+        # See https://bugzilla.redhat.com/2041480.
+        cmd.append("--allocation-depth")
 
     if config.readonly:
         cmd.append("--read-only")

--- a/tests/storage/nbd_test.py
+++ b/tests/storage/nbd_test.py
@@ -221,12 +221,12 @@ def test_detect_zeroes_no_discard(nbd_env, format):
             c.flush()
             extents = c.extents(0, nbd_env.virtual_size)
 
-    image_info = qemuimg.info(vol.volumePath)
+    # For qcow2 format, in qemu-nd < 6.2 actual zeroes written to image.
+    # In 6.2 zeroes seem to be converted to zero clusters. Since the
+    # behavior is not consistent we don't have easy way to verify.
     if format == "raw":
+        image_info = qemuimg.info(vol.volumePath)
         assert image_info["actual-size"] == nbd_env.virtual_size
-    else:
-        # qcow2 metadata requires extra space for fully allocated image.
-        assert image_info["actual-size"] >= nbd_env.virtual_size
 
     log.debug("image extents: %s", extents)
 

--- a/tests/storage/nbd_test.py
+++ b/tests/storage/nbd_test.py
@@ -27,7 +27,7 @@ To setup the environment for unprivileged user:
 
     $ sudo chown $USER:$USER /run/vdsm
 
-    $ sudo env PYTHONPATH=lib static/usr/sbin/supervdsmd \
+    $ sudo env PYTHONPATH=lib static/libexec/vdsm/supervdsmd \
           --data-center /var/tmp/vdsm/data-center \
           --transient-disks /var/tmp/vdsm/transient-disks \
           --sockfile /run/vdsm/svdsm.sock \


### PR DESCRIPTION
qemu-6.2 introduce a regression in extent reporting when using
--allocation-depth option. Avoid this issue by using this option
only for qcow2 format.

Running the nbd tests with qemu-6.2 revealed another change in
zero detection in qcow2 image. Update the test so they pass in
6.2 or earlier versions.

The nbd tests depends on running supervdsm manually, and it moved
recently without updating the comment.