### PR TITLE
Fix over allocation when preparing merge

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -428,6 +428,10 @@ class BlockVolumeManifest(volume.VolumeManifest):
             # minimal volume size.
             optimal_size = max(actual_size + MIN_PADDING, sc.MIN_CHUNK)
 
+        # Align to align size so callers can compare optimal size with the
+        # actual size.
+        optimal_size = utils.round(optimal_size, self.align_size)
+
         # Limit by maximum size.
         max_size = self.max_size(self.getCapacity(), self.getFormat())
         optimal_size = min(optimal_size, max_size)

--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -421,8 +421,10 @@ class BlockVolumeManifest(volume.VolumeManifest):
                 "irs", "volume_utilization_chunk_mb") * MiB
             optimal_size = actual_size + free_space
         else:
-            # For internal volumes, extend to minimal volume size.
-            optimal_size = max(actual_size, sc.MIN_CHUNK)
+            # For internal volumes, use the actual size. It cannot be zero
+            # since it includes qcow2 metadata.
+            assert actual_size > 0
+            optimal_size = actual_size
 
         # Align to align size so callers can compare optimal size with the
         # actual size.

--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -43,9 +43,6 @@ from vdsm.storage.volumemetadata import VolumeMetadata
 
 QCOW_OVERHEAD_FACTOR = 1.1
 
-# Minimal padding to be added to internal volume optimal size.
-MIN_PADDING = MiB
-
 log = logging.getLogger('storage.volume')
 
 
@@ -424,9 +421,8 @@ class BlockVolumeManifest(volume.VolumeManifest):
                 "irs", "volume_utilization_chunk_mb") * MiB
             optimal_size = actual_size + free_space
         else:
-            # For internal volumes, add minimal padding and extend to
-            # minimal volume size.
-            optimal_size = max(actual_size + MIN_PADDING, sc.MIN_CHUNK)
+            # For internal volumes, extend to minimal volume size.
+            optimal_size = max(actual_size, sc.MIN_CHUNK)
 
         # Align to align size so callers can compare optimal size with the
         # actual size.

--- a/lib/vdsm/storage/constants.py
+++ b/lib/vdsm/storage/constants.py
@@ -45,10 +45,6 @@ EXTERNAL_LEASE_NAMESPACE = "05_external_lease"
 VG_EXTENT_SIZE = 128 * MiB
 COW_OVERHEAD = 1.1
 
-# The minimal size used to limit internal volume size. This is mainly used
-# when calculating volume optimal size.
-MIN_CHUNK = 8 * VG_EXTENT_SIZE
-
 # TODO: This constant is useful only file base storage, it should be moved to
 # some constant module specific to file based storage once we have such module.
 # Specific stat(2) block size as defined in the man page

--- a/tests/storage/blockvolume_test.py
+++ b/tests/storage/blockvolume_test.py
@@ -160,9 +160,9 @@ class TestBlockVolumeManifest(VdsmTestCase):
         # virtual_size, actual_size, optimal_size
         # Limited by max size.
         (512 * MiB, 200 * MiB, 640 * MiB),
-        # Add minimum padding.
+        # Align to extent size.
         (2 * GiB, 1023 * MiB, 1024 * MiB),
-        (2 * GiB, 1024 * MiB, 1152 * MiB),
+        (2 * GiB, 1024 * MiB, 1024 * MiB),
     ])
     def test_optimal_size_cow_internal(
             self, virtual_size, actual_size, optimal_size):

--- a/tests/storage/blockvolume_test.py
+++ b/tests/storage/blockvolume_test.py
@@ -159,7 +159,9 @@ class TestBlockVolumeManifest(VdsmTestCase):
     @permutations([
         # virtual_size, actual_size, optimal_size
         # Limited by max size.
-        (512 * MiB, 200 * MiB, 640 * MiB),
+        (512 * MiB, 200 * MiB, 256 * MiB),
+        # Empty qcow2 image - align to extent size.
+        (2 * GiB, 262144, sc.VG_EXTENT_SIZE),
         # Align to extent size.
         (2 * GiB, 1023 * MiB, 1024 * MiB),
         (2 * GiB, 1024 * MiB, 1024 * MiB),


### PR DESCRIPTION
When preparing for merge, we extend the base volume in a dumb way, allocating too much space. We clean up when finalizing the merge, so the volume size is optimal when the merge is done. However during the merge the over allocation can cause the storage domain to become full which can cause vms to fail to extend their disks, or to other storage operation to because storage space is low.

This change fix the issue by measuring the required size for the merge, and calculating the optimal size of the volume based on the required size. When the merge is finalized the volume should be in the optimal size so we don't need to shrink the volume.

Fixes #134 