### PR TITLE
Prepare for eliminating delay on extend

### DIFF
--- a/doc/thin-provisioning.md
+++ b/doc/thin-provisioning.md
@@ -12,7 +12,8 @@ implemented with block based storage.
 Vdsm monitors thin provisioned drives or drives being replicated to thin
 provisioned drives periodically.  During startup, DriveWatermarkMonitor
 is created and scheduled with the periodic executor to run
-VM.monitor_volumes every 2 seconds (configurable) on all VMs.
+VM.volume_monitor.monitor_volumes every 2 seconds (configurable) on all
+VMs.
 
 For each VM, we fetch the drives that should be monitored. We have 2
 cases:
@@ -39,9 +40,9 @@ failed, a VM may try to write behind the current disk size. In this case
 qemu will pause the VM and we get a libvirt
 VIR_DOMAIN_EVENT_ID_IO_ERROR_REASON event with ```ENOSPC``` reason.
 
-When receiving such event, we call VM.monitor_volumes() on the paused VM.
-We are likely to find that one or more drives are too full, and trigger
-an extend of the drives.
+When receiving such event, we call VM.volume_monitor.on_enospc()
+on the paused VM.  We are likely to find that one or more drives are
+too full, and trigger an extend of the drives.
 
 
 ### Extend drive flow

--- a/lib/vdsm/virt/periodic.py
+++ b/lib/vdsm/virt/periodic.py
@@ -382,7 +382,7 @@ class VolumeWatermarkMonitor(_RunnableOnVm):
                 self._vm.volume_monitor.monitoring_needed())
 
     def _execute(self):
-        self._vm.monitor_volumes()
+        self._vm.volume_monitor.monitor_volumes()
 
 
 class _ExternalDataMonitor(_RunnableOnVm):

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -213,6 +213,12 @@ class VolumeMonitor(object):
         else:
             drive.on_block_threshold(path)
 
+    def on_enospc(self, drive=None):
+        """
+        Called when a VM pauses because of ENOSPC error writing to drive.
+        """
+        self.monitor_volumes()
+
     # Monitoring volumes.
 
     def monitor_volumes(self):

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -286,9 +286,8 @@ class VolumeMonitor(object):
         drive.on_block_threshold(drive.path)
 
         self._log.info(
-            "Requesting extension for volume %s on domain %s block_info %s "
-            "threshold_state %s",
-            drive.volumeID, drive.domainID, block_info, drive.threshold_state)
+            "Requesting an extension for volume %s on domain %s block_info %s",
+            drive.volumeID, drive.domainID, block_info)
 
         self.extend_volume(
             drive, drive.volumeID, block_info.physical, block_info.capacity)

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -262,9 +262,7 @@ class VolumeMonitor(object):
         Check if a drive should be extended, and start extension flow if
         needed.
 
-        When libvirt BLOCK_THRESHOLD event handling is enabled (
-        irs.enable_block_threshold_event == True), this method acts according
-        the drive.threshold_state:
+        We handle the drive according to the drive.threshold_state:
 
         - UNSET: the drive needs to register for a new block threshold,
                  so try to set it. We set the threshold both for chunked

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -213,11 +213,11 @@ class VolumeMonitor(object):
         else:
             drive.on_block_threshold(path)
 
-    def on_enospc(self, drive=None):
+    def on_enospc(self, drive):
         """
         Called when a VM pauses because of ENOSPC error writing to drive.
         """
-        self.monitor_volumes()
+        drive.on_enospc()
 
     # Monitoring volumes.
 

--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -261,18 +261,9 @@ class VolumeMonitor(object):
         """
         Check if a drive should be extended, and start extension flow if
         needed.
-
-        We handle the drive according to the drive.threshold_state:
-
-        - UNSET: the drive needs to register for a new block threshold,
-                 so try to set it. We set the threshold both for chunked
-                 drives and non-chunked drives replicating to chunked
-                 drives.
-        - EXCEEDED: the drive needs extension, try to extend it.
-        - SET: this method should never receive a drive in this state,
-               emit warning and exit.
         """
         if drive.threshold_state == storage.BLOCK_THRESHOLD.SET:
+            # Should never happen; we monitor only UNSET and EXCEEDED drives.
             self._log.warning(
                 "Unexpected state for drive %s: threshold_state SET",
                 drive.name)
@@ -280,6 +271,9 @@ class VolumeMonitor(object):
 
         block_info = drive.block_info
 
+        # Set block threshold if needed. However since this is racy, and we may
+        # not get a block threshold event, continue and check if the volume
+        # needs extension.
         if drive.threshold_state == storage.BLOCK_THRESHOLD.UNSET:
             self._set_threshold(drive, block_info.physical, block_info.index)
 

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -1300,9 +1300,9 @@ class Vm(object):
 
     def monitor_volumes(self):
         """
-        Return True if at least one volume is being extended, False otherwise.
+        Check and extend drives if needed.
         """
-        return self.volume_monitor.monitor_volumes()
+        self.volume_monitor.monitor_volumes()
 
     def extend_volume(self, vmDrive, volumeID, curSize, capacity,
                       callback=None):
@@ -5150,8 +5150,7 @@ class Vm(object):
             self._setGuestCpuRunning(False, flow='IOError')
             self._logGuestCpuStatus('onIOError')
             if reason == 'ENOSPC':
-                if not self.monitor_volumes():
-                    self.log.info("No volumes were extended")
+                self.monitor_volumes()
 
             self._send_ioerror_status_event(reason, blockDevAlias)
             self._update_metadata()

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -5150,9 +5150,9 @@ class Vm(object):
             except LookupError:
                 drive = None
                 self.log.warning('unknown disk alias: %s', blockDevAlias)
-
-            if reason == 'ENOSPC':
-                self.volume_monitor.on_enospc(drive)
+            else:
+                if reason == 'ENOSPC':
+                    self.volume_monitor.on_enospc(drive)
 
             self._send_ioerror_status_event(reason, blockDevAlias, drive=drive)
             self._update_metadata()

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -1298,12 +1298,6 @@ class Vm(object):
         _, raw_stats = res[0]
         return raw_stats
 
-    def monitor_volumes(self):
-        """
-        Check and extend drives if needed.
-        """
-        self.volume_monitor.monitor_volumes()
-
     def extend_volume(self, vmDrive, volumeID, curSize, capacity,
                       callback=None):
         """

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -5158,7 +5158,7 @@ class Vm(object):
                 self.log.warning('unknown disk alias: %s', blockDevAlias)
 
             if reason == 'ENOSPC':
-                self.monitor_volumes()
+                self.volume_monitor.on_enospc(drive)
 
             self._send_ioerror_status_event(reason, blockDevAlias, drive=drive)
             self._update_metadata()

--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -927,6 +927,8 @@ class Drive(core.Base):
 
         Mark this drive for extension, to be picked by the periodic monitor
         later.
+
+        Return True if threshold state was modified.
         """
         with self._lock:
             if reported_path != self._path:
@@ -934,9 +936,9 @@ class Drive(core.Base):
                     "block threshold event mismatch drive %r path=%r "
                     "reported path=%r - ignored",
                     self.name, self._path, reported_path)
-                return
+                return False
 
-            self._mark_for_extension()
+            return self._mark_for_extension()
 
     def on_enospc(self):
         """
@@ -945,9 +947,11 @@ class Drive(core.Base):
 
         We mark the drive for extension so it will be picked up by the periodic
         monitor later.
+
+        Return True if threshold state was modified.
         """
         with self._lock:
-            self._mark_for_extension()
+            return self._mark_for_extension()
 
     def _mark_for_extension(self):
         """
@@ -957,11 +961,12 @@ class Drive(core.Base):
             self.log.debug(
                 "drive %r block threshold already exceeded, ignored",
                 self.name)
-            return
+            return False
 
         self.log.info("drive %r needs extension", self.name)
         self._threshold_state = BLOCK_THRESHOLD.EXCEEDED
         self.exceeded_time = time.monotonic_time()
+        return True
 
 
 def chain_index(actual_chain, vol_id, drive_name):

--- a/tests/virt/thinp_monitor_test.py
+++ b/tests/virt/thinp_monitor_test.py
@@ -221,8 +221,7 @@ def test_extend(tmp_config):
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
     # Simulating periodic check
-    extended = vm.monitor_volumes()
-    assert extended is True
+    vm.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 1
     check_extension(vdb, drives[1], vm.cif.irs.extensions[0])
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
@@ -256,8 +255,7 @@ def test_extend_no_allocation(tmp_config):
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
     # Simulating periodic check
-    extended = vm.monitor_volumes()
-    assert extended is True
+    vm.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 1
     check_extension(vdb, drives[1], vm.cif.irs.extensions[0])
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
@@ -446,7 +444,7 @@ def test_monitor_all_drives_set(tmp_config):
     assert drives[1].threshold_state == BLOCK_THRESHOLD.SET
 
     # Next call should skip both drives.
-    assert not vm.monitor_volumes()
+    vm.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 0
 
 

--- a/tests/virt/thinp_monitor_test.py
+++ b/tests/virt/thinp_monitor_test.py
@@ -199,7 +199,7 @@ def test_extend(tmp_config):
     drv = drives[1]
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     # Simulate writing to drive vdb
     vdb = vm.block_stats[2]
@@ -221,7 +221,7 @@ def test_extend(tmp_config):
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
     # Simulating periodic check
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 1
     check_extension(vdb, drives[1], vm.cif.irs.extensions[0])
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
@@ -238,7 +238,7 @@ def test_extend_no_allocation(tmp_config):
     drives = vm.getDiskDevices()
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     # Simulate writing to drive vdb
     vdb = vm.block_stats[2]
@@ -255,7 +255,7 @@ def test_extend_no_allocation(tmp_config):
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
     # Simulating periodic check
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 1
     check_extension(vdb, drives[1], vm.cif.irs.extensions[0])
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
@@ -408,7 +408,7 @@ def test_set_new_threshold_when_state_unset(
     assert vda.threshold_state == BLOCK_THRESHOLD.UNSET
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     assert vda.threshold_state == expected_state
     if threshold is not None:
@@ -427,7 +427,7 @@ def test_set_new_threshold_when_state_unset_but_fails(tmp_config):
         libvirt.VIR_ERR_OPERATION_FAILED, "fake error")
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     for drive in drives:
         assert drive.threshold_state == BLOCK_THRESHOLD.UNSET
@@ -438,13 +438,13 @@ def test_monitor_all_drives_set(tmp_config):
     drives = vm.getDiskDevices()
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     assert drives[0].threshold_state == BLOCK_THRESHOLD.SET
     assert drives[1].threshold_state == BLOCK_THRESHOLD.SET
 
     # Next call should skip both drives.
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 0
 
 
@@ -464,7 +464,7 @@ def test_force_drive_threshold_state_exceeded(tmp_config):
     vda['allocation'] = allocation_threshold_for_resize_mb(
         vda, drives[0]) + 1 * MiB
 
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     # forced to exceeded by monitor_volumes() even if no
     # event received.
@@ -506,7 +506,7 @@ def test_event_received_before_write_completes(tmp_config):
         'vda[0]', '/virtio/0', alloc, 1 * MiB)
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     # The threshold state is correctly kept as exceeded, so extension
     # will be tried again next cycle.
@@ -518,7 +518,7 @@ def test_block_threshold_set_failure_after_drive_extended(tmp_config):
     drives = vm.getDiskDevices()
 
     # first run: does nothing but set the block thresholds
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
 
     # Simulate write on drive vdb
     vdb = vm.block_stats[2]
@@ -546,7 +546,7 @@ def test_block_threshold_set_failure_after_drive_extended(tmp_config):
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
     # Simulating periodic check
-    vm.monitor_volumes()
+    vm.volume_monitor.monitor_volumes()
     assert len(vm.cif.irs.extensions) == 1
 
     # Simulate completed extend operation, invoking callback

--- a/tests/virt/thinp_monitor_test.py
+++ b/tests/virt/thinp_monitor_test.py
@@ -480,8 +480,6 @@ def test_event_received_before_write_completes(tmp_config):
     # is possible that at the time we receive the event the
     # the write was not completed yet, or failed, and the
     # volume size is still bellow the threshold.
-    # We will not extend the drive, but keep it marked for
-    # extension.
     vm = FakeVM(drive_infos())
     drives = vm.getDiskDevices()
 
@@ -508,9 +506,12 @@ def test_event_received_before_write_completes(tmp_config):
 
     vm.volume_monitor.monitor_volumes()
 
-    # The threshold state is correctly kept as exceeded, so extension
-    # will be tried again next cycle.
+    # The drive is marked for extension.
     assert drv.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+
+    # And try to exend.
+    assert len(vm.cif.irs.extensions) == 1
+    check_extension(vda, drives[0], vm.cif.irs.extensions[0])
 
 
 def test_block_threshold_set_failure_after_drive_extended(tmp_config):

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -128,6 +128,16 @@ def test_on_block_threshold_unknown_drive():
     assert vda.threshold_state == BLOCK_THRESHOLD.UNSET
 
 
+def test_on_enospc():
+    vm = FakeVM()
+    mon = thinp.VolumeMonitor(vm, vm.log)
+    vda = make_drive(vm.log, index=0, iface='virtio')
+    vm.drives.append(vda)
+
+    mon.on_enospc(vda)
+    assert vda.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+
+
 def test_monitoring_needed():
 
     class FakeDrive:

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -178,14 +178,10 @@ class FakeVM(object):
     def __init__(self):
         self.id = "fake-vm-id"
         self.drives = []
-        self.block_stats = []
         self._dom = FakeDomain()
 
     def getDiskDevices(self):
         return self.drives[:]
-
-    def query_block_stats(self):
-        return self.block_stats
 
 
 class FakeDomain(object):

--- a/tests/virt/vmstorage_test.py
+++ b/tests/virt/vmstorage_test.py
@@ -626,8 +626,8 @@ class DriveDiskTypeTests(VdsmTestCase):
         drive.path = '/new/path'
         assert drive.threshold_state == BLOCK_THRESHOLD.UNSET
 
-    def test_block_threshold_set_state(self):
-        path = '/old/path'
+    def test_on_block_threshold_set(self):
+        path = '/path'
         conf = drive_config(diskType=DISK_TYPE.BLOCK, path=path)
         drive = Drive(self.log, **conf)
         drive.threshold_state = BLOCK_THRESHOLD.SET
@@ -635,13 +635,23 @@ class DriveDiskTypeTests(VdsmTestCase):
         drive.on_block_threshold(path)
         assert drive.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
-    def test_block_threshold_stale_path(self):
+    def test_on_block_threshold_set_stale_path(self):
         conf = drive_config(diskType=DISK_TYPE.BLOCK, path='/new/path')
         drive = Drive(self.log, **conf)
         drive.threshold_state = BLOCK_THRESHOLD.SET
 
         drive.on_block_threshold('/old/path')
         assert drive.threshold_state == BLOCK_THRESHOLD.SET
+
+    def test_on_block_threshold_exceeded(self):
+        path = '/path'
+        conf = drive_config(diskType=DISK_TYPE.BLOCK, path=path)
+        drive = Drive(self.log, **conf)
+        drive.threshold_state = BLOCK_THRESHOLD.EXCEEDED
+
+        # When exceeded, call does nothing.
+        drive.on_block_threshold(path)
+        assert drive.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
 
 def test_drive_exceeded_time(monkeypatch):

--- a/tests/virt/vmstorage_test.py
+++ b/tests/virt/vmstorage_test.py
@@ -651,6 +651,30 @@ class DriveDiskTypeTests(VdsmTestCase):
 
         # When exceeded, call does nothing.
         drive.on_block_threshold(path)
+
+    def test_on_enospc_unset(self):
+        conf = drive_config(diskType=DISK_TYPE.BLOCK)
+        drive = Drive(self.log, **conf)
+        drive.threshold_state = BLOCK_THRESHOLD.UNSET
+
+        drive.on_enospc()
+        assert drive.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+
+    def test_on_enospc_set(self):
+        conf = drive_config(diskType=DISK_TYPE.BLOCK)
+        drive = Drive(self.log, **conf)
+        drive.threshold_state = BLOCK_THRESHOLD.SET
+
+        drive.on_enospc()
+        assert drive.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+
+    def test_on_enospc_exceeded(self):
+        conf = drive_config(diskType=DISK_TYPE.BLOCK)
+        drive = Drive(self.log, **conf)
+        drive.threshold_state = BLOCK_THRESHOLD.EXCEEDED
+
+        # When exceeded, call does nothing.
+        drive.on_enospc()
         assert drive.threshold_state == BLOCK_THRESHOLD.EXCEEDED
 
 


### PR DESCRIPTION
This is the first part from #124, preparing for eliminating the the delay
before extending drives (#85). The changes were reviewed in the last 3 weeks
and should be ready for merge.

Fixes:
- Fix handling of block threshold events
- Fix handling of enospc events
- Fix the way we force drive to exceeded
- Fix extending of exceeded volume, was delayed checking stale allocation

Improvements:
- Improve handling of improbable allocation
- Validate allocation only when needed
- Unify logging

Refactoring:
- Simplify the way we update block info for drives
- Simplify monitor_volumes, removing unhelpful return value and logging.
- Remove VM.monitor_volumes, minimizing coupling with vm.py
- Introduce on_enospc event handler, unifying the way we handle libvirt events.
- Report changes in Drive event handlers
- Update stale documentation
- Remove stale tests infrastructure