### PR TITLE
Don't fail when connection list is empty

### DIFF
--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -2168,6 +2168,9 @@ class HSM(object):
                   successful
         :rtype: dict
         """
+        if not conList:
+            raise se.InvalidParameterException("conList", conList)
+
         vars.task.setDefaultException(
             se.StorageServerConnectionError(
                 "domType=%s, spUUID=%s, conList=%s" %
@@ -2226,6 +2229,12 @@ class HSM(object):
                   successful
         :rtype: dict
         """
+        if not conList:
+            # Engine currently sends empty list when more than one iSCSI SD use
+            # same iSCSI target. Return empty result list.
+            self.log.warning("Connection list is empty, ignoring request")
+            return dict(statuslist=[])
+
         vars.task.setDefaultException(
             se.StorageServerDisconnectionError(
                 "domType=%s, spUUID=%s, conList=%s" %

--- a/lib/vdsm/storage/storageServer.py
+++ b/lib/vdsm/storage/storageServer.py
@@ -935,11 +935,13 @@ def disconnect(dom_type, con_defs):
 
 def _prepare_connections(dom_type, con_defs):
     prep_cons = []
+    con_type = None
     for con_def in con_defs:
         con_info = _connectionDict2ConnectionInfo(dom_type, con_def)
         prep_con = ConnectionFactory.createConnection(con_info)
         prep_cons.append(prep_con)
-    con_class = ConnectionFactory.registeredConnectionTypes[con_info.type]
+        con_type = con_info.type
+    con_class = ConnectionFactory.registeredConnectionTypes[con_type]
     return con_class, prep_cons
 
 

--- a/tests/storage/hsm_connect_test.py
+++ b/tests/storage/hsm_connect_test.py
@@ -187,13 +187,11 @@ def test_cache_update(fake_hsm):
     assert hsm.sdCache.knownSDs['sd-uuid-1'] == nfs_find_method
 
 
-@pytest.mark.xfail(reason="BZ #2054745, not checking empty connections yet")
 def test_empty_conn_list_on_connect(fake_hsm):
     with pytest.raises(se.InvalidParameterException):
         fake_hsm.connectStorageServer(sd.ISCSI_DOMAIN, "fake-sp-uuid", [])
 
 
-@pytest.mark.xfail(reason="BZ #2054745, not ready to accept empty connection")
 def test_empty_conn_list_on_disconnect(fake_hsm):
     # If iSCSI target is used by multiple SDs, engine sends empty connection
     # list and vdsm has to handle empty list on disconnect.


### PR DESCRIPTION
Don't fail when engine sends empty connection list on storage server disconnect. This happens when multiple iSCSI SDs use same iSCSI target and therefore it cannot be disconnected as it's still used by other SDs. Engine should be fixed not to send disconnect request in such case, but we need to handle older engines. Log warning in such case, do nothing and return empty list as calling code expects iterable with results..
On the other hand engine always sends non-empty connection list when connecting SD. If the list is empty for some reason when connecting storage server, also log warning, but let vdsm throw `KeyError` as this is unexpected.

Fixes https://bugzilla.redhat.com/2054745