### PR TITLE
virt: Add support for parallel migration connections

### DIFF
--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -3514,6 +3514,14 @@ types:
             type: int
             added: '4.0'
 
+        -   name: parallel
+            type: uint
+            defaultvalue: null
+            description: The number of parallel migration connections
+                to use. If unspecified or 0, parallel connections are not
+                used.
+            added: '4.5'
+
         -   description: The UUID of the virtual machine to migrate
             name: vmId
             type: *UUID


### PR DESCRIPTION
libvirt added the capability of using several parallel migration
connections to speed up migrations.  This patch adds support for a new
migration parameter `parallel' to use the feature.

It is expected that Engine will provide maxBandwidth argument to
maximize throughput when parallel connections are requested.  If
maxBandwidth is not provided, the default Vdsm limit is applied as
usual.

It is possible to explicitly disable parallel migration connections by
setting the `parallel' parameter to 0.  This can be useful if implicit
parallel migration connection setting for a VM is introduced in
future and we need to disable it for a particular migration.

Note that it is meaningful to set the number of parallel migration
connections to 1.  In such a case, the feature is enabled for the
migration, which means a different way of copying data is used in QEMU
than without this feature enabled and it can make performance or
reliability differences.

This patch needs support on the Engine side to provide the new
parameter.

Moved from gerrit: https://gerrit.ovirt.org/c/vdsm/+/116313

Change-Id: Ic19764b3d467f1fa007c7b92f11ef07ac3eb806a
Bug-Url: https://bugzilla.redhat.com/1975720
Signed-off-by: Milan Zamazal <mzamazal@redhat.com>