### PR TITLE
net: Add systemd to all network containers

### DIFF
--- a/docker/network/functional/Dockerfile.centos-8
+++ b/docker/network/functional/Dockerfile.centos-8
@@ -19,6 +19,7 @@ RUN dnf -y install dnf-plugins-core \
         python3-devel \
         python3-pip \
         python3-yaml \
+        systemd \
         systemd-udev \
         # Install vdsm-network for its dependencies
         vdsm-network \

--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -23,6 +23,7 @@ RUN dnf -y install dnf-plugins-core \
         python3-devel \
         python3-pip \
         python3-yaml \
+        systemd \
         systemd-udev \
         # Install vdsm-network for its dependencies
         vdsm-network \

--- a/docker/network/integration/Dockerfile.centos-8
+++ b/docker/network/integration/Dockerfile.centos-8
@@ -17,6 +17,7 @@ RUN dnf -y install dnf-plugins-core \
         make \
         python3-devel \
         python3-pip \
+        systemd \
         # Install vdsm-network for its dependencies
         vdsm-network \
     && \

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -21,6 +21,7 @@ RUN dnf -y install dnf-plugins-core \
         make \
         python3-devel \
         python3-pip \
+        systemd \
         # Install vdsm-network for its dependencies
         vdsm-network \
     && \

--- a/docker/network/unit/Dockerfile.centos-8
+++ b/docker/network/unit/Dockerfile.centos-8
@@ -16,6 +16,7 @@ RUN dnf -y install dnf-plugins-core \
         python3-devel \
         python3-six \
         python3-pip \
+        systemd \
     && \
     dnf clean all
 

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -19,6 +19,7 @@ RUN dnf -y install dnf-plugins-core \
         python3-devel \
         python3-six \
         python3-pip \
+        systemd \
     && \
     dnf clean all
 


### PR DESCRIPTION
For some reason the built done by GH actions
won't install systemd in the el9 contianers, however
the local one does that. Add the systemd dependency explicitly
to prevent that issue.

Signed-off-by: Ales Musil <amusil@redhat.com>