### PR TITLE
github: Add OST workflow

### DIFF
--- a/.github/workflows/ost.yml
+++ b/.github/workflows/ost.yml
@@ -1,0 +1,16 @@
+name: OST
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-ost:
+    if: |
+      ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/ost') &&
+          ( github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR' )
+      }}
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}


### PR DESCRIPTION
Start OST run for current pull request when adding a comment like:

    /ost

We need to improve this later so only maintainers can start OST or
starting OST is possible only if the patch is approved.

replaceing PR: https://github.com/oVirt/vdsm/pull/44