### PR TITLE
copy_data: Consolidate semantically equal endpoint params

### DIFF
--- a/lib/vdsm/storage/sdm/api/copy_data.py
+++ b/lib/vdsm/storage/sdm/api/copy_data.py
@@ -54,10 +54,9 @@ class Job(base.Job):
                  copy_bitmaps=False):
         super(Job, self).__init__(job_id, 'copy_data', host_id)
         self._dest = _create_endpoint(
-            destination, host_id, writable=True, job_id=job_id)
+            destination, host_id, job_id=job_id)
         self._source = _create_endpoint(
-            source, host_id, writable=False, job_id=job_id,
-            dest=self._dest)
+            source, host_id, job_id=job_id, dest=self._dest)
         self._operation = None
         self._copy_bitmaps = copy_bitmaps
 
@@ -118,14 +117,12 @@ class Job(base.Job):
                         self._operation.run()
 
 
-def _create_endpoint(params, host_id, writable, job_id=None,
-                     dest=None):
+def _create_endpoint(params, host_id, job_id=None, dest=None):
     endpoint_type = params.pop('endpoint_type')
     if endpoint_type == 'div':
         return CopyDataDivEndpoint(
             params,
             host_id,
-            writable,
             dest=dest)
     elif endpoint_type == 'external':
         return CopyDataExternalEndpoint(params, host_id, job_id)
@@ -141,7 +138,7 @@ class CopyDataDivEndpoint(properties.Owner):
                                     maxval=sc.MAX_GENERATION)
     prepared = properties.Boolean(default=False)
 
-    def __init__(self, params, host_id, writable, dest=None):
+    def __init__(self, params, host_id, dest=None):
         self.sd_id = params.get('sd_id')
         self.img_id = params.get('img_id')
         self.vol_id = params.get('vol_id')
@@ -154,7 +151,6 @@ class CopyDataDivEndpoint(properties.Owner):
         self.lock_image = self.is_destination or self.img_id != dest.img_id
 
         self._host_id = host_id
-        self._writable = writable
         self._vol = None
 
     @property
@@ -166,10 +162,10 @@ class CopyDataDivEndpoint(properties.Owner):
         # are not the same, otherwise there will be a deadlock.
         if self.lock_image:
             img_ns = rm.getNamespace(sc.IMAGE_NAMESPACE, self.sd_id)
-            mode = rm.EXCLUSIVE if self._writable else rm.SHARED
+            mode = rm.EXCLUSIVE if self.is_destination else rm.SHARED
             ret.append(rm.Lock(img_ns, self.img_id, mode))
 
-        if self._writable:
+        if self.is_destination:
             dom = sdCache.produce_manifest(self.sd_id)
             if dom.hasVolumeLeases():
                 ret.append(volume.VolumeLease(self._host_id, self.sd_id,
@@ -234,8 +230,9 @@ class CopyDataDivEndpoint(properties.Owner):
         if self.prepared:
             yield
         else:
+            # Only destination volumes are writable and allowed illegal
             self.volume.prepare(
-                rw=self._writable,
+                rw=self.is_destination,
                 justme=False,
                 allow_illegal=self.is_destination)
             try:

--- a/lib/vdsm/storage/sdm/api/update_volume.py
+++ b/lib/vdsm/storage/sdm/api/update_volume.py
@@ -32,7 +32,7 @@ class Job(base.Job):
 
     def __init__(self, job_id, host_id, vol_info, vol_attr):
         super(Job, self).__init__(job_id, 'update_volume', host_id)
-        self._endpoint = CopyDataDivEndpoint(vol_info, host_id, writable=True)
+        self._endpoint = CopyDataDivEndpoint(vol_info, host_id)
         self._vol_attr = validators.VolumeAttributes(vol_attr)
 
     def _run(self):


### PR DESCRIPTION
Fixes #107 

**Verified** by triggering the `copy_data` behavior from the engine web UI by both copying and moving disks:
![image](https://user-images.githubusercontent.com/102953499/165481368-936a2b75-c401-484c-a216-af967d6973f8.png)
![image](https://user-images.githubusercontent.com/102953499/165481516-4c1131b3-5207-45bf-85ee-de89eec2ee0d.png)

One host was running with the `vdsm-client` installed and updated from RPMs. In both cases the operation succeed.

Signed-off-by: Albert Esteve <aesteve@redhat.com>