### PR TITLE
Use oVirt upload artifacts action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     - name: Build RPMs
       run: ./automation/rpm.sh
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: ovirt/upload-rpms-action@v2
       with:
-        name: artifacts
-        path: ${{ env.EXPORT_DIR }}
+        directory: ${{ env.EXPORT_DIR }}


### PR DESCRIPTION
In order to use RPMs on OST we need to adopt the common
naming. Use oVirt upload artifacts action that keeps
the convention in one place.

Signed-off-by: Ales Musil <amusil@redhat.com>