### PR TITLE
fileVolume: Fix creation of tiny volumes

### DIFF
--- a/lib/vdsm/storage/fileVolume.py
+++ b/lib/vdsm/storage/fileVolume.py
@@ -568,7 +568,7 @@ class FileVolume(volume.Volume):
             # If the image is preallocated, allocate the rest of the image
             # using fallocate helper. qemu-img create always writes zeroes to
             # the first block so we should skip it during preallocation.
-            if preallocate == sc.PREALLOCATED_VOL:
+            if size > 4096 and preallocate == sc.PREALLOCATED_VOL:
                 op = fallocate.allocate(vol_path, size - 4096, offset=4096)
 
                 # This is fast on NFS 4.2, GlusterFS, XFS and ext4, but can be


### PR DESCRIPTION
When creating preallocated volume with size <= 4096, we try to allocate
0 bytes:

    /usr/libexec/vdsm/fallocate --offset 4096 0 /path...

Which fail in fallocate() with EINVAL as expected, and then we raise

    VolumesZeroingError: Cannot zero out volume: /path...

It looks like engine does not handle this error correctly, and the disk
remain locked forever.

Creating a volume of 4k bytes or less is not a real use case, but there
is no technical reason why it should fail. Fixed by skipping the
allocation if we don't have anything to allocate.

Reported-by: Janos Bonic <jpasztor@redhat.com>
Signed-off-by: Nir Soffer <nsoffer@redhat.com>