### PR TITLE
mailbox: Minimize messages latency

### DIFF
--- a/contrib/extend-stats
+++ b/contrib/extend-stats
@@ -1,0 +1,101 @@
+#!/usr/bin/python3
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+
+"""
+Compute extend stats from vdsm log.
+
+Parse extend completion logs:
+
+    2022-03-23 03:57:59,502+0200 INFO  (mailbox-hsm/3) [virt.vm]
+    (vmId='108e7903-08a0-42b7-94cd-2e18272bda06') Extend volume
+    7d859aa5-feb5-4fa1-8ab4-657976a9888c completed
+    <Clock(total=1.65, wait=0.28, extend-volume=1.09, refresh-volume=0.28)>
+    (thinp:567)
+
+Usage:
+
+    $ contrib/extend-stats </var/log/vdsm/vdsm.log
+
+    Total time
+    min=1.050 avg=2.162 max=3.470
+
+    Wait time
+    min=0.090 avg=1.011 max=1.980
+
+    Extend time
+    min=0.560 avg=0.864 max=1.150
+
+    Refresh time
+    min=0.190 avg=0.285 max=0.600
+
+"""
+import sys
+import re
+
+patern = re.compile(
+    r"completed \<Clock\(total=(.+?), wait=(.+?), extend-volume=(.+?), "
+    r"refresh-volume=(.+?)\)")
+
+totals = []
+waits = []
+extends = []
+refreshes = []
+
+for line in sys.stdin:
+    m = patern.search(line)
+    if m:
+        totals.append(float(m[1]))
+        waits.append(float(m[2]))
+        extends.append(float(m[3]))
+        refreshes.append(float(m[4]))
+
+totals.sort()
+waits.sort()
+extends.sort()
+refreshes.sort()
+
+print()
+print("Total time")
+total_min = totals[0]
+total_avg = sum(totals) / len(totals)
+total_max = totals[-1]
+print(f"min={total_min:.3f} avg={total_avg:.3f} max={total_max:.3f}")
+
+print()
+print("Wait time")
+wait_min = waits[0]
+wait_avg = sum(waits) / len(waits)
+wait_max = waits[-1]
+print(f"min={wait_min:.3f} avg={wait_avg:.3f} max={wait_max:.3f}")
+
+print()
+print("Extend time")
+extend_min = extends[0]
+extend_avg = sum(extends) / len(extends)
+extend_max = extends[-1]
+print(f"min={extend_min:.3f} avg={extend_avg:.3f} max={extend_max:.3f}")
+
+print()
+print("Refresh time")
+refresh_min = refreshes[0]
+refresh_avg = sum(refreshes) / len(refreshes)
+refresh_max = refreshes[-1]
+print(f"min={refresh_min:.3f} avg={refresh_avg:.3f} max={refresh_max:.3f}")

--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -431,13 +431,13 @@ parameters = [
     # Section: [mailbox]
     ('mailbox', [
 
-        ('events_enable', 'false',
+        ('events_enable', 'true',
             'If enabled, hosts use storage events to signal the SPM '
             'when sending an extend request, and the SPM uses storage '
             'events to detect extend requests quickly. Enabling events '
             'decreases the time to extend a thin volume and lowers the '
             'risk of pausing virtual machines when a thin volume is '
-            'extended automatically. (default false)'),
+            'extended automatically. (default true)'),
     ]),
 
     # Section: [multipath]

--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -428,6 +428,18 @@ parameters = [
             '(default 20)'),
     ]),
 
+    # Section: [mailbox]
+    ('mailbox', [
+
+        ('events_enable', 'false',
+            'If enabled, hosts use storage events to signal the SPM '
+            'when sending an extend request, and the SPM uses storage '
+            'events to detect extend requests quickly. Enabling events '
+            'decreases the time to extend a thin volume and lowers the '
+            'risk of pausing virtual machines when a thin volume is '
+            'extended automatically. (default false)'),
+    ]),
+
     # Section: [multipath]
     ('multipath', [
 

--- a/lib/vdsm/host/caps.py
+++ b/lib/vdsm/host/caps.py
@@ -187,6 +187,7 @@ def get():
     caps["replicate_extend"] = True
     caps['measure_subchain'] = True
     caps['measure_active'] = True
+    caps['mailbox_events'] = config.getboolean("mailbox", "events_enable")
 
     return caps
 

--- a/tests/storage/stress/thinp.py
+++ b/tests/storage/stress/thinp.py
@@ -1,0 +1,57 @@
+"""
+Stress tests for thinp auto extend volume.
+
+Usage:
+
+1. Create a 50g thin disk on block storage domain
+
+2. Update RATE to the desired write rate
+
+3. Update PATH for the actual device in the guest.
+
+4. Start watching extension completion logs on the host running the vm:
+
+    $ tail -f /var/log/vdsm/vdsm.log | grep 'completed <Clock'
+
+5. Run inside the guest
+
+    $ python3 thinp.py
+
+"""
+import mmap
+import os
+import sys
+import time
+
+RATE = 500 * 1024**2
+SIZE = 50 * 1024**3
+PATH = "/dev/sdb"
+CHUNK = 128 * 1024**2
+
+start = time.monotonic()
+buf = mmap.mmap(-1, 8 * 1024**2)
+fd = os.open(PATH, os.O_RDWR | os.O_DIRECT)
+
+for offset in range(0, SIZE, CHUNK):
+    # Write a chunk.
+    for _ in range(CHUNK // len(buf)):
+        os.write(fd, buf)
+
+    # Check actual rate.
+    done = offset + CHUNK
+    elapsed = time.monotonic() - start
+    expected = done / RATE
+
+    # Throttle if needed.
+    if elapsed < expected:
+        time.sleep(expected - elapsed)
+
+    # Print stats
+    done_gb = done / 1024**3
+    rate_mbs = done // 1024**2 / elapsed
+    term = "\r" if done < SIZE else "\n"
+    line = f"{done_gb:.2f} GiB, {elapsed:.2f} s, {rate_mbs:.2f} MiB/s"
+    sys.stdout.write(line.ljust(79) + term)
+    sys.stdout.flush()
+
+os.close(fd)


### PR DESCRIPTION
Minimize message latency by introducing mailbox an events mechanism.

## How this changes system behavior?

The unused host 0 mailbox is used now for sending and receiving mailbox
events.

- Hosts write an event to host 0 mailbox after sending mail to the SPM.

- The SPM monitors host 0 mailbox every eventInterval (0.5 seconds)
  between monitor intervals, so it can handle new messages quickly.

- When hosts wait for reply from the SPM, they monitor their inbox every
  eventInterval (0.5 seconds), so they detect the reply quickly.

- Host reports a new "mailbox_events" capability. This can be used by
  engine to optimize mailbox I/O when all hosts in a data center
  supports this capability.

## Performance improvements

- Extend roundtrip latency reduced from 2.0-4.0 seconds to 0.5-1.0 seconds.
- Total time to extend a volume decreased from 2.3-5.9 seconds to 0.9-3.3
  seconds.
- Maximum write rate before VM starts to paused during extension increased
  from 350 MiB/s to 610 MiB/s. The theoretical improvement is bigger but the
  I could not write faster than 610 MiB/s on the tests system.

## Cost of using events

- The mailbox-spm thread cpu usage increased from 0.3% to 0.6%.
- The additional I/O on the SPM hosts is 4 4k reads every every 2 seconds. (+8k/s).
- On the other hosts, when a host waits for reply to extend message it reads the mailbox (4k) 4 times per second instead of once every 2 seconds. (+14k/s).

## Configuration

To control mailbox events, a new "mailbox:events_enable" was added. This
option allows disabling this optimization in production if needed.

To disable mailbox events, add a drop-in configuration file to all hosts:

    $ cat /etc/vdsm/vdsm.conf.d/99-local.conf
    [mailbox]
    events_enable = false

And restart the vdsmd service.

## Future work

The next improvement is eliminating the wait time. In the worst case, we
waited 1.97 seconds before sending an extend request, which is 68% of the
total extend time (3.31 seconds). This issue is tracked in
https://github.com/oVirt/vdsm/issues/85.

Fixes #102.