### PR TITLE
net: Add crypto policy workaround for el9s

### DIFF
--- a/docker/network/Makefile
+++ b/docker/network/Makefile
@@ -29,13 +29,13 @@ all: $(targets)
 $(targets):
 	for name in $(types); do \
 		cd $$name; \
-		$(CONTAINER_CMD) build --no-cache --rm -t $(PREFIX)-$$name:$@ -f Dockerfile.$@ .; \
+		$(CONTAINER_CMD) build --no-cache --rm -t $(PREFIX)-$$name:$@ -f Dockerfile.$@ . || exit $$?; \
 		cd -; \
 	done
 
 $(types):
 	for target in $(targets); do \
 		cd $@; \
-		$(CONTAINER_CMD) build --no-cache --rm -t $(PREFIX)-$@:$$target -f Dockerfile.$$target .; \
+		$(CONTAINER_CMD) build --no-cache --rm -t $(PREFIX)-$@:$$target -f Dockerfile.$$target . || exit $$?; \
 		cd -; \
 	done

--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -1,5 +1,11 @@
 FROM quay.io/centos/centos:stream9
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -1,5 +1,11 @@
 FROM quay.io/centos/centos:stream9
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -1,5 +1,11 @@
 FROM quay.io/centos/centos:stream9
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \


### PR DESCRIPTION
The copr packages were signed by SHA1 which was
removed on el9s, until the relevant BZ [0] is fixed
set crypto policy to lagacy.

[0] https://bugzilla.redhat.com/2059101

Signed-off-by: Ales Musil <amusil@redhat.com>