### PR TITLE
automation: Update network containers to use centos as base

### DIFF
--- a/docker/network/functional/Dockerfile.centos-8
+++ b/docker/network/functional/Dockerfile.centos-8
@@ -1,7 +1,11 @@
-FROM quay.io/ovirt/buildcontainer:stream8
+FROM quay.io/centos/centos:stream8
 
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
+    && \
+    dnf install -y ovirt-release-master \
     && \
     dnf update -y \
     && \
@@ -9,6 +13,8 @@ RUN dnf -y install dnf-plugins-core \
         autoconf \
         automake \
         dnsmasq \
+        git \
+        make \
         python3 \
         python3-devel \
         python3-pip \

--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -1,7 +1,11 @@
-FROM quay.io/ovirt/buildcontainer:stream9
+FROM quay.io/centos/centos:stream9
 
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && \
+    dnf install -y ovirt-release-master \
     && \
     dnf update -y \
     && \
@@ -13,6 +17,8 @@ RUN dnf -y install dnf-plugins-core \
         autoconf \
         automake \
         dnsmasq \
+        git \
+        make \
         python3 \
         python3-devel \
         python3-pip \

--- a/docker/network/integration/Dockerfile.centos-8
+++ b/docker/network/integration/Dockerfile.centos-8
@@ -1,12 +1,20 @@
-FROM quay.io/ovirt/buildcontainer:stream8
+FROM quay.io/centos/centos:stream8
 
 # Add runtime dependencies.
-RUN dnf update -y \
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
     && \
     dnf install -y \
         autoconf \
         automake \
         dnsmasq \
+        git \
+        make \
         python3-devel \
         python3-pip \
         # Install vdsm-network for its dependencies

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -1,7 +1,13 @@
-FROM quay.io/ovirt/buildcontainer:stream9
+FROM quay.io/centos/centos:stream9
 
 # Add runtime dependencies.
-RUN dnf update -y \
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
     && \
     # Without it the ovirt-openvswitch fails to install
     # It seems that the el8s container has systemd installed by default
@@ -11,6 +17,8 @@ RUN dnf update -y \
         autoconf \
         automake \
         dnsmasq \
+        git \
+        make \
         python3-devel \
         python3-pip \
         # Install vdsm-network for its dependencies

--- a/docker/network/unit/Dockerfile.centos-8
+++ b/docker/network/unit/Dockerfile.centos-8
@@ -1,7 +1,13 @@
-FROM quay.io/ovirt/buildcontainer:stream8
+FROM quay.io/centos/centos:stream8
 
 # Add runtime dependencies.
-RUN dnf update -y \
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
     && \
     dnf install -y \
         iproute-tc \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -1,7 +1,13 @@
-FROM quay.io/ovirt/buildcontainer:stream9
+FROM quay.io/centos/centos:stream9
 
 # Add runtime dependencies.
-RUN dnf update -y \
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
     && \
     # el9s does not have modprobe installed by default
     dnf install -y kmod \


### PR DESCRIPTION
The tag for build container has changed and the container itself
grew in size. With packages for JavaScript and Java there is no
point in keeping it as base.

Signed-off-by: Ales Musil <amusil@redhat.com>