### PR TITLE
NBD bitmap validation with single volume

### DIFF
--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -192,7 +192,9 @@ def _create_overlay(server_id, backing, bitmap):
     """
     filenames = _find_bitmap(backing, bitmap)
     if not filenames:
-        raise se.BitmapDoesNotExist(bitmap=bitmap)
+        raise se.BitmapDoesNotExist(
+            reason=f"Bitmap does not exist in {backing}",
+            bitmap=bitmap)
 
     overlay = transientdisk.create_disk(
         server_id,

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -134,7 +134,9 @@ def start_server(server_id, config):
 
     _create_rundir()
 
-    using_overlay = cfg.bitmap and vol.getParent() != sc.BLANK_UUID
+    # If the bitmap exists in the volume backing chain, we need to
+    # create an overlay exporting the bitmap from the entire chain.
+    using_overlay = cfg.bitmap and len(bitmap_chain) > 1
 
     if using_overlay:
         path = _create_overlay(

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -119,15 +119,26 @@ def start_server(server_id, config):
     if vol.isShared() and not cfg.readonly:
         raise se.SharedVolumeNonWritable(vol)
 
-    if cfg.bitmap and vol.getFormat() != sc.COW_FORMAT:
-        raise se.UnsupportedOperation("Cannot export bitmap from RAW volume")
+    if cfg.bitmap:
+        if vol.getFormat() != sc.COW_FORMAT:
+            raise se.UnsupportedOperation(
+                "Cannot export bitmap from RAW volume")
+
+        # The bitmap must exist in the volume, and may exist in the
+        # backing chain.
+        bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
+        if not bitmap_chain:
+            raise se.BitmapDoesNotExist(
+                reason=f"Bitmap does not exist in {vol.volumePath}",
+                bitmap=cfg.bitmap)
 
     _create_rundir()
 
     using_overlay = cfg.bitmap and vol.getParent() != sc.BLANK_UUID
 
     if using_overlay:
-        path = _create_overlay(server_id, vol.volumePath, cfg.bitmap)
+        path = _create_overlay(
+            server_id, vol.volumePath, cfg.bitmap, bitmap_chain)
         format = "qcow2"
         is_block = False
     else:
@@ -185,17 +196,11 @@ def stop_server(server_id):
     systemctl.stop(service)
 
 
-def _create_overlay(server_id, backing, bitmap):
+def _create_overlay(server_id, backing, bitmap, bitmap_chain):
     """
     To export bitmaps from entire chain, we need to create an overlay, and
     merge all bitmaps from the chain into the overlay.
     """
-    filenames = _find_bitmap(backing, bitmap)
-    if not filenames:
-        raise se.BitmapDoesNotExist(
-            reason=f"Bitmap does not exist in {backing}",
-            bitmap=bitmap)
-
     overlay = transientdisk.create_disk(
         server_id,
         OVERLAY,
@@ -204,7 +209,7 @@ def _create_overlay(server_id, backing, bitmap):
     try:
         # Merge bitmap from filenames into overlay.
         qemuimg.bitmap_add(overlay, bitmap).run()
-        for src_img in filenames:
+        for src_img in bitmap_chain:
             qemuimg.bitmap_merge(
                 src_img, bitmap, "qcow2", overlay, bitmap).run()
     except:

--- a/tests/storage/nbd_test.py
+++ b/tests/storage/nbd_test.py
@@ -631,7 +631,6 @@ def test_bitmap_backing_chain(nbd_env):
             assert c.read(2 * MiB, 64 * KiB) == b"\xf2" * 64 * KiB
 
 
-@pytest.mark.xfail(reason="missing validation")
 @broken_on_ci
 @requires_privileges
 def test_bitmap_in_use_single_volume(nbd_env):
@@ -686,7 +685,6 @@ def test_bitmap_in_use_backing_chain(nbd_env):
             pass
 
 
-@pytest.mark.xfail(reason="missing validation")
 @broken_on_ci
 @requires_privileges
 def test_bitmap_disabled_single_volume(nbd_env):
@@ -737,7 +735,6 @@ def test_bitmap_disabled_backing_chain(nbd_env):
             pass
 
 
-@pytest.mark.xfail(reason="missing validation")
 @broken_on_ci
 @requires_privileges
 def test_bitmap_missing_single_volume(nbd_env):

--- a/tests/storage/nbd_test.py
+++ b/tests/storage/nbd_test.py
@@ -633,7 +633,7 @@ def test_bitmap_backing_chain(nbd_env):
 
 @broken_on_ci
 @requires_privileges
-def test_bitmap_in_use(nbd_env):
+def test_bitmap_in_use_backing_chain(nbd_env):
     vol1 = create_volume(nbd_env, "qcow2", "sparse")
     vol2 = create_volume(nbd_env, "qcow2", "sparse", parent=vol1)
 
@@ -661,7 +661,7 @@ def test_bitmap_in_use(nbd_env):
 
 @broken_on_ci
 @requires_privileges
-def test_bitmap_disabled(nbd_env):
+def test_bitmap_disabled_backing_chain(nbd_env):
     vol1 = create_volume(nbd_env, "qcow2", "sparse")
     vol2 = create_volume(nbd_env, "qcow2", "sparse", parent=vol1)
 
@@ -747,7 +747,7 @@ def test_bitmap_missing_middle(nbd_env):
 
 @broken_on_ci
 @requires_privileges
-def test_bitmap_does_not_exist(nbd_env):
+def test_bitmap_does_not_exist_backing_chain(nbd_env):
     vol1 = create_volume(nbd_env, "raw", "sparse")
     vol2 = create_volume(nbd_env, "qcow2", "sparse", parent=vol1)
 


### PR DESCRIPTION
When exporting bitmap from single volume, we did not validate that
the bitmap exists and valid. When staring qemu-nbd service, qemu-nbd
starts normally so we report success, but then it fails and exits.
Later, the user fail when trying to download the backup.

Another issue, we created an overlay when exporting a volume with a parent
when the parent volume does not include the bitmap. This case does not
require an overlay.

- Add failing tests for bitmap validation
- Add bitmap validation when exporting single volume
- Create overlay only if needed