### PR TITLE
net: Fix tc tokens parsing

### DIFF
--- a/lib/vdsm/network/tc/filter.py
+++ b/lib/vdsm/network/tc/filter.py
@@ -116,7 +116,7 @@ def _parse_u32(tokens):
         elif token == 'terminal':
             data['terminal'] = _parser.parse_true(tokens)
             _parser.consume(tokens, 'flowid')
-            _parser.consume(tokens, '???')
+            _parser.consume(tokens, '???', 'not_in_hw')
         elif token == 'ht':
             _parser.consume(tokens, 'divisor')
             data['ht_divisor'] = _parser.parse_int(tokens)

--- a/tests/network/unit/tc_filter_show.out
+++ b/tests/network/unit/tc_filter_show.out
@@ -17,14 +17,14 @@ filter protocol all pref 49149 u32 fh 803::800 order 2048 key ht 803 bkt 0 termi
 
 filter protocol all pref 49150 u32
 filter protocol all pref 49150 u32 fh 802: ht divisor 1
-filter protocol all pref 49150 u32 fh 802::800 order 2048 key ht 802 bkt 0 terminal flowid ???
+filter protocol all pref 49150 u32 fh 802::800 order 2048 key ht 802 bkt 0 terminal flowid ??? not_in_hw
   match 00000000/00000000 at 0
 	action order 33: mirred (Egress Mirror to device tap2) pipe
  	index 17 ref 1 bind 1
 
 filter protocol all pref 49152 u32
 filter protocol all pref 49152 u32 fh 800: ht divisor 1
-filter protocol all pref 49152 u32 fh 800::800 order 2048 key ht 800 bkt 0 terminal flowid ???
+filter protocol all pref 49152 u32 fh 800::800 order 2048 key ht 800 bkt 0 terminal flowid not_in_hw
   match 00000000/00000000 at 0
 	action order 1: mirred (Egress Mirror to device target) pipe
  	index 60 ref 1 bind 1


### PR DESCRIPTION
Newer version of iproute-tc (>=5.15.0-3) omits the
"???" from the filter output. Include also "not_in_hw"
for potential consume, this will ensure that both formats
are accepted e.g. ".. terminal flowid ??? not_in_hw .."
and ".. terminal flowid not_in_hw ..". One important thing
to note, it is safe to consume "not_in_hw" because the value
is skipped otherwise by the parser.

Signed-off-by: Ales Musil <amusil@redhat.com>