### PR TITLE
Eliminate the wait before extending a volume

### DIFF
--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -455,6 +455,10 @@ parameters = [
             'monitoring. On timeout, the drive will be monitored in the '
             'next monitoring cycle. (default 0.5)'),
 
+        ('extend_timeout', '2.0',
+            'Time in seconds to wait for extend completion during periodic '
+            'monitoring before retrying to extend. (default 2.0)'),
+
         ('refresh_timeout', '60.0',
             'Time in seconds to wait for drive monitor lock when refreshing '
             'a volume after extend completed. (default 60.0)'),

--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -454,6 +454,10 @@ parameters = [
             'Time in seconds to wait for drive monitor lock during periodic '
             'monitoring. On timeout, the drive will be monitored in the '
             'next monitoring cycle. (default 0.5)'),
+
+        ('refresh_timeout', '60.0',
+            'Time in seconds to wait for drive monitor lock when refreshing '
+            'a volume after extend completed. (default 60.0)'),
     ]),
 
     # Section: [multipath]

--- a/lib/vdsm/common/config.py.in
+++ b/lib/vdsm/common/config.py.in
@@ -447,6 +447,15 @@ parameters = [
             '(default 0.5)'),
     ]),
 
+    # Section: [thinp]
+    ('thinp', [
+
+        ('monitor_timeout', '0.5',
+            'Time in seconds to wait for drive monitor lock during periodic '
+            'monitoring. On timeout, the drive will be monitored in the '
+            'next monitoring cycle. (default 0.5)'),
+    ]),
+
     # Section: [multipath]
     ('multipath', [
 

--- a/lib/vdsm/virt/periodic.py
+++ b/lib/vdsm/virt/periodic.py
@@ -117,6 +117,20 @@ def stop():
     _executor.stop(wait=False)
 
 
+def dispatch(callable, timeout=None, discard=True):
+    """
+    Dispatch callable on the periodic executor.
+
+    Should be used when a periodic operation should run as soon as possible
+    instead of waiting for the next cycle.
+
+    Raises:
+    - vdsm.exception.ResourceExhausted if the executor queue is full
+    - vdsm.executor.NotRunning if the executor is not running
+    """
+    _executor.dispatch(callable, timeout=timeout, discard=discard)
+
+
 class Operation(object):
     """
     Operation runs a callable with a given period until

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -93,6 +93,7 @@ from vdsm.virt import guestagent
 from vdsm.virt import libvirtxml
 from vdsm.virt import metadata
 from vdsm.virt import migration
+from vdsm.virt import periodic
 from vdsm.virt import sampling
 from vdsm.virt import saslpasswd2
 from vdsm.virt import thinp
@@ -437,7 +438,7 @@ class Vm(object):
         self._hotunplugged_devices = {}  # { alias: device_object }
 
         self.volume_monitor = thinp.VolumeMonitor(
-            self, self.log, enabled=False)
+            self, self.log, dispatch=periodic.dispatch, enabled=False)
         self._connection = libvirtconnection.get(cif)
         if (recover and
             # status retrieved from the recovery file (legacy style)

--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -129,7 +129,7 @@ class Drive(core.Base):
                  'vm_custom', '_block_info', '_threshold_state', '_lock',
                  '_monitor_lock', '_monitorable', 'guestName', '_iotune',
                  'RBD', 'managed', 'scratch_disk', 'exceeded_time',
-                 'managed_reservation')
+                 'extend_time', 'managed_reservation')
     VOLWM_CHUNK_SIZE = (config.getint('irs', 'volume_utilization_chunk_mb') *
                         MiB)
     VOLWM_FREE_PCT = 100 - config.getint('irs', 'volume_utilization_percent')
@@ -248,6 +248,7 @@ class Drive(core.Base):
             self.vm_custom = {}
         self._monitorable = True
         self.threshold_state = BLOCK_THRESHOLD.UNSET
+        self.extend_time = 0.0  # Distant past.
         # Keep sizes as int
         self.reqsize = int(kwargs.get('reqsize', '0'))  # Backward compatible
         self.truesize = int(kwargs.get('truesize', '0'))

--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -85,6 +85,8 @@ class BLOCK_THRESHOLD:
     SET = "set"
     # event delivered, Drive waiting to be picked up for check and extension
     EXCEEDED = "exceeded"
+    # Drive extended to maximum size and does not need monitoring.
+    DISABLED = "disabled"
 
 
 class VolumeNotFound(errors.Base):


### PR DESCRIPTION
When receiving a block threshold event or when pausing because of ENOSPC,
extend the drive as soon as possible.

This change decreases the wait before sending an extend request from 0.0-2.0
seconds to 10-30 milliseconds.

Here are test results from 4 runs, each writing 50 GiB to think disk at
~1300 MiB/s. Each run extends the disk 20 times. The VM was not paused
during the test.
    
| time        |  min  |  avg  |  max  |
|-------------|-------|-------|-------|
| total       |  0.77 |  1.15 |  1.39 |
| extend      |  0.55 |  0.92 |  1.14 |
| refresh     |  0.16 |  0.22 |  0.31 |
| wait        |  0.01 |  0.01 |  0.03 |

Fixes: #85