### PR TITLE
el9: Move 'nwfilter' and 'dummybr' to 'vdsm-network.service'

### DIFF
--- a/init/vdsmd_init_common.sh.in
+++ b/init/vdsmd_init_common.sh.in
@@ -80,16 +80,6 @@ task_syslog_available() {
 }
 
 
-task_nwfilter(){
-    "${VDSM_TOOL}" nwfilter
-}
-
-
-task_dummybr(){
-    "${VDSM_TOOL}" dummybr
-}
-
-
 _has_systemd() {
     "@MOUNTPOINT_PATH@" -q /cgroup/systemd ||
         "@MOUNTPOINT_PATH@" -q /sys/fs/cgroup/systemd
@@ -232,8 +222,6 @@ case "$1" in
             validate_configuration \
             prepare_transient_repository \
             syslog_available \
-            nwfilter \
-            dummybr \
             tune_system \
             test_space \
             test_lo \

--- a/static/usr/lib/systemd/system/vdsm-network.service.in
+++ b/static/usr/lib/systemd/system/vdsm-network.service.in
@@ -8,6 +8,8 @@ After=libvirtd.service openvswitch.service NetworkManager.service
 Type=oneshot
 EnvironmentFile=-/etc/sysconfig/vdsm
 ExecStartPre=@BINDIR@/vdsm-tool dump-bonding-options
+ExecStart=@BINDIR@/vdsm-tool nwfilter
+ExecStart=@BINDIR@/vdsm-tool dummybr
 ExecStart=@BINDIR@/vdsm-tool restore-nets
 RemainAfterExit=yes
 


### PR DESCRIPTION
'vdsmd_init_common.sh' script is used as an 'ExecStartPre' command of
'vdsmd' systemd service [1].

The systemd documentation states:
"Note that ExecStartPre= may not be used to start long-running
processes. All processes forked off by processes invoked via
ExecStartPre= will be killed before the next service process is run."

'vdsmd_init_common.sh' abuses this rule. Specifically, on el9, spawning
either 'vdsm-tool nwfilter' or 'vdsm-tool dummybr' causes systemd to
kill the script and thus breaks the start of 'vdsmd' service.

Moving these commands to be part of 'vdsm-network' service makes sense -
they're both network related and the dependency chain of the services
will make them triggered just before 'vdsmd' starts.

[1] https://github.com/oVirt/vdsm/blob/2cc33dc391f399fe856453db99f1261e5da5ef4f/static/usr/lib/systemd/system/vdsmd.service.in#L16

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
