### PR TITLE
multipath: Fix generated multipath.conf

### DIFF
--- a/lib/vdsm/tool/configurators/multipath.py
+++ b/lib/vdsm/tool/configurators/multipath.py
@@ -37,9 +37,10 @@ _CONF_FILE = "/etc/multipath.conf"
 # "VDSM REVISION X.Y" tag.  Note that older version used "RHEV REVISION X.Y"
 # format.
 
-_CURRENT_TAG = "# VDSM REVISION 2.1"
+_CURRENT_TAG = "# VDSM REVISION 2.2"
 
 _OLD_TAGS = (
+    "# VDSM REVISION 2.1",
     "# VDSM REVISION 2.0",
     "# VDSM REVISION 1.9",
     "# VDSM REVISION 1.8",
@@ -193,8 +194,8 @@ defaults {
     max_fds                     4096
 }
 
-Blacklist local devices, obsolete protocols, and device nodes which
-should not be used with multipath.
+# Blacklist local devices, obsolete protocols, and device nodes which
+# should not be used with multipath.
 #
 # Complete list of protocols recognized by multipath:
 # scsi:fcp        Fibre Channel


### PR DESCRIPTION
When running multipath we see new warnings:

    # multipath -ll
    Mar 15 03:11:33 | ignoring extra data starting with 'devices,' on line 119 of /etc/multipath.conf
    Mar 15 03:11:33 | /etc/multipath.conf line 119, invalid keyword: Blacklist
    Mar 15 03:11:33 | ignoring extra data starting with 'be' on line 120 of /etc/multipath.conf
    Mar 15 03:11:33 | /etc/multipath.conf line 120, invalid keyword: should

Recent change in multipath replaced part of a comment with text; comment
it properly.

Fixes a08988ed30538b32f87b198120b27d98ba7e3de1

Signed-off-by: Nir Soffer <nsoffer@redhat.com>