### PR TITLE
Add SCSI reservations support to hotplug API

### DIFF
--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -118,7 +118,7 @@ class Drive(core.Base):
                  '_diskType', 'hosts', 'protocol', 'auth', 'discard',
                  'vm_custom', '_block_info', '_threshold_state', '_lock',
                  '_monitorable', 'guestName', '_iotune', 'RBD', 'managed',
-                 'scratch_disk', 'exceeded_time')
+                 'scratch_disk', 'exceeded_time', 'managed_reservation')
     VOLWM_CHUNK_SIZE = (config.getint('irs', 'volume_utilization_chunk_mb') *
                         MiB)
     VOLWM_FREE_PCT = 100 - config.getint('irs', 'volume_utilization_percent')
@@ -228,6 +228,7 @@ class Drive(core.Base):
         self._iotune = {}
         self.managed = False
         self.scratch_disk = None
+        self.managed_reservation = False
 
         super(Drive, self).__init__(log, **kwargs)
 
@@ -1039,6 +1040,10 @@ def _getSourceXML(drive):
     if drive["diskType"] == DISK_TYPE.BLOCK:
         needs_seclabel = True
         source.setAttrs(dev=drive["path"])
+        if 'managed_reservation' in drive and drive["managed_reservation"]:
+            reservations = vmxml.Element('reservations')
+            reservations.set('managed', 'yes')
+            source.appendChild(reservations)
     elif drive["diskType"] == DISK_TYPE.NETWORK:
         if drive["protocol"] == "gluster":
             needs_seclabel = True

--- a/lib/vdsm/virt/vmdevices/storagexml.py
+++ b/lib/vdsm/virt/vmdevices/storagexml.py
@@ -130,6 +130,10 @@ def _update_source_params(params, disk_type, source):
         path = ''
     elif disk_type == 'block':
         path = source.attrib.get('dev')
+        reservations = vmxml.find_first(source, 'reservations', None)
+        if (reservations is not None and
+                reservations.attrib.get('managed') == 'yes'):
+            params['managed_reservation'] = True
     elif disk_type == 'file':
         path = source.attrib.get('file', '')
     elif 'protocol' in source.attrib:


### PR DESCRIPTION
During Direct LUN disk hotplug with SCSI Reservation, Reservation is
not enabled. The configuration received by vdsm from the engine
contains the 'reservations' parameter, but the one transferred to
libvirt - does not.

Found that this parameter is not supported neither in vmdevices/storagexml.py
when desalinizing config from the engine, nor in vmdevices/storage.py when
serializing config for libvirt, thus this configuration is not passed to libvirt on
hotplug.

Added support for the 'reservations' parameter support both to vm
metadata deserialization and serialization.

Bug-Url: https://bugzilla.redhat.com/2028481