### PR TITLE
virt: Add support for vGPU driver parameters

### DIFF
--- a/lib/vdsm/supervdsm_api/virt.py
+++ b/lib/vdsm/supervdsm_api/virt.py
@@ -132,12 +132,11 @@ def mdev_create(device, mdev_properties, mdev_uuid=None):
 
 @expose
 def mdev_delete(device, mdev_uuid):
-    """
+    """Remove the given mediated device.
 
     Args:
         device: PCI address of the parent device in the format
             (domain:bus:slot.function). Example:  0000:06:00.0.
-        mdev_type: Type to be spawned. Example: nvidia-11.
         mdev_uuid: UUID for the spawned device. Keeping None generates a new
             UUID.
 

--- a/tests/hostdev_test.py
+++ b/tests/hostdev_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Red Hat, Inc.
+# Copyright 2014-2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -252,8 +252,10 @@ class TestMdev(TestCaseBase):
                 (hostdev, '_each_mdev_device', lambda: self.devices)
         ]):
             for mdev_type, mdev_uuid in mdev_specs:
-                hostdev.spawn_mdev(mdev_type, mdev_uuid, mdev_placement,
-                                   self.log)
+                mdev_properties = hostdev.MdevProperties(
+                    mdev_type, mdev_placement, None
+                )
+                hostdev.spawn_mdev(mdev_properties, mdev_uuid, self.log)
         for inst, dev in zip(instances, self.devices):
             dev_inst = []
             for mdev_type in dev.mdev_types:
@@ -268,7 +270,10 @@ class TestMdev(TestCaseBase):
         with MonkeyPatchScope([
                 (hostdev, '_each_mdev_device', lambda: self.devices)
         ]):
+            mdev_properties = hostdev.MdevProperties(
+                'unsupported', placement, None
+            )
             self.assertRaises(
                 exception.ResourceUnavailable,
-                hostdev.spawn_mdev, 'unsupported', '1234', placement, self.log
+                hostdev.spawn_mdev, mdev_properties, '1234', self.log
             )

--- a/tests/hostdevlib.py
+++ b/tests/hostdevlib.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Red Hat, Inc.
+# Copyright 2014-2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -515,8 +515,8 @@ class FakeSuperVdsm:
     def getProxy(self):
         return self
 
-    def mdev_create(self, device, mdev_type, mdev_uuid):
+    def mdev_create(self, device, mdev_properties, mdev_uuid):
         for device_type in device.mdev_types:
-            if device_type.name == mdev_type:
+            if device_type.name == mdev_properties.device_type:
                 break
         device_type.mdev_create(mdev_uuid)


### PR DESCRIPTION
Engine is going to add a new metadata item for vGPU devices,
mdevDriverParameters.  It specifies driver parameters to be set when
the mediated device is created, by writing a file in /sys.

The driver consumes the last character written to the file in /sys, so
it is important to write a new line character at the end, as `echo'
from a shell command line would do.

Since mediated devices are created before each use and destroyed after
each use, it's enough to write the driver parameters, if specified,
only when the device is created.  It's not necessary to clear them
when the device is removed, although it is possible to do it by
writing a space to the driver parameters file in /sys.

Currently, only NVidia driver parameters are supported.  If setting
driver parameters is attempted for other cards or if setting the
driver parameters fails for another reason, creation of the mediated
device will fail and the VM won't be started.

Bug-Url: https://bugzilla.redhat.com/1987121