### PR TITLE
github: Fix OST condition

### DIFF
--- a/.github/workflows/ost.yml
+++ b/.github/workflows/ost.yml
@@ -7,10 +7,12 @@ on:
 jobs:
   trigger-ost:
     if: |
-      ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/ost') &&
-          ( github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'COLLABORATOR' )
-      }}
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ost') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
     with:
       pr_url: ${{ github.event.issue.pull_request.url }}


### PR DESCRIPTION
The current if condition always matches, so every comment will trigger
OST run.

For example, this comment:
https://github.com/oVirt/vdsm/pull/49#issuecomment-1028473401

Triggered this run:
https://github.com/oVirt/vdsm/actions/runs/1786861822

I could not find documentation for this but the issue is metioned here:
https://github.community/t/how-to-write-multi-line-condition-in-if/128477

Looks like "|" and "${{}}" do not work together. For multi-line if we
should use only "|".

Fixes: 588a421d1c97d6eeb5784a162a72bca5f05dd15f
Signed-off-by: Nir Soffer <nsoffer@redhat.com>