### PR TITLE
Silence mailbox logs

### DIFF
--- a/lib/vdsm/storage/mailbox.py
+++ b/lib/vdsm/storage/mailbox.py
@@ -99,7 +99,7 @@ def _mboxExecCmd(*args, **kwargs):
 
 class SPM_Extend_Message:
 
-    log = logging.getLogger('storage.spm.messages.extend')
+    log = logging.getLogger('storage.mailbox')
 
     def __init__(self, volumeData, newSize, callbackFunction=None):
         if ('poolID' not in volumeData or
@@ -190,7 +190,7 @@ class SPM_Extend_Message:
 
 class HSM_Mailbox:
 
-    log = logging.getLogger('storage.mailbox.hsm')
+    log = logging.getLogger('storage.mailbox')
 
     def __init__(self, hostID, poolID, inbox, outbox, monitorInterval=2.0,
                  eventInterval=0.5):
@@ -235,7 +235,7 @@ class HSM_Mailbox:
 
 
 class HSM_MailMonitor(object):
-    log = logging.getLogger('storage.mailbox.hsmmailmonitor')
+    log = logging.getLogger('storage.mailbox')
 
     def __init__(self, inbox, outbox, hostID, queue, monitorInterval,
                  eventInterval):
@@ -559,7 +559,7 @@ class HSM_MailMonitor(object):
 
 class SPM_MailMonitor:
 
-    log = logging.getLogger('storage.MailBox.SpmMailMonitor')
+    log = logging.getLogger('storage.mailbox')
 
     def registerMessageType(self, messageType, callback):
         self._messageTypes[messageType] = callback

--- a/lib/vdsm/storage/mailbox.py
+++ b/lib/vdsm/storage/mailbox.py
@@ -391,8 +391,7 @@ class HSM_MailMonitor(object):
         return self._handleResponses(in_mail)
 
     def _sendMail(self):
-        self.log.info("HSM_MailMonitor sending mail to SPM - " +
-                      str(self._outCmd))
+        self.log.debug("HSM_MailMonitor sending mail to SPM")
         pChk = packed_checksum(
             self._outgoingMail[0:MAILBOX_SIZE - CHECKSUM_BYTES])
         self._outgoingMail = \
@@ -536,7 +535,7 @@ class HSM_MailMonitor(object):
         # considered as a new event on the SPM side.
         event = uuid.uuid4()
 
-        self.log.info("HSM_MailMonitor sending event %s to SPM", event)
+        self.log.debug("HSM_MailMonitor sending event %s to SPM", event)
 
         buf = bytearray(MAILBOX_SIZE)
         buf[0:4] = EVENT_CODE
@@ -865,7 +864,7 @@ class SPM_MailMonitor:
                 self.log.warning("Error reading event block: %s", e)
             else:
                 if event != self._last_event:
-                    self.log.info("Received event: %s", event)
+                    self.log.debug("Received event: %s", event)
                     self._last_event = event
                     return
 

--- a/lib/vdsm/storage/mailbox.py
+++ b/lib/vdsm/storage/mailbox.py
@@ -378,7 +378,7 @@ class HSM_MailMonitor(object):
     def _checkForMail(self):
         # self.log.debug("HSM_MailMonitor - checking for mail")
         # self.log.debug("Running command: " + str(self._inCmd))
-        (rc, in_mail, err) = misc.execCmd(self._inCmd, raw=True)
+        (rc, in_mail, err) = _mboxExecCmd(self._inCmd, raw=True)
         if rc:
             raise RuntimeError("_handleResponses.Could not read mailbox - rc "
                                "%s" % rc)
@@ -769,7 +769,7 @@ class SPM_MailMonitor:
             cmd = self._inCmd + ['bs=' + str(self._outMailLen)]
             # self.log.debug("SPM_MailMonitor - reading incoming mail, "
             #               "command: " + str(cmd))
-            (rc, in_mail, err) = misc.execCmd(cmd, raw=True)
+            (rc, in_mail, err) = _mboxExecCmd(cmd, raw=True)
             if rc:
                 raise IOError(errno.EIO, "_handleRequests._checkForMail - "
                               "Could not read mailbox: %s" % self._inbox)

--- a/lib/vdsm/storage/mailbox.py
+++ b/lib/vdsm/storage/mailbox.py
@@ -27,11 +27,13 @@ import time
 import threading
 import struct
 import logging
-
 import uuid
+
+from functools import partial
 
 from six.moves import queue
 
+from vdsm.common import commands
 from vdsm.common.units import KiB
 from vdsm.config import config
 from vdsm.storage import misc
@@ -63,6 +65,10 @@ SLOTS_PER_MAILBOX = int(MAILBOX_SIZE // MESSAGE_SIZE)
 # etc)
 MESSAGES_PER_MAILBOX = SLOTS_PER_MAILBOX - 1
 
+log = logging.getLogger('storage.mailbox')
+
+_mboxExecCmd = partial(commands.execCmd, execCmdLogger=log)
+
 
 class ReadEventError(Exception):
     pass
@@ -91,10 +97,6 @@ def runTask(args):
         args = None
     ctask = task.Task(id=None, name=cmd)
     ctask.prepare(cmd, *args)
-
-
-def _mboxExecCmd(*args, **kwargs):
-    return misc.execCmd(*args, **kwargs)
 
 
 class SPM_Extend_Message:

--- a/static/etc/vdsm/logger.conf.in
+++ b/static/etc/vdsm/logger.conf.in
@@ -1,7 +1,7 @@
 # Vdsm logging configuration.
 
 [loggers]
-keys=root,vds,storage,virt,ovirt_hosted_engine_ha,ovirt_hosted_engine_ha_config,IOProcess,schema_inconsistency,devel
+keys=root,vds,storage,mailbox,virt,ovirt_hosted_engine_ha,ovirt_hosted_engine_ha_config,IOProcess,schema_inconsistency,devel
 
 [handlers]
 keys=console,syslog,logfile,logthread,schema_inconsistency
@@ -24,6 +24,12 @@ propagate=0
 level=INFO
 handlers=logthread
 qualname=storage
+propagate=0
+
+[logger_mailbox]
+level=INFO
+handlers=logthread
+qualname=storage.mailbox
 propagate=0
 
 [logger_ovirt_hosted_engine_ha]


### PR DESCRIPTION
The mailbox logs were always noisy, but with mailbox event they are too noisy.

This change:
- Add separate storage_mailbox logger configuration, so enabling DEBUG logs for storage does not enable mailbox logs
- Silence common logs that log too much detail or use wrong log level
- Run commands with storage.mailbox logger, so we can control the logging using logger.conf
- Run all commands with same runner so we can use the same logger for all mailbox commands
- Use same logger for all mailbox classes, logger per class is not needed

This is backport of #136

Bug-Url: https://bugzilla.redhat.com/2076545