### PR TITLE
Allow selecting OST suite and distro

### DIFF
--- a/.github/workflows/ost.yml
+++ b/.github/workflows/ost.yml
@@ -5,7 +5,19 @@ on:
     types: [created]
 
 jobs:
+  parse-params:
+    outputs:
+      ost_suite: ${{ steps.parse-params.outputs.ost_suite }}
+      ost_images_distro: ${{ steps.parse-params.outputs.ost_images_distro }}
+    steps:
+    - id: parse-params
+      run: |
+        echo "::set-output name=ost_suite::$(echo ${{ github.event.comment.body }} | egrep -o '\w+-suite-master' || echo basic-suite-master)"
+      run: |
+        echo "::set-output name=ost_images_distro::$(echo ${{ github.event.comment.body }} | egrep -o '(el8stream|el9stream|rhel8)' || echo el8stream)"
+
   trigger-ost:
+    needs: parse-params
     if: |
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/ost') &&
@@ -16,3 +28,5 @@ jobs:
     uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
     with:
       pr_url: ${{ github.event.issue.pull_request.url }}
+      suite: ${{ needs.parse-params.outputs.ost_suite }}
+      distro: ${{ needs.parse-params.outputs.ost_images_distro }}


### PR DESCRIPTION
This PR adds the logic for parsing the parameters to '/ost'
comments that allow specifying which suite and distro to use
in the OST run, i.e.:

 /ost network-suite-master rhel8

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
