### PR TITLE
Improve extend timing

### DIFF
--- a/lib/vdsm/common/time.py
+++ b/lib/vdsm/common/time.py
@@ -78,10 +78,12 @@ class Clock(object):
     def __init__(self):
         self._timers = collections.OrderedDict()
 
-    def start(self, name):
+    def start(self, name, start_time=None):
         if name in self._timers:
             raise RuntimeError("Timer %r already started" % name)
-        self._timers[name] = (monotonic_time(), None)
+        if start_time is None:
+            start_time = monotonic_time()
+        self._timers[name] = (start_time, None)
 
     def stop(self, name):
         if name not in self._timers:

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -462,7 +462,16 @@ class VolumeMonitor(object):
         # Note that the volume is extended after the replica is extended, so
         # the total extend time includes the time to extend the replica.
         clock = time.Clock()
-        clock.start("total")
+
+        # If we received a block threshold event for this drive, include
+        # the time since we received the event in the total time.
+        # Otherwise measure only the time to extend the volume.
+        if vmDrive.exceeded_time:
+            clock.start("total", start_time=vmDrive.exceeded_time)
+            clock.start("wait", start_time=vmDrive.exceeded_time)
+            clock.stop("wait")
+        else:
+            clock.start("total")
 
         if vmDrive.replicaChunked:
             self._extend_replica(

--- a/tests/common/time_test.py
+++ b/tests/common/time_test.py
@@ -81,6 +81,30 @@ class TestClock:
                 fake_time.time += 4
         assert str(c) == "<Clock(outer=7.00, inner=4.00)>"
 
+    def test_start_with_start_time(self, fake_time):
+        # We received an event.
+        event_time = fake_time.time
+
+        # The event was handled after 5 seconds...
+        fake_time.time += 5
+        c = time.Clock()
+
+        # The total time includes the wait time..
+        c.start("total", start_time=event_time)
+
+        # Measure the time we waited since the event was received.
+        c.start("wait", start_time=event_time)
+        c.stop("wait")
+
+        # Measure processing time.
+        c.start("process")
+        fake_time.time += 2
+        c.stop("process")
+
+        c.stop("total")
+
+        assert str(c) == "<Clock(total=7.00, wait=5.00, process=2.00)>"
+
     # Inccorrect usage
 
     def test_start_started_clock(self):


### PR DESCRIPTION
Include the time since the the block threshold event was received until
we handled it in the extend timing log.

Based on the timing info we can tune the volume extension parameters to
minimize vm pauses, both in vdsm defaults and in the fields in the defaults
need to be changed for a particular environment.

To improve the timing info, vdsm.comon.time.Clock was modified to allow
timing since a time in the past.

Bug-Url: https://bugzilla.redhat.com/2051997