### PR TITLE
net: Lower severity of nic not configured for monitoring

### DIFF
--- a/lib/vdsm/network/dhcp_monitor.py
+++ b/lib/vdsm/network/dhcp_monitor.py
@@ -168,7 +168,7 @@ def _dhcp_event_handler(cif, net_api, event):
     address = IPAddressData(event[EventField.ADDRESS], iface)
 
     if not net_api.is_dhcp_ip_monitored(iface, family):
-        logging.warning(
+        logging.debug(
             'Nic %s is not configured for IPv%s monitoring.', iface, family
         )
         return


### PR DESCRIPTION
The message was logged with warning, which results in some confusion
and spam in the journal. Let's have it as debug as the intention
is really to know what was happening with the monitoring.

Signed-off-by: Ales Musil <amusil@redhat.com>