### PR TITLE
network: Run network tests every week after new containers are built

### DIFF
--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -14,6 +14,9 @@ on:
       - 'lib/vdsm/common/**'
       - 'tests/network/**'
       - '.github/workflows/network.yml'
+  # Build every week on Sunday 02:00 to pick up new container
+  schedule:
+    - cron:  '0 2 * * 0'
 
 jobs:
   tests:


### PR DESCRIPTION
By running tests after the container is built we can find any possible
regression caused by newer packages in the container.

Signed-off-by: Ales Musil <amusil@redhat.com>