### PR TITLE
managedvolume: create link for MBS devices

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -1820,8 +1820,8 @@ class ManagedVolume(APIBase):
 
     @api.logged(on="api.storage")
     @api.method
-    def detach_volume(self, vol_id):
-        return managedvolume.detach_volume(vol_id)
+    def detach_volume(self, vol_id, sd_id):
+        return managedvolume.detach_volume(sd_id, vol_id)
 
     @api.logged(on="api.storage")
     @api.method

--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -1809,11 +1809,14 @@ class ManagedVolume(APIBase):
 
     @api.logged(on="api.storage")
     @api.method
-    def attach_volume(self, vol_id, connection_info):
+    def attach_volume(self, vol_id, connection_info, sd_id):
         """
         attach volume and return attached device information
         """
-        return managedvolume.attach_volume(vol_id, connection_info)
+        return managedvolume.attach_volume(
+            sd_id,
+            vol_id,
+            connection_info)
 
     @api.logged(on="api.storage")
     @api.method

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -9752,6 +9752,11 @@ ManagedVolume.attach_volume:
     -   description: The information needed to attach a volume
         name: connection_info
         type: *ManagedVolumeConnection
+    -   defaultvalue: '00000000-0000-0000-0000-000000000000'
+        added: '4.5.1'
+        description: The storage domain ID
+        name: sd_id
+        type: *UUID
     return:
         description: Information about the attached volume.
         type: *ManagedVolumeInformation

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -1187,9 +1187,18 @@ types:
             name: connection_info
             type: *ManagedVolumeConnection
         -   defaultvalue: null
-            description: The volume path to be used in the VM XML
+            description: A stable volume path constructed by vdsm, used by
+                by engine to run VMs. Superseded by managed_path.
             name: path
             type: string
+            deprecated: '4.5'
+        -   defaultvalue: null
+            description: The volume path to be used for running VMs,
+                         a vdsm controlled link to the path mapped by
+                         os-brick.
+            name: managed_path
+            type: string
+            added: '4.5.1'
         -   defaultvalue: null
             description: The attached volume information
             name: attachment

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -9769,6 +9769,11 @@ ManagedVolume.detach_volume:
     -   description: The volume ID
         name: vol_id
         type: *UUID
+    -   defaultvalue: '00000000-0000-0000-0000-000000000000'
+        added: '4.5.1'
+        description: The storage domain ID
+        name: sd_id
+        type: *UUID
 
 ManagedVolume.volumes_info:
     added: '4.3'

--- a/lib/vdsm/clientIF.py
+++ b/lib/vdsm/clientIF.py
@@ -419,9 +419,14 @@ class clientIF(object):
         """
         if type(drive) is dict:
             device = drive['device']
+
+            # Managed drives are prepared in ManagedVolume.attach_volume
+            if drive.get("managed", False):
+                volPath = drive['path']
+
             # PDIV drive format
             # Since version 4.2 cdrom may use a PDIV format
-            if device in ("cdrom", "disk") and isVdsmImage(drive):
+            elif device in ("cdrom", "disk") and isVdsmImage(drive):
                 res = self.irs.prepareImage(
                     drive['domainID'], drive['poolID'],
                     drive['imageID'], drive['volumeID'])

--- a/lib/vdsm/common/udevadm.py
+++ b/lib/vdsm/common/udevadm.py
@@ -53,7 +53,12 @@ def settle(timeout, exit_if_exists=None):
         logging.error("%s", e)
 
 
-def trigger(attr_matches=(), property_matches=(), subsystem_matches=()):
+def trigger(
+    attr_matches=(),
+    property_matches=(),
+    subsystem_matches=(),
+    path=None,
+):
     '''
     Request device events from the kernel.
 
@@ -83,6 +88,10 @@ def trigger(attr_matches=(), property_matches=(), subsystem_matches=()):
 
                         Causes only events related to specified subsystem to
                         be triggered.
+
+    path                Path to trigger events for. For example:
+                        /dev/mapper/20024f4005854000a
+
     '''
     _run_command(['control', '--reload'])
 
@@ -96,6 +105,9 @@ def trigger(attr_matches=(), property_matches=(), subsystem_matches=()):
 
     for name in subsystem_matches:
         cmd.append('--subsystem-match={}'.format(name))
+
+    if path:
+        cmd.append(path)
 
     _run_command(cmd)
 

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -127,7 +127,7 @@ def attach_volume(sd_id, vol_id, connection_info):
 
 
 @requires_os_brick
-def detach_volume(vol_id):
+def detach_volume(sd_id, vol_id):
     """
     Detach volume with os-brick.
     """

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -85,7 +85,7 @@ def connector_info():
 
 
 @requires_os_brick
-def attach_volume(vol_id, connection_info):
+def attach_volume(sd_id, vol_id, connection_info):
     """
     Attach volume with os-brick.
     """

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -114,7 +114,7 @@ def attach_volume(sd_id, vol_id, connection_info):
                         "rbd, iscsi")
 
                 run_link = _add_run_link(sd_id, vol_id, path)
-                _add_udev_rule(vol_id, path)
+                _add_udev_rule(sd_id, vol_id, path)
             except:
                 _silent_detach(connection_info, attachment)
                 raise
@@ -144,7 +144,7 @@ def detach_volume(sd_id, vol_id):
         if "path" in vol_info and os.path.exists(vol_info["path"]):
             run_helper("detach", vol_info)
 
-        _remove_udev_rule(vol_info['vol_id'])
+        _remove_udev_rule(sd_id, vol_info['vol_id'])
         _remove_run_link(sd_id, vol_id)
         db.remove_volume(vol_id)
 
@@ -270,7 +270,7 @@ def _silent_remove(db, sd_id, vol_id):
     except Exception:
         log.exception("Failed to remove managed volume %s from DB", vol_id)
 
-    _remove_udev_rule(vol_id)
+    _remove_udev_rule(sd_id, vol_id)
     _remove_run_link(sd_id, vol_id)
 
 
@@ -286,20 +286,20 @@ def _silent_detach(connection_info, attachment):
         log.exception("Failed to detach managed volume %s", vol_info)
 
 
-def _add_udev_rule(vol_id, path):
+def _add_udev_rule(sd_id, vol_id, path):
     proxy = supervdsm.getProxy()
-    proxy.add_managed_udev_rule(vol_id, path)
+    proxy.add_managed_udev_rule(sd_id, vol_id, path)
     try:
         proxy.trigger_managed_udev_rule(path)
     except:
-        _remove_udev_rule(vol_id)
+        _remove_udev_rule(sd_id, vol_id)
         raise
 
 
-def _remove_udev_rule(vol_id):
+def _remove_udev_rule(sd_id, vol_id):
     try:
         proxy = supervdsm.getProxy()
-        proxy.remove_managed_udev_rule(vol_id)
+        proxy.remove_managed_udev_rule(sd_id, vol_id)
     except Exception:
         log.exception(
             "Failed to remove udev rule for volume %s", vol_id)

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -161,7 +161,7 @@ def test_attach_volume_not_installed_attach(monkeypatch):
     # Simulate missing os_brick.
     monkeypatch.setattr(managedvolume, "os_brick", None)
     with pytest.raises(se.ManagedVolumeNotSupported):
-        managedvolume.attach_volume("vol_id", {})
+        managedvolume.attach_volume("sd_id", "vol_id", {})
 
 
 @requires_root
@@ -172,7 +172,10 @@ def test_attach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
         "driver_volume_type": "iscsi",
         "data": {"some_info": 26}
     }
-    ret = managedvolume.attach_volume("fake_vol_id", connection_info)
+    ret = managedvolume.attach_volume(
+        "fake_sd_id",
+        "fake_vol_id",
+        connection_info)
     path = "/dev/mapper/fakemultipathid"
 
     assert ret["result"]["path"] == path
@@ -211,7 +214,10 @@ def test_attach_volume_ok_rbd(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
         "data": {
             "name": "volumes/volume-fake"
         }}
-    ret = managedvolume.attach_volume("fake_vol_id", connection_info)
+    ret = managedvolume.attach_volume(
+        "fake_sd_id",
+        "fake_vol_id",
+        connection_info)
     path = "/dev/rbd/volumes/volume-fake"
 
     assert ret["result"]["path"] == path
@@ -243,9 +249,13 @@ def test_attach_volume_no_multipath_id(monkeypatch, fake_os_brick, tmp_db,
     # Simulate attaching iSCSI or FC device without multipath_id.
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "NO_WWN")
     with pytest.raises(se.ManagedVolumeUnsupportedDevice):
-        managedvolume.attach_volume("vol_id", {
-            "driver_volume_type": vol_type,
-            "data": {"some_info": 26}})
+        managedvolume.attach_volume(
+            "sd_id",
+            "vol_id",
+            {
+                "driver_volume_type": vol_type,
+                "data": {"some_info": 26}
+            })
 
     # Verify that we deatch the unsupported device.
     entries = fake_os_brick.log()
@@ -271,13 +281,16 @@ def test_reattach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmpdir, tmp_db,
         "driver_volume_type": "iscsi",
         "data": {"some_info": 26}
     }
-    managedvolume.attach_volume("fake_vol_id", connection_info)
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
 
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False
 
     with pytest.raises(se.ManagedVolumeAlreadyAttached):
-        managedvolume.attach_volume("fake_vol_id", connection_info)
+        managedvolume.attach_volume(
+            "fake_sd_id",
+            "fake_vol_id",
+            connection_info)
 
     # Device still owned by managed volume.
     assert tmp_db.owns_multipath("fakemultipathid")
@@ -307,7 +320,10 @@ def test_attach_volume_fail_update(monkeypatch, fake_os_brick, tmpdir, tmp_db,
     monkeypatch.setattr(managedvolumedb.DB, "update_volume", raise_error)
 
     with pytest.raises(RuntimeError):
-        managedvolume.attach_volume("fake_vol_id", connection_info)
+        managedvolume.attach_volume(
+            "fake_sd_id",
+            "fake_vol_id",
+            connection_info)
 
     entries = fake_os_brick.log()
     assert len(entries) == 2
@@ -326,7 +342,7 @@ def test_reattach_volume_other_connection(monkeypatch, fake_os_brick, tmp_db,
         "driver_volume_type": "iscsi",
         "data": {"some_info": 26}
     }
-    managedvolume.attach_volume("fake_vol_id", connection_info)
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
 
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False
@@ -337,7 +353,10 @@ def test_reattach_volume_other_connection(monkeypatch, fake_os_brick, tmp_db,
     }
 
     with pytest.raises(se.ManagedVolumeConnectionMismatch):
-        managedvolume.attach_volume("fake_vol_id", other_connection_info)
+        managedvolume.attach_volume(
+            "fake_sd_id",
+            "fake_vol_id",
+            other_connection_info)
 
     entries = fake_os_brick.log()
     assert len(entries) == 1
@@ -355,7 +374,7 @@ def test_detach_volume_iscsi_not_attached(monkeypatch, fake_os_brick, tmp_db,
         "driver_volume_type": "iscsi",
         "data": {"some_info": 26}
     }
-    managedvolume.attach_volume("fake_vol_id", connection_info)
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
 
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False
@@ -414,7 +433,7 @@ def test_detach_volume_iscsi_attached(monkeypatch, fake_os_brick, tmpdir,
         "driver_volume_type": "iscsi",
         "data": {"some_info": 26}
     }
-    managedvolume.attach_volume("fake_vol_id", connection_info)
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
 
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -97,7 +97,7 @@ def fake_supervdsm(monkeypatch):
         def getProxy(self):
             return self
 
-        def add_managed_udev_rule(self, vol_id, path):
+        def add_managed_udev_rule(self, sd_id, vol_id, path):
             self.udev_rules[vol_id] = {
                 "path": path,
                 "triggered": False,
@@ -112,7 +112,7 @@ def fake_supervdsm(monkeypatch):
             raise OSError(
                 errno.EINVAL, 'Could not trigger change for rule %r', rule)
 
-        def remove_managed_udev_rule(self, vol_id):
+        def remove_managed_udev_rule(self, sd_id, vol_id):
             self.udev_rules.pop(vol_id, None)
 
     fsupervdsm = fake_supervdsm()

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -379,7 +379,7 @@ def test_detach_volume_iscsi_not_attached(monkeypatch, fake_os_brick, tmp_db,
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False
 
-    managedvolume.detach_volume("fake_vol_id")
+    managedvolume.detach_volume("fake_sd_id", "fake_vol_id")
 
     with pytest.raises(managedvolumedb.NotFound):
         tmp_db.get_volume("fake_vol_id")
@@ -402,7 +402,7 @@ def test_detach_volume_not_installed(monkeypatch, fake_os_brick, tmp_db,
     fake_lvm.devices_invalidated = False
 
     with pytest.raises(se.ManagedVolumeNotSupported):
-        managedvolume.detach_volume("vol_id")
+        managedvolume.detach_volume("sd_id", "vol_id")
 
     # No multipath id added, no need to invalidated filter.
     assert not fake_lvm.devices_invalidated
@@ -411,7 +411,7 @@ def test_detach_volume_not_installed(monkeypatch, fake_os_brick, tmp_db,
 @requires_root
 def test_detach_not_in_db(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
                           fake_supervdsm):
-    managedvolume.detach_volume("fake_vol_id")
+    managedvolume.detach_volume("sd_id", "fake_vol_id")
 
     # Attaching invalidates the filter, reset.
     fake_lvm.devices_invalidated = False
@@ -439,7 +439,7 @@ def test_detach_volume_iscsi_attached(monkeypatch, fake_os_brick, tmpdir,
     fake_lvm.devices_invalidated = False
 
     tmpdir.join("fakemultipathid").write("")
-    managedvolume.detach_volume("fake_vol_id")
+    managedvolume.detach_volume("fake_sd_id", "fake_vol_id")
 
     entries = fake_os_brick.log()
     assert len(entries) == 2

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -51,7 +51,8 @@ def fake_os_brick(monkeypatch, tmpdir):
     log_path = tmpdir.join("os_brick.log")
     log_path.write("")
     monkeypatch.setenv("FAKE_OS_BRICK_LOG", str(log_path))
-
+    monkeypatch.setattr(
+        managedvolume, 'VOLUME_LINK_DIR', tmpdir.join("volumes"))
     monkeypatch.setattr(
         managedvolume, 'HELPER', "../lib/vdsm/storage/managedvolume-helper")
     os_brick_dir = os.path.abspath("storage/fake_os_brick")


### PR DESCRIPTION
The current code for attaching MBS devices tries to construct stable
path. This works for RBD and mpath devices, however doesn't scale for
drivers that do not fall in this category, for instance, NVMe/TCP
drivers.

This patch create a link for the path returned by os-brick, this link
will be managed by vdsm and will be used by engine as the path to run
VMs.

Link example:
```shell
ll /var/run/vdsm/managedvolumes/fa728e08-2db4-4016-bfbb-bd75f2ee1735_876fa465-d92b-4070-833d-c5ec4331ceb5
lrwxrwxrwx. 1 vdsm kvm 60 May  3 10:21 /var/run/vdsm/managedvolumes/fa728e08-2db4-4016-bfbb-bd75f2ee1735_876fa465-d92b-4070-833d-c5ec4331ceb5 -> /dev/rbd/volumes/volume-876fa465-d92b-4070-833d-c5ec4331ceb5
```

Snippet for VM XML:
```xml
<disk type='block' device='disk' snapshot='no'>
      <driver name='qemu' type='raw' cache='none'/>
      <source dev='/run/vdsm/managedvolumes/fa728e08-2db4-4016-bfbb-bd75f2ee1735_876fa465-d92b-4070-833d-c5ec4331ceb5' index='1'>
        <seclabel model='dac' relabel='no'/>
      </source>
      <backingStore/>
      <target dev='sda' bus='scsi'/>
      <serial>876fa465-d92b-4070-833d-c5ec4331ceb5</serial>
      <boot order='1'/>
      <alias name='ua-876fa465-d92b-4070-833d-c5ec4331ceb5'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
</disk>
```

Rule content
```shell
$ cat /etc/udev/rules.d/99-vdsm-managed_fa728e08-2db4-4016-bfbb-bd75f2ee1735_d1530bb1-8b92-40e8-9d5b-1adbcbc4eedc.rules
SYMLINK=="rbd/volumes/volume-d1530bb1-8b92-40e8-9d5b-1adbcbc4eedc", RUN+="/usr/bin/chown vdsm:qemu $env{DEVNAME}"
```

```shell
$ cat /etc/udev/rules.d/99-vdsm-managed_fc3b802e-cbc5-4896-995d-87f4b25a1a68_0d850fc9-9dfe-44ee-a4f6-a209d1f4bf7b.rules
SYMLINK=="mapper/20024f4005854000a", RUN+="/usr/bin/chown vdsm:qemu $env{DEVNAME}"
```