### PR TITLE
Add a blacklist for rbd devices

### DIFF
--- a/lib/vdsm/tool/configurators/multipath.py
+++ b/lib/vdsm/tool/configurators/multipath.py
@@ -37,9 +37,10 @@ _CONF_FILE = "/etc/multipath.conf"
 # "VDSM REVISION X.Y" tag.  Note that older version used "RHEV REVISION X.Y"
 # format.
 
-_CURRENT_TAG = "# VDSM REVISION 2.0"
+_CURRENT_TAG = "# VDSM REVISION 2.1"
 
 _OLD_TAGS = (
+    "# VDSM REVISION 2.0",
     "# VDSM REVISION 1.9",
     "# VDSM REVISION 1.8",
     "# VDSM REVISION 1.7",
@@ -192,8 +193,8 @@ defaults {
     max_fds                     4096
 }
 
-# Blacklist local and obsolete protocols which run on devices which are not
-# multipathable.
+Blacklist local devices, obsolete protocols, and device nodes which
+should not be used with multipath.
 #
 # Complete list of protocols recognized by multipath:
 # scsi:fcp        Fibre Channel
@@ -253,9 +254,14 @@ defaults {
 #   blacklist_exceptions {
 #       protocol "(scsi:spi|scsi:ssa)"
 #   }
+#
+# We blacklist all RADOS Block Device (RBD) devices.
+# When using Ceph, multipath prevents the rbd devices from being unmapped
+# and the devices remain busy.
 
 blacklist {
     protocol "(scsi:adt|scsi:sbp)"
+    devnode "^(rbd)[0-9]*"
 }
 
 # Options defined here override device specific options embedded into


### PR DESCRIPTION
When using Ceph, multipath might prevent the rbd device from being
unmapped and it stays mapped.
It results with getting the following error while operating the disk:
rbd.ImageBusy: [errno 16] RBD image is busy
This patch adds rbd to the multipath blacklist.

Bug-Url: https://bugzilla.redhat.com/1881832
Bug-Url: https://bugzilla.redhat.com/1755801
Signed-off-by: Shani Leviim [sleviim@redhat.com](mailto:sleviim@redhat.com)