### PR TITLE
Numa migration

### DIFF
--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -3606,6 +3606,16 @@ types:
             -   string
             added: '4.5'
 
+        -   defaultvalue: null
+            description: A list of NUMA nodesets (e.g. '1,3-5') for all NUMA
+              nodes. Items of the list correspond to vNUMA cells and, if
+              specified, length of the list must match number of vNUMA cells
+              in the VM.
+            name: numaNodesets
+            type:
+            -   string
+            added: '4.5'
+
         type: object
 
     MigrationStatus: &MigrationStatus

--- a/lib/vdsm/virt/domain_descriptor.py
+++ b/lib/vdsm/virt/domain_descriptor.py
@@ -175,6 +175,17 @@ class MutableDomainDescriptor(object):
                     pinning[int(vcpu)] = cpus
         return pinning
 
+    @property
+    def vnuma_count(self):
+        """
+        :return: Number of vNUMA cells defined in VM. Zero is returned when
+          NUMA is not defined.
+        """
+        numa = vmxml.find_first(self._dom, 'cpu/numa', None)
+        if numa is None:
+            return 0
+        return len(list(vmxml.find_all(numa, 'cell')))
+
 
 class DomainDescriptor(MutableDomainDescriptor):
 

--- a/tests/virt/vmoperations_test.py
+++ b/tests/virt/vmoperations_test.py
@@ -24,7 +24,6 @@ from __future__ import division
 
 import libvirt
 from six.moves import zip
-import xml.etree.ElementTree as ET
 
 from vdsm import numa
 from vdsm.common import define
@@ -465,25 +464,18 @@ class TestVmOperations(XMLTestCase):
             testvm._dom = fake.Domain(vmId='testvm')
             assert not response.is_error(testvm.acpiReboot())
 
-    def test_process_migration_cpusets(self):
-        with fake.VM() as testvm:
-            elements = testvm._process_migration_cpusets(['1,3-5'])
-            assert len(elements) == 1
-            assert isinstance(elements[0], ET.Element)
-            assert elements[0].tag == 'vcpupin'
-            assert sorted(elements[0].keys()) == ['cpuset', 'vcpu']
-            assert elements[0].get('vcpu') == '0'
-            assert elements[0].get('cpuset') == '1,3-5'
-
     @permutations([
+        # length should be 1
         [[], exception.InvalidParameter],
+        # length should be 1
         [['2', '4'], exception.InvalidParameter],
+        # cannot be arbitrary string
         [['abc'], exception.InvalidParameter],
     ])
     def test_process_migration_cpusets_invalid(self, cpusets, exception):
         with fake.VM() as testvm:
             with pytest.raises(exception):
-                testvm._process_migration_cpusets(cpusets)
+                testvm._validate_migration_cpusets(cpusets)
 
 
 def _mem_committed(mem_size_mb):


### PR DESCRIPTION
Necessary code and API changes to allow migration of NUMA VMs. It has to be possible to adapt the NUMA pinning during migration because CPUs on destination host may be used differently or destination host may have different hardware. Similarly it is necessary to allow modification to manual CPU pinning to limit virtual NUMA cells to corresponding physical NUMA cells.