### PR TITLE
protocoldetector: Handle None return value from sock.recv()

### DIFF
--- a/lib/vdsm/protocoldetector.py
+++ b/lib/vdsm/protocoldetector.py
@@ -112,7 +112,7 @@ class _ProtocolDetector(object):
             dispatcher.handle_error()
             return
 
-        if len(data) < self._required_size:
+        if data is None or len(data) < self._required_size:
             return
 
         for detector in self._detectors:


### PR DESCRIPTION
Few years ago we had code checking for None, which was possible return
value from asyncore when a socket is not ready. The code handling None
was removed and we never had an issue, but maybe the recent python 3
works introduce this issue again.

We have a report showing that data is None:

2019-12-17 16:36:58,393-0600 ERROR (Reactor thread) [vds.dispatcher] uncaptured python exception, closing channel
<yajsonrpc.betterAsyncore.Dispatcher connected ('::ffff:172.20.1.142', 38002, 0, 0) at 0x7fbda865ed30> (
  <class 'TypeError'>:object of type 'NoneType' has no len()
  [/usr/lib64/python3.6/asyncore.py|readwrite|108]
  [/usr/lib64/python3.6/asyncore.py|handle_read_event|423]
  [/usr/lib/python3.6/site-packages/yajsonrpc/betterAsyncore.py|handle_read|71]
  [/usr/lib/python3.6/site-packages/yajsonrpc/betterAsyncore.py|_delegate_call|168]
  [/usr/lib/python3.6/site-packages/vdsm/protocoldetector.py|handle_read|115]
)
(betterAsyncore:179)

Try to treat None in the same way we treat empty or short read.

Change-Id: I17634df0c65b152b1810f18d902f5e187a19817d
Bug-Url: https://bugzilla.redhat.com/2072100
Signed-off-by: Nir Soffer <nsoffer@redhat.com>
