### PR TITLE
net: Fix empty OVN bridge mappings

### DIFF
--- a/lib/vdsm/network/nmstate/ovs/network.py
+++ b/lib/vdsm/network/nmstate/ovs/network.py
@@ -394,7 +394,7 @@ def _create_bridge_mappings(bridges):
         bridge = bridges.bridge_by_sb[sb]
         mapping_pairs.extend([f'{nb}:{bridge}' for nb in sorted(nbs)])
 
-    return ','.join(mapping_pairs) or '""'
+    return ','.join(mapping_pairs)
 
 
 def _create_sb_iface_state(name, mtu):

--- a/lib/vdsm/network/nmstate/state.py
+++ b/lib/vdsm/network/nmstate/state.py
@@ -76,7 +76,8 @@ class NetworkingState(object):
                 ns for ns in self._dns_state.values()
             )
             state[DNS.KEY] = {DNS.CONFIG: {DNS.SERVER: list(nameservers)}}
-        if self._bridge_mappings:
+        # Empty string ('') is valid mapping
+        if self._bridge_mappings is not None:
             state[OvsDB.KEY] = {
                 OvsDB.EXTERNAL_IDS: {
                     OVN_BRIDGE_MAPPINGS_KEY: self._bridge_mappings

--- a/tests/network/unit/nmstate/testlib.py
+++ b/tests/network/unit/nmstate/testlib.py
@@ -380,7 +380,7 @@ def create_ovs_bridge_mappings_state(nbs_by_bridge=None):
     return {
         nmstate.OvsDB.KEY: {
             nmstate.OvsDB.EXTERNAL_IDS: {
-                OVN_BRIDGE_MAPPINGS_KEY: ','.join(mapping_pairs) or '""'
+                OVN_BRIDGE_MAPPINGS_KEY: ','.join(mapping_pairs)
             }
         }
     }


### PR DESCRIPTION
The openvswitch does not accept '""' and complains
about it, change it to simple empty string instead.

Signed-off-by: Ales Musil <amusil@redhat.com>