### PR TITLE
config: Increase thin provisioning threshold

### DIFF
--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -315,12 +315,14 @@ parameters = [
 
         ('irsd', '%(images)s/irsd', None),
 
-        ('volume_utilization_percent', '50',
+        ('volume_utilization_percent', '20',
             'Together with volume_utilization_chunk_mb, set the minimal free '
             'space before a thin provisioned block volume is extended. Use '
-            'lower values to extend earlier.'),
+            'lower values to extend earlier. With the default value (20) the'
+            'system will extend the volume when free space is 80% of '
+            'volume_utilization_chunk_mb (2 GiB).'),
 
-        ('volume_utilization_chunk_mb', '1024',
+        ('volume_utilization_chunk_mb', '2560',
             'Size of extension chunk in megabytes, and together with '
             'volume_utilization_percent, set the free space limit. Use higher '
             'values to extend in bigger chunks.'),

--- a/tests/storage/merge_test.py
+++ b/tests/storage/merge_test.py
@@ -41,6 +41,7 @@ from storage.storagetestlib import (
 
 from . import qemuio
 
+from testlib import make_config
 from testlib import make_uuid
 
 from vdsm.common import cmdutils
@@ -56,6 +57,10 @@ from vdsm.storage import qemuimg
 from vdsm.storage import resourceManager as rm
 from vdsm.storage import volume
 
+CONFIG = make_config([
+    ('irs', 'volume_utilization_chunk_mb', '1024'),
+    ('irs', 'volume_utilizzation_precent', '50'),
+])
 
 Volume = namedtuple("Volume", "format,virtual,physical")
 Expected = namedtuple("Expected", "virtual,physical")
@@ -73,32 +78,35 @@ def make_env(env_type, base, top):
         prealloc = sc.SPARSE_VOL
 
     with fake_env(env_type) as env:
-        env.make_volume(base.virtual * GiB, img_id, base_id,
-                        vol_format=sc.name2type(base.format),
-                        prealloc=prealloc)
-        env.make_volume(top.virtual * GiB, img_id, top_id,
-                        parent_vol_id=base_id,
-                        vol_format=sc.COW_FORMAT)
-        env.subchain = merge.SubchainInfo(
-            dict(sd_id=env.sd_manifest.sdUUID, img_id=img_id,
-                 base_id=base_id, top_id=top_id), 0)
-
-        if env_type == 'block':
-            # Simulate allocation by adjusting the LV sizes
-            env.lvm.extendLV(env.sd_manifest.sdUUID, base_id,
-                             base.physical * GiB // MiB)
-            env.lvm.extendLV(env.sd_manifest.sdUUID, top_id,
-                             top.physical * GiB // MiB)
-
         with MonkeyPatch().context() as mp:
             mp.setattr(guarded, 'context', fake_guarded_context())
+            mp.setattr(merge, "config", CONFIG)
             mp.setattr(merge, 'sdCache', env.sdcache)
+            mp.setattr(blockVolume, "config", CONFIG)
             mp.setattr(blockVolume, 'rm', FakeResourceManager())
             mp.setattr(blockVolume, 'sdCache', env.sdcache)
             mp.setattr(
                 image.Image, 'getChain',
                 lambda self, sdUUID, imgUUID:
                     [env.subchain.base_vol, env.subchain.top_vol])
+
+            env.make_volume(base.virtual * GiB, img_id, base_id,
+                            vol_format=sc.name2type(base.format),
+                            prealloc=prealloc)
+            env.make_volume(top.virtual * GiB, img_id, top_id,
+                            parent_vol_id=base_id,
+                            vol_format=sc.COW_FORMAT)
+            env.subchain = merge.SubchainInfo(
+                dict(sd_id=env.sd_manifest.sdUUID, img_id=img_id,
+                     base_id=base_id, top_id=top_id), 0)
+
+            if env_type == 'block':
+                # Simulate allocation by adjusting the LV sizes
+                env.lvm.extendLV(env.sd_manifest.sdUUID, base_id,
+                                 base.physical * GiB // MiB)
+                env.lvm.extendLV(env.sd_manifest.sdUUID, top_id,
+                                 top.physical * GiB // MiB)
+
             yield env
 
 

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -23,6 +23,7 @@ import logging
 
 from vdsm.virt import thinp
 
+from vdsm.common.config import config
 from vdsm.common.units import MiB, GiB
 from vdsm.virt.vmdevices.storage import Drive, BLOCK_THRESHOLD
 
@@ -57,7 +58,9 @@ def test_set_threshold():
     vm.drives.append(vda)
 
     apparentsize = 4 * GiB
-    threshold = 512 * MiB
+    chunk_size = config.getint("irs", "volume_utilization_chunk_mb") * MiB
+    free = (100 - config.getint("irs", "volume_utilization_percent")) / 100
+    threshold = chunk_size * free
 
     # TODO: Use public API.
     mon._set_threshold(vda, apparentsize, 1)


### PR DESCRIPTION
Collecting extend stats shows that extend takes between 2.2 to 6.2
seconds, with average of 3.7 seconds. With the default thresholds:

[irs]
volume_utilization_chunk_mb = 1024
volume_utilization_percent = 50

This means that we extend the volume when free space is 512 MiB. Writing
more than 512 MiB in 3.7 seconds (138.4 MiB/s) will cause the VM to
pause with ENOSPC.

This configuration was too low 10 years ago, and we need to update it
for modern storage. Update the values to allow 4 times faster writes
before we pause with ENOSPC.

With the new configuration:

[irs]
volume_utilization_chunk_mb = 2560
volume_utilization_percent = 20

We extend the volume when free space is 2048 MiB.

Testing with old and new configuration show that we can cope now with 4x
times faster write rate before we VMs pause during extend.

Before:

write rate  extends   pauses
----------------------------
 75 MiB/s        50        0
100 MiB/s        50        4
125 MiB/s        50        4
150 MiB/s        53       24

After:

write rate  extends   pauses
----------------------------
200 MiB/s        20        0
250 MiB/s        20        0
300 MiB/s        20        0
350 MiB/s        21        0
400 MiB/s        20        1
450 MiB/s        20        2
500 MiB/s        22        7
550 MiB/s        23        7

The downside of this change is allocating more space in the storage
domain. New empty disk will consume 2.5 GiB instead of 1 GiB.

Bug-Url: https://bugzilla.redhat.com/2051997
Signed-off-by: Nir Soffer <nsoffer@redhat.com>