### PR TITLE
Suppress lvm warnings

### DIFF
--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -317,7 +317,9 @@ class LVMRunner(object):
             "WARNING: This metadata update is NOT backed up",
             (r"WARNING: ignoring metadata seqno \d+ on /dev/mapper/\w+ for "
              r"seqno \d+ on /dev/mapper/\w+ for VG \w+"),
-            r"WARNING: Inconsistent metadata found for VG \w+"
+            r"WARNING: Inconsistent metadata found for VG \w+",
+            ("WARNING: Activation disabled. No device-mapper interaction "
+             "will be attempted"),
         ]),
         re.IGNORECASE)
 

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -711,6 +711,7 @@ def test_suppress_warnings(fake_devices):
   before
   WARNING: This metadata update is NOT backed up.
   WARNING: Combining activation change with other commands is not advised.
+  WARNING: Activation disabled. No device-mapper interaction will be attempted.
   Configuration setting "global/event_activation" unknown.
   WARNING: ignoring metadata seqno 1566 on /dev/mapper/3600a098038304437415d4b6a59684474 for seqno 1567 on /dev/mapper/3600a098038304437415d4b6a59684474 for VG Bug."
   WARNING: Inconsistent metadata found for VG Bug."

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -720,14 +720,14 @@ def test_suppress_warnings(fake_devices):
     fake_runner.rc = 1
     with pytest.raises(se.LVMCommandError) as e:
         lc.run_command(["fake"])
-        assert e.rc == 1
-        assert e.err == [
-            u"  before",
-            (u"  WARNING: Combining activation change with other commands is "
-             "not advised."),
-            u"  Configuration setting \"global/event_activation\" unknown.",
-            u"  after"
-        ]
+    assert e.value.rc == 1
+    assert e.value.err == [
+        u"  before",
+        (u"  WARNING: Combining activation change with other commands is "
+         "not advised."),
+        u"  Configuration setting \"global/event_activation\" unknown.",
+        u"  after"
+    ]
 
 
 def test_suppress_multiple_lvm_warnings(fake_devices):
@@ -743,8 +743,8 @@ def test_suppress_multiple_lvm_warnings(fake_devices):
     fake_runner.rc = 1
     with pytest.raises(se.LVMCommandError) as e:
         lc.run_command(["fake"])
-        assert e.rc == 1
-        assert e.err == [u"  before", u"  after"]
+    assert e.value.rc == 1
+    assert e.value.err == [u"  before", u"  after"]
 
 
 def test_pv_move_cmd(fake_devices, monkeypatch):


### PR DESCRIPTION
Fix lvm suppressing tests, and fix new warning we introduced recently
by adding the "--driverloaded n" option in lvextend.