### PR TITLE
vm: Remove ancient unused method

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -1280,15 +1280,6 @@ class Vm(object):
         self.log.debug('new rtc offset %s', newTimeOffset)
         self._timeOffset = newTimeOffset
 
-    def getChunkedDrives(self):
-        """
-        Return list of writable chunked drives, or writable non-chunked
-        drives replicating to chunked replica drive.
-        """
-        return [drive for drive in self._devices[hwclass.DISK]
-                if (drive.chunked or drive.replicaChunked) and not
-                drive.readonly]
-
     def _amend_block_info(self, drive, block_info):
         """
         Ammend block info from libvirt in case the drive is not chucked and is

--- a/tests/virt/vmoperations_test.py
+++ b/tests/virt/vmoperations_test.py
@@ -40,7 +40,6 @@ from vdsm.virt import saslpasswd2
 from vdsm.virt import virdomain
 from vdsm.virt import vmexitreason
 from vdsm.virt.vmdevices import hwclass
-from vdsm.virt.vmdevices import storage
 
 from monkeypatch import MonkeyPatch, MonkeyPatchScope
 from testlib import XMLTestCase
@@ -465,29 +464,6 @@ class TestVmOperations(XMLTestCase):
         with fake.VM() as testvm:
             testvm._dom = fake.Domain(vmId='testvm')
             assert not response.is_error(testvm.acpiReboot())
-
-    @permutations([
-        # info, expected
-        ({'readonly': True, 'diskType': storage.DISK_TYPE.BLOCK}, []),
-        ({'readonly': True, 'diskType': storage.DISK_TYPE.FILE}, []),
-        ({'readonly': False, 'diskType': storage.DISK_TYPE.FILE}, []),
-        ({'readonly': False, 'diskType': storage.DISK_TYPE.FILE}, []),
-        ({'readonly': False, 'diskType': storage.DISK_TYPE.BLOCK,
-          'format': 'raw'}, []),
-        ({'readonly': False, 'diskType': storage.DISK_TYPE.BLOCK}, ['vda']),
-        ({'readonly': False, 'diskType': storage.DISK_TYPE.FILE,
-          'diskReplicate': {
-              'format': 'cow', 'diskType': storage.DISK_TYPE.BLOCK}
-          },
-         ['vda']),
-    ])
-    def testGetChunkedDrives(self, disk_conf, expected):
-        with fake.VM() as testvm:
-            vda = storage.Drive(self.log, **drive_config(**disk_conf))
-            testvm._devices[hwclass.DISK] = [vda]
-
-            drives = [drive.name for drive in testvm.getChunkedDrives()]
-            assert drives == expected
 
     def test_process_migration_cpusets(self):
         with fake.VM() as testvm:


### PR DESCRIPTION
VM.getChunkedDrives() is not used since 2017, remove it.

Fixes: 6a251845f4a237b9c9b78e5d7461bcd9c6184c3b
Signed-off-by: Nir Soffer <nsoffer@redhat.com>