### PR TITLE
Cleanup VolumeMonitor API

### DIFF
--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -419,7 +419,7 @@ class VolumeMonitor(object):
 
     def _amend_block_info(self, drive, block_info):
         """
-        Ammend block info from libvirt in case the drive is not chucked and is
+        Amend block info from libvirt in case the drive is not chucked and is
         replicating to a chunked drive.
         """
         if not drive.chunked:
@@ -437,7 +437,7 @@ class VolumeMonitor(object):
 
         return block_info
 
-    # Exteding volumes.
+    # Extending volumes.
 
     def extend_volume(self, vmDrive, volumeID, curSize, capacity,
                       callback=None):

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -258,12 +258,9 @@ class VolumeMonitor(object):
                 drive.name)
             return False
 
-        index = self._vm.query_drive_volume_index(drive, drive.volumeID)
-        block_info = self._amend_block_info(drive, block_stats[index])
-        drive.block_info = block_info
-
+        block_info = self._query_block_info(drive, drive.volumeID, block_stats)
         if drive.threshold_state == storage.BLOCK_THRESHOLD.UNSET:
-            self._set_threshold(drive, block_info.physical, index)
+            self._set_threshold(drive, block_info.physical, block_info.index)
 
         if not self._should_extend_volume(drive, drive.volumeID, block_info):
             return False
@@ -372,8 +369,10 @@ class VolumeMonitor(object):
 
         The updated block info is stored in the drive.
         """
+        return self._query_block_info(drive, vol_id, self._get_block_stats())
+
+    def _query_block_info(self, drive, vol_id, block_stats):
         index = self._vm.query_drive_volume_index(drive, vol_id)
-        block_stats = self._get_block_stats()
         drive.block_info = self._amend_block_info(drive, block_stats[index])
         return drive.block_info
 

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -84,7 +84,7 @@ class VolumeMonitor(object):
         """
         return self._enabled and bool(self.monitored_volumes())
 
-    def set_threshold(self, drive, apparentsize, index=None):
+    def set_threshold(self, drive, apparentsize, index):
         """
         Set the libvirt block threshold on the given drive image, enabling
         libvirt to deliver the event when the threshold is crossed.
@@ -152,7 +152,7 @@ class VolumeMonitor(object):
         else:
             drive.threshold_state = storage.BLOCK_THRESHOLD.SET
 
-    def clear_threshold(self, drive, index=None):
+    def clear_threshold(self, drive, index):
         """
         Clear the libvirt block threshold on the given drive, disabling
         libvirt events.
@@ -263,7 +263,7 @@ class VolumeMonitor(object):
         drive.block_info = block_info
 
         if drive.threshold_state == storage.BLOCK_THRESHOLD.UNSET:
-            self.set_threshold(drive, block_info.physical, index=index)
+            self.set_threshold(drive, block_info.physical, index)
 
         if not self.should_extend_volume(drive, drive.volumeID, block_info):
             return False
@@ -570,17 +570,14 @@ class VolumeMonitor(object):
         drive.truesize = volsize.truesize
 
         index = self._vm.query_drive_volume_index(drive, drive.volumeID)
-        self.set_threshold(drive, volsize.apparentsize, index=index)
+        self.set_threshold(drive, volsize.apparentsize, index)
 
 
 _TARGET_RE = re.compile(r"([hvs]d[a-z]+)\[(\d+)\]")
 
 
 def format_target(name, index):
-    if index is None:
-        return name
-    else:
-        return "{}[{}]".format(name, index)
+    return "{}[{:d}]".format(name, index)
 
 
 def parse_target(target):

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -218,7 +218,7 @@ class VolumeMonitor(object):
             return False
 
         try:
-            block_stats = self._get_block_stats()
+            block_stats = self._query_block_stats()
         except libvirt.libvirtError as e:
             self._log.error("Unable to get block stats: %s", e)
             return False
@@ -369,20 +369,20 @@ class VolumeMonitor(object):
 
         The updated block info is stored in the drive.
         """
-        return self._query_block_info(drive, vol_id, self._get_block_stats())
+        return self._query_block_info(drive, vol_id, self._query_block_stats())
 
     def _query_block_info(self, drive, vol_id, block_stats):
         index = self._vm.query_drive_volume_index(drive, vol_id)
         drive.block_info = self._amend_block_info(drive, block_stats[index])
         return drive.block_info
 
-    def _get_block_stats(self):
+    def _query_block_stats(self):
         """
         Extract monitoring related info from libvirt block stats.
 
         Return mapping from volume backing index to its BlockInfo.
         """
-        block_stats = self._vm.get_block_stats()
+        block_stats = self._vm.query_block_stats()
         result = {}
 
         for i in range(block_stats["block.count"]):

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -57,6 +57,8 @@ class VolumeMonitor(object):
         self._log = log
         self._enabled = enabled
 
+    # Enabling and disabling the monitor.
+
     def enabled(self):
         return self._enabled
 
@@ -83,6 +85,8 @@ class VolumeMonitor(object):
         monitor_volumes during this periodic cycle.
         """
         return self._enabled and bool(self._monitored_volumes())
+
+    # Managing libvirt block threshold.
 
     def _set_threshold(self, drive, apparentsize, index):
         """
@@ -208,6 +212,8 @@ class VolumeMonitor(object):
                 drive_name, self._vm.id)
         else:
             drive.on_block_threshold(path)
+
+    # Monitoring volumes.
 
     def monitor_volumes(self):
         """
@@ -357,7 +363,7 @@ class VolumeMonitor(object):
                 "Drive %s needs to be extended, forced threshold_state "
                 "to exceeded", drive.name)
 
-    # Quering libvirt
+    # Querying libvirt
 
     def query_block_info(self, drive, vol_id):
         """

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -281,7 +281,7 @@ class VolumeMonitor(object):
             "threshold_state %s",
             drive.volumeID, drive.domainID, block_info, drive.threshold_state)
 
-        self._vm.extend_volume(
+        self.extend_volume(
             drive, drive.volumeID, block_info.physical, block_info.capacity)
 
         return True

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -4356,11 +4356,8 @@ class Vm(object):
 
         if drive.chunked or drive.replicaChunked:
             try:
-                index = self.query_drive_volume_index(drive, drive.volumeID)
-                block_stats = self.volume_monitor.get_block_stats()
-                block_info = self.volume_monitor.amend_block_info(
-                    drive, block_stats[index])
-                drive.block_info = block_info
+                block_info = self.volume_monitor.query_block_info(
+                    drive, drive.volumeID)
                 self.extend_volume(
                     drive,
                     drive.volumeID,

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -1278,7 +1278,7 @@ class Vm(object):
         self.log.debug('new rtc offset %s', newTimeOffset)
         self._timeOffset = newTimeOffset
 
-    def get_block_stats(self):
+    def query_block_stats(self):
         """
         Return stats for all block nodes.
 

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -4209,7 +4209,7 @@ class Vm(object):
     def clear_drive_threshold(self, drive, old_volume_id):
         try:
             index = self.query_drive_volume_index(drive, old_volume_id)
-            self.volume_monitor.clear_threshold(drive, index=index)
+            self.volume_monitor.clear_threshold(drive, index)
         except Exception as e:
             self.log.error("Unable to clear drive threshold: %s", e)
 

--- a/tests/virt/drive_extension_test.py
+++ b/tests/virt/drive_extension_test.py
@@ -402,7 +402,8 @@ def test_set_new_threshold_when_state_unset(
     assert vda.threshold_state == BLOCK_THRESHOLD.UNSET
     # first run: does nothing but set the block thresholds
 
-    vm.volume_monitor.update_threshold_state_exceeded = \
+    # TODO: Use public API.
+    vm.volume_monitor._update_threshold_state_exceeded = \
         lambda *args: None
 
     vm.monitor_volumes()

--- a/tests/virt/drive_extension_test.py
+++ b/tests/virt/drive_extension_test.py
@@ -442,7 +442,7 @@ def test_set_new_threshold_when_state_set(tmp_config):
 
     drives[0].threshold_state = BLOCK_THRESHOLD.SET
 
-    block_stats = mon._get_block_stats()
+    block_stats = mon._query_block_stats()
     extended = mon._extend_drive_if_needed(drives[0], block_stats)
 
     assert not extended
@@ -600,7 +600,7 @@ class FakeVM(Vm):
     def should_refresh_destination_volume(self):
         return False
 
-    def get_block_stats(self):
+    def query_block_stats(self):
         # Create libvirt response.
         raw_stats = {"block.count": len(self.block_stats)}
         for i, block_info in enumerate(self.block_stats.values()):

--- a/tests/virt/drive_extension_test.py
+++ b/tests/virt/drive_extension_test.py
@@ -442,7 +442,7 @@ def test_set_new_threshold_when_state_set(tmp_config):
 
     drives[0].threshold_state = BLOCK_THRESHOLD.SET
 
-    block_stats = mon.get_block_stats()
+    block_stats = mon._get_block_stats()
     extended = mon._extend_drive_if_needed(drives[0], block_stats)
 
     assert not extended

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -533,7 +533,7 @@ def test_get_block_stats():
     }
 
     mon = thinp.VolumeMonitor(vm, vm.log)
-    block_stats = mon.get_block_stats()
+    block_stats = mon._get_block_stats()
 
     assert block_stats == {
         2: thinp.BlockInfo(

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -59,7 +59,8 @@ def test_set_threshold():
     apparentsize = 4 * GiB
     threshold = 512 * MiB
 
-    mon.set_threshold(vda, apparentsize, 1)
+    # TODO: Use public API.
+    mon._set_threshold(vda, apparentsize, 1)
     expected = apparentsize - threshold
     assert vm._dom.thresholds == [('vda[1]', expected)]
 
@@ -76,7 +77,8 @@ def test_set_threshold_drive_too_small():
 
     apparentsize = 128 * MiB
 
-    mon.set_threshold(vda, apparentsize, 3)
+    # TODO: Use public API.
+    mon._set_threshold(vda, apparentsize, 3)
     target, value = vm._dom.thresholds[0]
     assert target == 'vda[3]'
     assert value >= 1
@@ -466,7 +468,8 @@ def test_monitored_volumes(drives, monitored):
         drive.monitorable = conf.get('monitorable', True)
         vm.drives.append(drive)
 
-    found = [drv.name for drv in mon.monitored_volumes()]
+    # TODO: Use public API
+    found = [drv.name for drv in mon._monitored_volumes()]
     assert found == monitored
 
 

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -50,7 +50,7 @@ def test_disable_runtime():
     assert mon.enabled() is False
 
 
-def test_set_threshold_drive_name():
+def test_set_threshold():
     vm = FakeVM()
     mon = thinp.VolumeMonitor(vm, vm.log)
     vda = make_drive(vm.log, index=0, iface='virtio')
@@ -59,21 +59,7 @@ def test_set_threshold_drive_name():
     apparentsize = 4 * GiB
     threshold = 512 * MiB
 
-    mon.set_threshold(vda, apparentsize)
-    expected = apparentsize - threshold
-    assert vm._dom.thresholds == [('vda', expected)]
-
-
-def test_set_threshold_indexed_name():
-    vm = FakeVM()
-    mon = thinp.VolumeMonitor(vm, vm.log)
-    vda = make_drive(vm.log, index=0, iface='virtio')
-    vm.drives.append(vda)
-
-    apparentsize = 4 * GiB
-    threshold = 512 * MiB
-
-    mon.set_threshold(vda, apparentsize, index=1)
+    mon.set_threshold(vda, apparentsize, 1)
     expected = apparentsize - threshold
     assert vm._dom.thresholds == [('vda[1]', expected)]
 
@@ -90,29 +76,20 @@ def test_set_threshold_drive_too_small():
 
     apparentsize = 128 * MiB
 
-    mon.set_threshold(vda, apparentsize, index=3)
+    mon.set_threshold(vda, apparentsize, 3)
     target, value = vm._dom.thresholds[0]
     assert target == 'vda[3]'
     assert value >= 1
 
 
-def test_clear_with_index_equal_none():
-    vm = FakeVM()
-    mon = thinp.VolumeMonitor(vm, vm.log)
-    vda = make_drive(vm.log, index=0, iface='virtio')
-
-    mon.clear_threshold(vda)
-    assert vm._dom.thresholds == [('vda', 0)]
-
-
-def test_clear_with_index():
+def test_clear_threshold():
     vm = FakeVM()
     mon = thinp.VolumeMonitor(vm, vm.log)
     # one drive (virtio, 0)
     vda = make_drive(vm.log, index=0, iface='virtio')
 
     # clear the 1st element in the backing chain of the drive
-    mon.clear_threshold(vda, index=1)
+    mon.clear_threshold(vda, 1)
     assert vm._dom.thresholds == [('vda[1]', 0)]
 
 

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -473,7 +473,7 @@ def test_monitored_volumes(drives, monitored):
     assert found == monitored
 
 
-def test_get_block_stats():
+def test_query_block_stats():
     vm = FakeVM()
 
     vm.block_stats = {
@@ -533,7 +533,7 @@ def test_get_block_stats():
     }
 
     mon = thinp.VolumeMonitor(vm, vm.log)
-    block_stats = mon._get_block_stats()
+    block_stats = mon._query_block_stats()
 
     assert block_stats == {
         2: thinp.BlockInfo(
@@ -579,7 +579,7 @@ class FakeVM(object):
     def getDiskDevices(self):
         return self.drives[:]
 
-    def get_block_stats(self):
+    def query_block_stats(self):
         return self.block_stats
 
 


### PR DESCRIPTION
Clean up the API after we moved all the monitoring and extending code
to thinp.VolumeMonitor.

- Remove unneeded optional arguments
- Make methods private
- Move last lefover monitoring code from VM
- Remove duplication
- Avoid unneeded calls to VM methods
- Unify methods names
- Group methods by category.

Based on top of #58.