### PR TITLE
tests: Refine thinp stress test

### DIFF
--- a/tests/storage/stress/thinp.py
+++ b/tests/storage/stress/thinp.py
@@ -5,52 +5,73 @@ Usage:
 
 1. Create a 50g thin disk on block storage domain
 
-2. Update RATE to the desired write rate
-
-3. Update PATH for the actual device in the guest.
-
-4. Start watching extension completion logs on the host running the vm:
+2. Start watching extension completion logs on the host running the vm:
 
     $ tail -f /var/log/vdsm/vdsm.log | grep 'completed <Clock'
 
-5. Run inside the guest
+3. Run inside the guest
 
-    $ python3 thinp.py
+    $ python3 thinp.py --rate 500 /dev/sdb
 
 """
+import argparse
 import mmap
 import os
 import sys
 import time
 
-RATE = 500 * 1024**2
-SIZE = 50 * 1024**3
-PATH = "/dev/sdb"
-CHUNK = 128 * 1024**2
+MiB = 1024**2
+GiB = 1024 * MiB
+CHUNK = 128 * MiB
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    "-r", "--rate",
+    type=lambda s: int(s) * MiB,
+    default=500 * MiB,
+    help="Write rate in MiB per second (default 500)")
+
+parser.add_argument(
+    "-s", "--size",
+    type=lambda s: int(s) * GiB,
+    default=50 * GiB,
+    help="Size in GiB (default 50)")
+
+parser.add_argument(
+    "path",
+    help="Device path (e.g. /dev/sdb)")
+
+args = parser.parse_args()
 
 start = time.monotonic()
-buf = mmap.mmap(-1, 8 * 1024**2)
-fd = os.open(PATH, os.O_RDWR | os.O_DIRECT)
+buf = mmap.mmap(-1, 8 * MiB)
+fd = os.open(args.path, os.O_RDWR | os.O_DIRECT)
+correction = 0
 
-for offset in range(0, SIZE, CHUNK):
+for offset in range(0, args.size, CHUNK):
     # Write a chunk.
-    for _ in range(CHUNK // len(buf)):
-        os.write(fd, buf)
+    todo = length = min(CHUNK, args.size - offset)
+    while todo:
+        n = min(len(buf), todo)
+        todo -= os.write(fd, memoryview(buf)[:n])
 
     # Check actual rate.
-    done = offset + CHUNK
+    done = offset + length
     elapsed = time.monotonic() - start
-    expected = done / RATE
+    expected = done / args.rate
 
     # Throttle if needed.
-    if elapsed < expected:
-        time.sleep(expected - elapsed)
+    if elapsed + correction < expected:
+        time.sleep(expected - elapsed - correction)
+        elapsed = time.monotonic() - start
+        correction = elapsed - expected
 
     # Print stats
-    done_gb = done / 1024**3
-    rate_mbs = done // 1024**2 / elapsed
-    term = "\r" if done < SIZE else "\n"
-    line = f"{done_gb:.2f} GiB, {elapsed:.2f} s, {rate_mbs:.2f} MiB/s"
+    done_gb = done / GiB
+    rate_mbs = round(done // MiB / elapsed, 1)
+    term = "\r" if done < args.size else "\n"
+    line = f"{done_gb:.2f} GiB, {elapsed:.2f} s, {rate_mbs:.1f} MiB/s"
     sys.stdout.write(line.ljust(79) + term)
     sys.stdout.flush()
 


### PR DESCRIPTION
Make the thinp test script easier to use for testing, and nicer as
example for RHV demo.

- Add command line arguments so there is no need to edit the script.
- Fix short write - previously short write would be ignored, reporting
  incorrect actual rate and total size.
- Fix actual rate - previously did not consider throttling.
- Add correction time for throttling, considering the time to sleep and
  get the next timestamp in the next sleep.
- Round the actual rate for more stable results.

Example usage with this change:

    $ python tests/storage/stress/thinp.py --rate 1024 --size 10 thinp.data
    10.00 GiB, 10.00 s, 1024.1 MiB/s

Signed-off-by: Nir Soffer <nsoffer@redhat.com>