### PR TITLE
lvm: use devices file as default config method

### DIFF
--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -444,11 +444,11 @@ parameters = [
     # Section: [lvm]
     ('lvm', [
 
-        ('config_method', 'filter',
+        ('config_method', 'devices',
             'Method how to specify devices which LVM can use. Possible values'
             'are either "filter" or "devices". Filter method will use LVM '
             'filter, while device will use LVM devices file. The default '
-            'value is "filter".'),
+            'value is "devices".'),
     ]),
 
     # Section: [sanlock]


### PR DESCRIPTION
Switch the default from filter based LVM configuration to devices file
configuration. Any newly installed host or host upgraded to vdsm version
containing this commit will start to use LVM devices file and LVM filter
will be ignored.

If the user has any issue with this setup, it can be reverted by
creating custom vdsm config file (or modifying if such file already
exists) and setting config_method to "filter" in lvm section, e.g.:

    $ cat /etc/vdsm/vdsm.conf.d/99-lvm.conf
    [lvm]
    config_method= filter

Change-Id: Ib4d814fe42e5e0f2b75ed0d6f974c756b7605ad6
Signed-off-by: Vojtěch Juránek <vjuranek@redhat.com>