### PR TITLE
Support Ceph mount using DNS name

### DIFF
--- a/lib/vdsm/storage/mount.py
+++ b/lib/vdsm/storage/mount.py
@@ -231,7 +231,13 @@ class Mount(object):
             fs_specs = self.fs_spec, None
 
         for record in _iterMountRecords():
-            if self.fs_file == record.fs_file and record.fs_spec in fs_specs:
+            if self.fs_file == record.fs_file:
+                # Note: We cannot compare fs_spec, as some file
+                # systems will record _different_ information in
+                # /proc/mounts than was given to the mount command...
+                #
+                # E.g. ceph will resolve DNS names given into IP
+                # addresses to be presented in /proc/mounts...
                 return record
 
         raise OSError(errno.ENOENT,


### PR DESCRIPTION
Case in point: For Ceph file systems, the mount command can look like this:

    mount -t ceph -o mds_namespace=ns1,name=ovirt,secret=xxx monitors.storage.example.com:/ /mnt

but the resulting entry in /proc/mounts will NOT look identical, as ceph will resolve DNS names into their IP addresses:

    192.168.1.5,192.168.1.6,192.168.1.7:/ /mnt ceph rw,seclabel,relatime,name=ovirt,secret=<hidden>,acl,mds_namespace=ovirt 0 0

(in this example `monitors.storage.example.com` was a DNS entry
resolving to 3 IP addresses).

Lesson learned: We cannot rely on mount options being carried
unmolested into /proc/mounts...

Bug-Url: https://bugzilla.redhat.com/1995610