### PR TITLE
mailbox: Configurable event interval

### DIFF
--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -438,6 +438,13 @@ parameters = [
             'decreases the time to extend a thin volume and lowers the '
             'risk of pausing virtual machines when a thin volume is '
             'extended automatically. (default true)'),
+
+        ('events_interval', '0.5',
+            'Interval in seconds between mailbox events checks. '
+            'Shorter interval decreases the time to extend a volume, '
+            'but increases CPU usage and I/O to the inbox special volume '
+            'on the SPM, and to the outbox special volume on other hosts. '
+            '(default 0.5)'),
     ]),
 
     # Section: [multipath]

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -378,7 +378,9 @@ class StoragePool(object):
                     inbox = self._master_volume_path("inbox")
                     outbox = self._master_volume_path("outbox")
                     self.spmMailer = mailbox.SPM_MailMonitor(
-                        self, maxHostID, inbox, outbox)
+                        self, maxHostID, inbox, outbox,
+                        eventInterval=config.getfloat(
+                            "mailbox", "events_interval"))
                     self.spmMailer.start()
                     self.spmMailer.registerMessageType(
                         mailbox.EXTEND_CODE, partial(
@@ -532,7 +534,8 @@ class StoragePool(object):
             outbox = self._master_volume_path("inbox")
             inbox = self._master_volume_path("outbox")
             self.hsmMailer = mailbox.HSM_Mailbox(
-                self.id, self.spUUID, inbox, outbox)
+                self.id, self.spUUID, inbox, outbox,
+                eventInterval=config.getfloat("mailbox", "events_interval"))
             self.log.debug("HSM mailbox ready for pool %s on master "
                            "domain %s", self.spUUID, self.masterDomain.sdUUID)
 


### PR DESCRIPTION
Add "mailbox:events_interval" configuration, allowing using longer or
shorter events interval without changing the code. This is useful for
testing the best value in scale tests or to tuning in production.

To change the configuration, users can add a file on all hosts like:

    $ cat /etc/vdsm/vdsm.conf.d/99-local.conf
    [mailbox]
    events_interval = 0.25

And restart the vdsmd service.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>