### PR TITLE
github: Fix can_push condition

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: docker/network
         run: make ${{ matrix.container }}
       - name: Push to Quay.io
-        if: ${{ env.can_push == true }}
+        if: ${{ env.can_push == 'true' }}
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -35,5 +35,5 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Print image url
-        if: ${{ env.can_push == true }}
+        if: ${{ env.can_push == 'true' }}
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
When we set:

    can_push: ${{ github.repository_owner == 'oVirt' }}

Github converts the boolean value to the strings 'true' or 'false'[1],
so checking:

    if: ${{ env.can_push == true }}

Does not match and now we never push to quay.

Example run on my fork show that we still skip the push on forks:
https://github.com/nirs/vdsm/actions/runs/1740365670

Unfortunately, the only way to test this properly is to merge to master.

[1] https://docs.github.com/en/enterprise-server@3.0/actions/learn-github-actions/expressions#functions

Fixes 746975bb434e5fbb4c41c3e119728bc3322fb5e9

Signed-off-by: Nir Soffer <nsoffer@redhat.com>