### PR TITLE
Minimize scratch disk initial size

### DIFF
--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -8455,6 +8455,21 @@ types:
                 volume resides on ('file').
             name: type
             type: *DiskType
+
+        -   description: The UUID of the Storage Domain containing the Volume
+            name: domainID
+            type: *UUID
+            added: '4.5'
+
+        -   description: The UUID of the Image
+            name: imageID
+            type: *UUID
+            added: '4.5'
+
+        -   description: The UUID of the Volume
+            name: volumeID
+            type: *UUID
+            added: '4.5'
         type: object
 
     BlockScratchDisk: &BlockScratchDisk
@@ -8471,6 +8486,21 @@ types:
                 volume resides on ('block').
             name: type
             type: *DiskType
+
+        -   description: The UUID of the Storage Domain containing the Volume
+            name: domainID
+            type: *UUID
+            added: '4.5'
+
+        -   description: The UUID of the Image
+            name: imageID
+            type: *UUID
+            added: '4.5'
+
+        -   description: The UUID of the Volume
+            name: volumeID
+            type: *UUID
+            added: '4.5'
         type: object
 
     ScratchDisk: &ScratchDisk

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -8459,7 +8459,7 @@ types:
 
     BlockScratchDisk: &BlockScratchDisk
         added: '4.4.5'
-        description: VM backup file-based scratch disk parameters
+        description: VM backup block-based scratch disk parameters
             for usage when starting a backup.
         name: BlockScratchDisk
         properties:

--- a/lib/vdsm/virt/backup.py
+++ b/lib/vdsm/virt/backup.py
@@ -358,14 +358,17 @@ def _start_monitoring_scratch_disks(vm, backup_disks, backup):
     disks = backup["disks"]
     for backup_disk in backup_disks.values():
         if backup_disk.scratch_disk.type == DISK_TYPE.BLOCK:
-            # TODO: Add domain, image, and volume ids when they are
-            # availble.
             scratch_disk = disks[backup_disk.drive.name]
             vm.log.info("Start monitoring scratch disk %s for drive %s",
                         scratch_disk, backup_disk.drive.name)
-            backup_disk.drive.scratch_disk = {
-                "index": scratch_disk["index"],
-            }
+            d = {"index": scratch_disk["index"]}
+            if backup_disk.scratch_disk.sd_id is not None:
+                d["sd_id"] = backup_disk.scratch_disk.sd_id
+            if backup_disk.scratch_disk.img_id is not None:
+                d["img_id"] = backup_disk.scratch_disk.img_id
+            if backup_disk.scratch_disk.vol_id is not None:
+                d["vol_id"] = backup_disk.scratch_disk.vol_id
+            backup_disk.drive.scratch_disk = d
 
 
 def _stop_monitoring_scratch_disks(vm):

--- a/lib/vdsm/virt/backup.py
+++ b/lib/vdsm/virt/backup.py
@@ -72,10 +72,16 @@ class ScratchDiskConfig(properties.Owner):
     type = properties.Enum(
         required=True,
         values=[DISK_TYPE.FILE, DISK_TYPE.BLOCK])
+    sd_id = properties.UUID(required=False)
+    img_id = properties.UUID(required=False)
+    vol_id = properties.UUID(required=False)
 
     def __init__(self, **kw):
         self.path = kw.get("path")
         self.type = kw.get("type")
+        self.sd_id = kw.get("sd_id")
+        self.img_id = kw.get("img_id")
+        self.vol_id = kw.get("vol_id")
 
 
 class DiskConfig(properties.Owner):
@@ -98,7 +104,10 @@ class DiskConfig(properties.Owner):
             scratch_disk = disk_config.get("scratch_disk")
             self.scratch_disk = ScratchDiskConfig(
                 path=scratch_disk.get("path"),
-                type=scratch_disk.get("type"))
+                type=scratch_disk.get("type"),
+                sd_id=scratch_disk.get("domainID"),
+                img_id=scratch_disk.get("imageID"),
+                vol_id=scratch_disk.get("volumeID"))
         else:
             self.scratch_disk = None
 


### PR DESCRIPTION
Add to VDSM API and use 3 new properties that will allow creating scratch disk on block storage with small initial size.
VDSM will monitor the scratch disk block threshold and extend it as needed.

Signed-off-by: Pavel Bar <pbar@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1913389