### PR TITLE
github: Don't try to push to quay on forks

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -8,6 +8,7 @@ on:
     - cron:  '0 0 * * 0'
 env:
   IMAGE_REGISTRY: quay.io
+  can_push: ${{ github.repository_owner == 'oVirt' }}
 jobs:
   container:
     runs-on: ubuntu-latest
@@ -24,6 +25,7 @@ jobs:
         working-directory: docker/network
         run: make ${{ matrix.container }}
       - name: Push to Quay.io
+        if: ${{ env.can_push == true }}
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -33,4 +35,5 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
+        if: ${{ env.can_push == true }}
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
The containers workflow fails every week in my vdsm fork because the
ovirt organization secrets are not available in forks. Skip the push to
quay if repository owner is not 'oVirt'.

Example run from my fork, suceeded without pushing to quay:
https://github.com/nirs/vdsm/actions/runs/1740212112

Signed-off-by: Nir Soffer <nsoffer@redhat.com>