### PR TITLE
Don't use hardcoded value for lvm devices file

### DIFF
--- a/lib/vdsm/storage/lvmconf.py
+++ b/lib/vdsm/storage/lvmconf.py
@@ -72,8 +72,6 @@ TODO
 
 """
 
-from __future__ import absolute_import
-
 import logging
 
 from augeas import Augeas

--- a/lib/vdsm/storage/lvmconf.py
+++ b/lib/vdsm/storage/lvmconf.py
@@ -76,7 +76,21 @@ import logging
 
 from augeas import Augeas
 
+from vdsm import constants
+from vdsm.common import commands
+
+
 log = logging.getLogger("storage.lvmconf")
+
+
+class UnexpectedLvmConfigOutput(Exception):
+    msg = "Unexpected LVM config output"
+
+    def __init__(self, reason):
+        self.value = "reason=%s" % reason
+
+    def __str__(self):
+        return "%s: %s" % (self.msg, repr(self.value))
 
 
 class LVMConfig(object):
@@ -184,3 +198,38 @@ class LVMConfig(object):
     def close(self):
         log.debug("Closing LVM configuration %s", self.path)
         self.aug.close()
+
+
+def configured_value(section, option):
+    """
+    Return value configured for the option, taken into account all config
+    files and default configurations.
+    """
+    if not section:
+        raise ValueError("Section must not be empty.")
+    if not option:
+        raise ValueError("Option must not be empty.")
+
+    cmd = [constants.EXT_LVM, "lvmconfig",
+           "--typeconfig", "full",
+           f"{section}/{option}"]
+    out = commands.run(cmd).decode("utf-8").strip()
+
+    # Validate, that the output is in expected format key=value and doesn't
+    # span multiple lines.
+    if "=" not in out or "\n" in out:
+        raise UnexpectedLvmConfigOutput(
+            f"Unexpected output: option={section}/{option}, output={out}")
+
+    key, value = out.split("=", 1)
+
+    # Validate, that returned key matches requested option.
+    if key.strip() != option:
+        raise UnexpectedLvmConfigOutput(
+            f"Returned key doesn't match option: option={option}, key={key}")
+
+    # String value.
+    if value[0] == '"' and value[-1] == '"':
+        value = value[1:-1]
+
+    return value

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -34,12 +34,13 @@ import logging
 import os
 import subprocess
 
+from vdsm import constants
 from vdsm.common import cmdutils
 from vdsm.common import commands
 from vdsm.storage import lvmconf
 from vdsm.storage import lvmfilter
 
-LVM = "/usr/sbin/lvm"
+
 _LVM_SYSTEM_DEVICES_PATH = "/etc/lvm/devices/system.devices"
 
 
@@ -126,7 +127,7 @@ def _run_vgimportdevices(vg):
     devices won't be imported. If the filter is wrong, we may miss some
     devices. To avoid such situation, set the filter to enable all the devices.
     """
-    cmd = [LVM,
+    cmd = [constants.EXT_LVM,
            'vgimportdevices',
            vg,
            '--config',
@@ -154,7 +155,7 @@ def _run_check():
     raise any exception if the check finds issues in devices file, but only
     log a waring with found issues.
     """
-    cmd = [LVM, 'lvmdevices', "--check"]
+    cmd = [constants.EXT_LVM, 'lvmdevices', "--check"]
 
     p = commands.start(
         cmd,

--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -41,7 +41,7 @@ from vdsm.storage import lvmconf
 from vdsm.storage import lvmfilter
 
 
-_LVM_SYSTEM_DEVICES_PATH = "/etc/lvm/devices/system.devices"
+_LVM_DEVICES_DIR = "/etc/lvm/devices"
 
 
 log = logging.getLogger("lvmdevices")
@@ -98,7 +98,13 @@ def _devices_file_exists():
     Returns True if default lvm devices file exists. If the file doesn't
     exists, lvm disables whole devices file functionality.
     """
-    return os.path.exists(_LVM_SYSTEM_DEVICES_PATH)
+    try:
+        devicesfile = lvmconf.configured_value("devices", "devicesfile")
+    except (cmdutils.Error, lvmconf.UnexpectedLvmConfigOutput):
+        return False
+
+    devices_file = os.path.join(_LVM_DEVICES_DIR, devicesfile)
+    return os.path.exists(devices_file)
 
 
 def _configure_devices_file(enable=True):

--- a/lib/vdsm/storage/lvmfilter.py
+++ b/lib/vdsm/storage/lvmfilter.py
@@ -46,13 +46,13 @@ import operator
 import os
 import re
 
+from vdsm import constants
 from vdsm.common import errors
 from vdsm.common import udevadm
 from vdsm.common.compat import subprocess
 from vdsm.storage import lvmconf
 
 LSBLK = "/usr/bin/lsblk"
-LVM = "/usr/sbin/lvm"
 PROC_DEVICES = "/proc/devices"
 SYS_BLOCK_DEVICE_PATTERN = "/sys/block/{}/device/subsystem"
 WWID_ATTRIBUTE = {
@@ -455,7 +455,7 @@ def vg_info(lv_path):
     """
     log.debug("Looking up information for logical volume %r", lv_path)
     out = _run([
-        LVM,
+        constants.EXT_LVM,
         "lvs",
         "--noheadings",
         "--readonly",
@@ -482,7 +482,7 @@ def vg_devices(vg_name):
     """
     log.debug("Looking up volume group %r devices", vg_name)
     out = _run([
-        LVM,
+        constants.EXT_LVM,
         "vgs",
         "--noheadings",
         "--readonly",


### PR DESCRIPTION
Currently path to lvm devices files is hardcoded in lvmdevices module and uses default lvm value. This would break if the user for some reason configures lvm to use custom devices file. This PR:
* add new function which allows to determine lvm config value which will be actually used by lvm
* replace hardcoded path to lvm devices file by one actually used by lvm
* does some minor cleanup, especially reuse existing constant pointing to lvm executable instead of defining it again in each module using lvm command