### PR TITLE
Create a developer's readme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -147,6 +147,10 @@ tests-storage: tox
 storage:
 	python3 tests/storage/userstorage.py setup
 
+.PHONY: clean-storage
+clean-storage:
+	python3 tests/storage/userstorage.py teardown
+
 all-local: \
 	vdsm.spec
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ log collection.
 
 ## How to contribute
 
+### Contibuting
+
+To contribute please read the [development](./doc/development.md)
+documentation.
+
 ### Submitting patches
 
 Please use GitHub pull requests.
@@ -63,99 +68,6 @@ To inspect Vdsm service status:
 
 Vdsm logs can be found at `/var/log/vdsm/*.log` (refer to README.logging for further information).
 
-
-## Development environment setup
-
-Fork the project on https://github.com/oVirt/vdsm.
-
-Clone your fork:
-
-    sudo dnf install -y git
-    git@github.com:{user}/vdsm.git
-
-Enable oVirt packages for Fedora:
-
-    sudo dnf copr enable -y nsoffer/ioprocess-preview
-    sudo dnf copr enable -y nsoffer/ovirt-imageio-preview
-
-Install additional packages for Fedora, CentOS, and RHEL:
-
-    sudo dnf install -y `cat automation/check-patch.packages`
-
-Create virtual environment for vdsm:
-
-    python3 -m venv ~/.venv/vdsm
-    source ~/.venv/vdsm/bin/activate
-    pip install --upgrade pip
-    pip install -r docker/requirements.txt
-    deactivate
-
-Before running vdsm tests, activate the environment:
-
-    source ~/.venv/vdsm/bin/activate
-
-When done, you can deactivate the environment:
-
-    deactivate
-
-## Building Vdsm
-
-To configure sources (run `./configure --help` to see configuration options):
-
-    git clean -xfd
-    ./autogen.sh --system --enable-timestamp
-    make
-
-To test Vdsm (refer to tests/README for further tests information):
-
-    make check
-
-To create an RPM:
-
-    rm -rf ~/rpmbuild/RPMS/*/vdsm*.rpm
-    make rpm
-
-To update your system with local build's RPM:
-
-    (cd ~/rpmbuild/RPMS && sudo dnf upgrade */vdsm*.rpm)
-
-
-## Making new releases
-
-Release process of Vdsm version `VERSION` consists of the following
-steps:
-
-- Changing `Version:` field value in `vdsm.spec.in` to `VERSION`.
-
-- Updating `%changelog` line in `vdsm.spec.in` to the current date,
-  the committer, and `VERSION`.
-
-- Committing these changes, with subject "New release: `VERSION`" and
-  posting the patch to gerrit.
-
-- Verifying the patch by checking that the Jenkins build produced a
-  correct set of rpm's with the correct version.
-
-- Merging the patch (no review needed).
-
-- Tagging the commit immediately after merge with an annotated tag:
-  `git tag -a vVERSION`
-
-- Setting "Keep this build forever" for the check-merge Jenkins build.
-
-- Updating releng-tools with the new Vdsm version.  See releng-tools
-  repo (`git clone https://gerrit.ovirt.org/releng-tools`) and Vdsm
-  related patches there for examples.
-
-
-## CI
-
-Running tests locally is convenient, but before your changes can be
-merged, we need to test them on all supported distributions and
-architectures.
-
-When you push patches to GitHub, CI will run its tests according to the
-configuration in the .github/workflows/ci.yml file.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -154,24 +154,8 @@ Running tests locally is convenient, but before your changes can be
 merged, we need to test them on all supported distributions and
 architectures.
 
-When you submit patches to gerrit, oVirt's Jenkins CI will run its tests
-according to configuration in the stdci.yaml file.
-
-### Travis CI for storage patches
-
-oVirt's Jenkins CI is the integrated method for testing Vdsm patches,
-however for storage related patches we have to cover also 4k tests which
-are not covered currently by Jenkins CI. This can be achieved in a fast
-way manually and independently from gerrit by invoking Travis CI on your
-github branch:
-
-- Fork the project on github.
-- Visit https://travis-ci.org, register using your github account, and
-  enable builds for your Vdsm fork.
-- Push your changes to your github fork to trigger a build.
-
-See .travis.yml file for tested Travis platforms and tests configurations.
-
+When you push patches to GitHub, CI will run its tests according to the
+configuration in the .github/workflows/ci.yml file.
 
 ## Getting Help
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,95 @@
+# Development
+
+## Environment setup
+
+Fork the project on https://github.com/oVirt/vdsm.
+
+Clone your fork:
+
+    sudo dnf install -y git
+    git@github.com:{user}/vdsm.git
+
+Enable oVirt packages for Fedora:
+
+    sudo dnf copr enable -y nsoffer/ioprocess-preview
+    sudo dnf copr enable -y nsoffer/ovirt-imageio-preview
+
+Install additional packages for Fedora, CentOS, and RHEL:
+
+    sudo dnf install -y `cat automation/check-patch.packages`
+
+Create virtual environment for vdsm:
+
+    python3 -m venv ~/.venv/vdsm
+    source ~/.venv/vdsm/bin/activate
+    pip install --upgrade pip
+    pip install -r docker/requirements.txt
+    deactivate
+
+Before running vdsm tests, activate the environment:
+
+    source ~/.venv/vdsm/bin/activate
+
+When done, you can deactivate the environment:
+
+    deactivate
+
+
+## Building Vdsm
+
+To configure sources (run `./configure --help` to see configuration options):
+
+    git clean -xfd
+    ./autogen.sh --system --enable-timestamp
+    make
+
+To test Vdsm (refer to tests/README for further tests information):
+
+    make check
+
+To create an RPM:
+
+    rm -rf ~/rpmbuild/RPMS/*/vdsm*.rpm
+    make rpm
+
+To update your system with local build's RPM:
+
+    (cd ~/rpmbuild/RPMS && sudo dnf upgrade */vdsm*.rpm)
+
+
+## Making new releases
+
+Release process of Vdsm version `VERSION` consists of the following
+steps:
+
+- Changing `Version:` field value in `vdsm.spec.in` to `VERSION`.
+
+- Updating `%changelog` line in `vdsm.spec.in` to the current date,
+  the committer, and `VERSION`.
+
+- Committing these changes, with subject "New release: `VERSION`" and
+  posting the patch to gerrit.
+
+- Verifying the patch by checking that the Jenkins build produced a
+  correct set of rpm's with the correct version.
+
+- Merging the patch (no review needed).
+
+- Tagging the commit immediately after merge with an annotated tag:
+  `git tag -a vVERSION`
+
+- Setting "Keep this build forever" for the check-merge Jenkins build.
+
+- Updating releng-tools with the new Vdsm version.  See releng-tools
+  repo (`git clone https://gerrit.ovirt.org/releng-tools`) and Vdsm
+  related patches there for examples.
+
+
+## CI
+
+Running tests locally is convenient, but before your changes can be
+merged, we need to test them on all supported distributions and
+architectures.
+
+When you push patches to GitHub, CI will run its tests according to the
+configuration in the `.github/workflows/ci.yml` file.

--- a/doc/development.md
+++ b/doc/development.md
@@ -14,6 +14,16 @@ Enable oVirt packages for Fedora:
     sudo dnf copr enable -y nsoffer/ioprocess-preview
     sudo dnf copr enable -y nsoffer/ovirt-imageio-preview
 
+Enable
+[virt-preview](https://copr.fedorainfracloud.org/coprs/g/virtmaint-sig/virt-preview/)
+repository to obtain latest qemu and libvirt versions:
+
+    sudo dnf copr enable @virtmaint-sig/virt-preview
+
+Update the system after enabling all repositories:
+
+    sudo dnf update -y
+
 Install additional packages for Fedora, CentOS, and RHEL:
 
     sudo dnf install -y `cat automation/check-patch.packages`
@@ -24,14 +34,6 @@ Create virtual environment for vdsm:
     source ~/.venv/vdsm/bin/activate
     pip install --upgrade pip
     pip install -r docker/requirements.txt
-    deactivate
-
-Before running vdsm tests, activate the environment:
-
-    source ~/.venv/vdsm/bin/activate
-
-When done, you can deactivate the environment:
-
     deactivate
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,4 @@
-==========
-Vdsm tests
-==========
+# Vdsm tests
 
 This tests suite is built on tox, pytest and nose. For more info on
 these projects see:
@@ -9,13 +7,11 @@ these projects see:
 - pytest: https://pytest.readthedocs.io/
 - nose: http://nose.readthedocs.io/
 
-Tox and pytest based tests
-==========================
+# Tox and pytest based tests
 
 Note: Not all tests have been converted to tox and/or pytest yet.
 
-Running the tests
------------------
+## Running the tests
 
 Run storage tests:
 
@@ -35,8 +31,7 @@ Running specific storage tests modules:
     tox -e storage -- storage/image_test.py
 
 
-Using tox virtual environment
------------------------------
+## Using tox virtual environment
 
 Tox creates a virtual environment for each testenv. You don't have to
 know anything about this if you run the tests with tox, but if you like
@@ -85,8 +80,7 @@ Note that your prompt has changed again:
     [user@fedora tests (storage-tests)]$
 
 
-Troubleshooting
----------------
+## Troubleshooting
 
 Tox may fail due to an outdated or corrupted virtual environment.
 To solve this you can recreate a specific tox environment without test execution:
@@ -98,8 +92,7 @@ Or just remove the tox hidden folder to clean all tox environments by doing:
     rm -rf .tox
 
 
-Using pytest directly
----------------------
+## Using pytest directly
 
 Running all the tests takes couple of minutes. For quicker feedback you can use
 pytest directly to run a module or some tests in a module.
@@ -135,8 +128,7 @@ Running only stress tests, using markers:
 
     pytest -m "stress" storage
 
-Running the tests as root
--------------------------
+## Running the tests as root
 
 When using sudo, use env to pass PYTHONPATH to the underlying program:
 
@@ -149,11 +141,9 @@ When running the tests as root, use another --basetemp directory for pytest:
 This will avoid failures when you run the tests later as regular user, when
 pytest will try to remove old temporary directories created by root.
 
-Nose based tests
-================
+# Nose based tests
 
-Running the tests
------------------
+## Running the tests
 
 Running the tests from the tests directory, using vdsm code from the source
 directory (lib/vdsm):
@@ -166,8 +156,7 @@ Running individual test module, test cases class or test function:
     ./run_tests_local.sh foo_test:TestBar
     ./run_tests_local.sh foo_test:TestBar.test_baz
 
-Enabling slow tests:
--------------------
+## Enabling slow tests
 
 Some tests are too slow to run on each build. these are marked in the source
 with the @slowtest decorator and are disabled by default.
@@ -178,8 +167,7 @@ To enable slow tests:
 
 Slow tests are also enabled if NOSE_SLOW_TESTS environment variable is set.
 
-Enabling stress tests:
----------------------
+## Enabling stress tests
 
 Some tests stress the resources of the system running the tests. These tests
 are too slow to run on each build, and may fail on overloaded system or when
@@ -192,8 +180,7 @@ To enable stress tests:
 
 Stress tests are also enabled if NOSE_STRESS_TESTS environment variable is set.
 
-Enabling threads leak check
----------------------------
+## Enabling threads leak check
 
 To find tests leaking threads, you can enable the thread leak checker plugin:
 
@@ -203,8 +190,7 @@ To run the entire test suit with thread leak detection:
 
     make check NOSE_WITH_THREAD_LEAK_CHECK=1
 
-Enabling process leak check
-----------------------------
+## Enabling process leak check
 
 To find tests leaking child processes, you can enable the process leak checker
 plugin:
@@ -215,8 +201,7 @@ To run the entire test suit with process leak detection:
 
     make check NOSE_WITH_PROCESS_LEAK_CHECK=1
 
-Enabling file leak check
-------------------------
+## Enabling file leak check
 
 To find tests leaking file descriptors, you can enable the process leak checker
 plugin:
@@ -227,8 +212,7 @@ To run the entire test suit with file leak detection:
 
     make check NOSE_WITH_FILE_LEAK_CHECK=1
 
-Control verbose level:
----------------------
+## Control verbose level
 
 By default, tests run without verbose level 1.
 To run with verbose output, set verbose level to 3.
@@ -237,16 +221,14 @@ To set verbose level:
     
     make check NOSE_VERBOSE=<VERBOSE LEVEL>
 
-Functional test suite:
-----------------------
+## Functional test suite
 
 The functional test suite is designed to test a running vdsm instance.  To run
 the full suite of functional tests from within the installed directory:
     
     ./run_tests.sh functional/*.py
 
-Test timeout
-------------
+## Test timeout
 
 If TIMEOUT environment variable is set, and a test run is too slow, it is
 aborted, and a backtrace of all threads is printed.

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,23 @@ Note: Not all tests have been converted to tox and/or pytest yet.
 
 ## Running the tests
 
+Before running vdsm tests, activate the environment:
+
+    source ~/.venv/vdsm/bin/activate
+
+When done, you can deactivate the environment:
+
+    deactivate
+
+Before running storage tests, make sure you have setup the user storage
+accordingly. To create storage you can do:
+
+    make storage
+
+See
+[Setting up user storage](./storage/README.md#setting-up-user-storage)
+for more information.
+
 Run storage tests:
 
     tox -e storage
@@ -29,6 +46,14 @@ You can also use environment variables:
 Running specific storage tests modules:
 
     tox -e storage -- storage/image_test.py
+
+Alternatively, all tests but storage tests can be run by doing:
+
+    make tests
+
+Furthermore, storage-only tests can be run by doing:
+
+    make tests-storage
 
 
 ## Using tox virtual environment

--- a/tests/storage/README.md
+++ b/tests/storage/README.md
@@ -16,7 +16,7 @@ be run again after rebooting the host.
 
 If you want to tear down the user storage, run:
 
-    python tests/storage/userstorage.py teardown
+    make clean-storage
 
 There is no need to tear down the storage normally. The loop devices are
 backed up by sparse files and do not consume much resources.

--- a/tests/storage/README.md
+++ b/tests/storage/README.md
@@ -9,7 +9,7 @@ or fail (depending on the test).
 
 To setup storage for these tests, run:
 
-    python tests/storage/userstorage.py setup
+    make storage
 
 This can be run once when setting up development environment, and must
 be run again after rebooting the host.


### PR DESCRIPTION
Create a new developer's README similar to other projects (e.g., ovirt-imageio). This change slightly improves readability
information's organization. In the update is important to keep the files linked so that it is easy to find information
and navigate between the different documentation files.

This PR includes an update of the tests README to markdown format and the update of some sections before
moving them to the new developer's document. Here's a summary of the changes:
1. Transform the **tests** `README` file to `README.md` and change format to fully comply with Markdown syntax.
2. Remove outdated parts from the original README
3. Create a developer's readme in the doc folder and move all developer-specific sections from main `README.md` and `test/README.md` to `doc/development.md`, and linking the new document from main README
4. Improve new development readme:
    - Add `copr virt-preview` enablement to the developer's readme
    - Update storage README "setting up" section to use `make storage` instead of direct script invocation
5. Create and document a new 'clean-storage' make target

Related: #42 