### PR TITLE
Use lvm devices in lvm commands instead of filter

### DIFF
--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -1882,7 +1882,7 @@ class HSM(object):
 
         # After multipath.rescan, existing devices may disapper, and new
         # devices may appear, making lvm filter stale.
-        lvm.invalidateFilter()
+        lvm.invalidate_devices()
 
         return {'visible': visibility}
 

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -256,6 +256,8 @@ backup {
 USER_DEV_LIST = [d for d in config.get("irs", "lvm_dev_whitelist").split(",")
                  if d is not None]
 
+USE_DEVICES = config.get("lvm", "config_method").lower() == "devices"
+
 
 def _prepare_device_set(devs):
     devices = set(d.strip() for d in chain(devs, USER_DEV_LIST))
@@ -424,7 +426,12 @@ class LVMCache(object):
         else:
             device_set = self._cached_devices()
 
-        dev_filter = _buildFilter(device_set)
+        if USE_DEVICES:
+            if device_set:
+                newcmd += ["--devices", ",".join(device_set)]
+            dev_filter = ""
+        else:
+            dev_filter = _buildFilter(device_set)
 
         conf = _buildConfig(
             dev_filter=dev_filter,

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -238,7 +238,7 @@ devices {
  ignore_suspended_devices=1
  write_cache_state=0
  disable_after_error_count=3
- filter=%(filter)s
+ %(filter)s
  hints="none"
  obtain_device_list_from_udev=0
 }
@@ -273,7 +273,10 @@ def _buildFilter(devices):
     return '[{}"r|.*|"]'.format(accept)
 
 
-def _buildConfig(dev_filter, use_lvmpolld="1"):
+def _buildConfig(dev_filter="", use_lvmpolld="1"):
+    if dev_filter:
+        dev_filter = f"filter={dev_filter}"
+
     conf = LVMCONF_TEMPLATE % {
         "filter": dev_filter,
         "use_lvmpolld": use_lvmpolld,

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -421,9 +421,10 @@ class LVMCache(object):
 
         if devices:
             device_set = _prepare_device_set(devices)
-            dev_filter = _buildFilter(device_set)
         else:
-            dev_filter = _buildFilter(self._cached_devices())
+            device_set = self._cached_devices()
+
+        dev_filter = _buildFilter(device_set)
 
         conf = _buildConfig(
             dev_filter=dev_filter,

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -105,7 +105,7 @@ def attach_volume(vol_id, connection_info):
                     path=path,
                     attachment=attachment,
                     multipath_id=attachment.get("multipath_id"))
-                _invalidate_lvm_filter(attachment)
+                _invalidate_lvm_devices(attachment)
                 volume_type = connection_info["driver_volume_type"]
                 if volume_type not in ("rbd", "iscsi"):
                     raise se.UnsupportedOperation(
@@ -242,20 +242,20 @@ def _resolve_path(vol_id, connection_info, attachment):
         return attachment["path"]
 
 
-def _invalidate_lvm_filter(attachment):
+def _invalidate_lvm_devices(attachment):
     """
-    Invalidate lvm filter when attached disk has a multipath id.
+    Invalidate lvm devices when attached disk has a multipath id.
 
     Vdsm may discover a managed volume after we connected the device to the
     host on the storage side (FC), or after we attached the volume but before
-    we store the multipath id (iSCSI). In this case lvm filter may include the
+    we store the multipath id (iSCSI). In this case lvm devices may include the
     device, and the next lvm command will scan the device.
 
-    Invalidate the lvm filter to ensure that it does not contain the managed
+    Invalidate the lvm devices to ensure that it does not contain the managed
     volume.
     """
     if "multipath_id" in attachment:
-        lvm.invalidateFilter()
+        lvm.invalidate_devices()
 
 
 def _silent_remove(db, vol_id):

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -244,10 +244,10 @@ def _resolve_path(vol_id, connection_info, attachment):
 
 def _invalidate_lvm_filter(attachment):
     """
-    Invalidate lvm filter when if attached disk has a multipath id.
+    Invalidate lvm filter when attached disk has a multipath id.
 
     Vdsm may discover a managed volume after we connected the device to the
-    host on the storage side (FC), or after we attached the volume but betore
+    host on the storage side (FC), or after we attached the volume but before
     we store the multipath id (iSCSI). In this case lvm filter may include the
     device, and the next lvm command will scan the device.
 

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -49,13 +49,13 @@ from . marks import requires_root
 def test_build_filter():
     devices = ("/dev/mapper/a", "/dev/mapper/b")
     expected = '["a|^/dev/mapper/a$|^/dev/mapper/b$|", "r|.*|"]'
-    assert expected == lvm._buildFilter(devices)
+    assert expected == lvm._buildFilter(lvm._prepare_device_set(devices))
 
 
 def test_build_filter_quoting():
     devices = (r"\x20\x24\x7c\x22\x28",)
     expected = r'["a|^\\x20\\x24\\x7c\\x22\\x28$|", "r|.*|"]'
-    assert expected == lvm._buildFilter(devices)
+    assert expected == lvm._buildFilter(lvm._prepare_device_set(devices))
 
 
 def test_build_filter_no_devices():
@@ -67,8 +67,9 @@ def test_build_filter_no_devices():
 
 def test_build_filter_with_user_devices(monkeypatch):
     monkeypatch.setattr(lvm, "USER_DEV_LIST", ("/dev/b",))
-    expected_filter = '["a|^/dev/a$|^/dev/b$|^/dev/c$|", "r|.*|"]'
-    assert expected_filter == lvm._buildFilter(("/dev/a", "/dev/c"))
+    expected = '["a|^/dev/a$|^/dev/b$|^/dev/c$|", "r|.*|"]'
+    actual = lvm._buildFilter(lvm._prepare_device_set(("/dev/a", "/dev/c")))
+    assert expected == actual
 
 
 def test_build_config(fake_devices):
@@ -115,7 +116,7 @@ def fake_devices(monkeypatch):
 
 def build_config(devices, use_lvmpolld="1"):
     return lvm._buildConfig(
-        dev_filter=lvm._buildFilter(devices),
+        dev_filter=lvm._buildFilter(lvm._prepare_device_set(devices)),
         use_lvmpolld=use_lvmpolld)
 
 

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -143,7 +143,7 @@ def test_rebuild_filter_after_invaliation(fake_devices):
     fake_runner = FakeRunner()
     lc = lvm.LVMCache(fake_runner)
     fake_devices.append("/dev/mapper/c")
-    lc.invalidateFilter()
+    lc.invalidate_devices()
 
     lc.run_command(["lvs"])
     cmd = fake_runner.calls[0]


### PR DESCRIPTION
This is follow-up patch of PR #27.

PR #27 introduced new lvm configuration, which uses devices file instead lvm filter. Not to touch user devices accidentally, vdsm allows lvm to use only local devices and all other devices are by default excluded by lvm filter configured by vdsm. For each lvm command vdsm provides lvm config where vdsm sets lvm filter where given device upon lvm command should act is explicitly enabled. However, once lvm is configured to use devices file, lvm filter is ignored.

With devices files we can achieve same result by adding only local devices into lvm devices file (done in PR #27) and then explicitly allow devices in lvm commands by providing `--devices $dev1, ..., $devN` argument in lvm commands. This is implemented in this PR - when vdsm is configured to use devices file, `--devices` argument is used in lvm commands instead of filter.

As vdsm still can be configured to use lvm filter, no code related to lvm filter is removed from vdsm at this point. The only missing step is to enable lvm devices file as the default choice in vdsm.