### PR TITLE
lvm: reload VG error handling

### DIFF
--- a/lib/vdsm/storage/exception.py
+++ b/lib/vdsm/storage/exception.py
@@ -1349,6 +1349,26 @@ class VolumeGroupDoesNotExist(StorageException):
     code = 506
     msg = "Volume Group does not exist"
 
+    def __init__(self, vg_name=None, vg_uuid=None, error=None):
+        if vg_name is None and vg_uuid is None:
+            raise ValueError("Require a VG name or UUID")
+
+        if error is not None and not isinstance(error, LVMCommandError):
+            raise TypeError(
+                f"Expecting instance of LVMCommandError, got {type(error)}")
+
+        self.vg_name = vg_name
+        self.vg_uuid = vg_uuid
+        self.error = error
+
+    @property
+    def value(self):
+        return ", ".join(f"{k}={v}" for k, v in self.__dict__.items() if v)
+
+    @classmethod
+    def from_error(cls, vg_name, error):
+        return cls(vg_name=vg_name, error=error).with_exception(error)
+
 
 class VolumeGroupRenameError(StorageException):
     code = 507

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1487,19 +1487,13 @@ def _checkpvsblksize(pvs, vgBlkSize=None):
 
 
 def checkVGBlockSizes(vg_name, vgBlkSize=None):
-    pvs = listPVNames(vg_name)
-    if not pvs:
-        raise se.VolumeGroupDoesNotExist(vg_name=vg_name)
-    _checkpvsblksize(pvs, vgBlkSize)
+    _checkpvsblksize(listPVNames(vg_name), vgBlkSize)
 
 
 def getVGBlockSizes(vg_name):
-    pvs = listPVNames(vg_name)
-    if not pvs:
-        raise se.VolumeGroupDoesNotExist(vg_name=vg_name)
     # Returning the block size of the first pv is correct since we don't allow
     # devices with different block size to be on the same VG.
-    return _getpvblksize(pvs[0])
+    return _getpvblksize(listPVNames(vg_name)[0])
 
 #
 # Public Logical volume interface
@@ -1844,11 +1838,7 @@ def getVgMetadataPv(vgName):
 
 
 def listPVNames(vgName):
-    try:
-        pvNames = _lvminfo._vgs[vgName].pv_name
-    except (KeyError, AttributeError):
-        pvNames = getVG(vgName).pv_name
-    return pvNames
+    return getVG(vgName).pv_name
 
 
 def setrwLV(vg_name, lv_name, rw=True):

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1486,17 +1486,17 @@ def _checkpvsblksize(pvs, vgBlkSize=None):
             raise se.VolumeGroupBlockSizeError(vgBlkSize, pvBlkSize)
 
 
-def checkVGBlockSizes(vgUUID, vgBlkSize=None):
-    pvs = listPVNames(vgUUID)
+def checkVGBlockSizes(vg_name, vgBlkSize=None):
+    pvs = listPVNames(vg_name)
     if not pvs:
-        raise se.VolumeGroupDoesNotExist(vg_uuid=vgUUID)
+        raise se.VolumeGroupDoesNotExist(vg_name=vg_name)
     _checkpvsblksize(pvs, vgBlkSize)
 
 
-def getVGBlockSizes(vgUUID):
-    pvs = listPVNames(vgUUID)
+def getVGBlockSizes(vg_name):
+    pvs = listPVNames(vg_name)
     if not pvs:
-        raise se.VolumeGroupDoesNotExist(vg_uuid=vgUUID)
+        raise se.VolumeGroupDoesNotExist(vg_name=vg_name)
     # Returning the block size of the first pv is correct since we don't allow
     # devices with different block size to be on the same VG.
     return _getpvblksize(pvs[0])

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1275,7 +1275,7 @@ def movePV(vgName, src_device, dst_devices):
 def getVG(vgName):
     vg = _lvminfo.getVg(vgName)  # returns single VG namedtuple
     if not vg:
-        raise se.VolumeGroupDoesNotExist(vgName)
+        raise se.VolumeGroupDoesNotExist(vg_name=vgName)
     else:
         return vg
 
@@ -1301,7 +1301,7 @@ def getVGbyUUID(vgUUID):
             log.debug("%s", e, exc_info=True)
             continue
     # If not cry loudly
-    raise se.VolumeGroupDoesNotExist("vg_uuid: %s" % vgUUID)
+    raise se.VolumeGroupDoesNotExist(vg_uuid=vgUUID)
 
 
 def getLV(vgName, lvName=None):
@@ -1489,14 +1489,14 @@ def _checkpvsblksize(pvs, vgBlkSize=None):
 def checkVGBlockSizes(vgUUID, vgBlkSize=None):
     pvs = listPVNames(vgUUID)
     if not pvs:
-        raise se.VolumeGroupDoesNotExist("vg_uuid: %s" % vgUUID)
+        raise se.VolumeGroupDoesNotExist(vg_uuid=vgUUID)
     _checkpvsblksize(pvs, vgBlkSize)
 
 
 def getVGBlockSizes(vgUUID):
     pvs = listPVNames(vgUUID)
     if not pvs:
-        raise se.VolumeGroupDoesNotExist("vg_uuid: %s" % vgUUID)
+        raise se.VolumeGroupDoesNotExist(vg_uuid=vgUUID)
     # Returning the block size of the first pv is correct since we don't allow
     # devices with different block size to be on the same VG.
     return _getpvblksize(pvs[0])

--- a/tests/storage/exception_test.py
+++ b/tests/storage/exception_test.py
@@ -25,6 +25,8 @@ import six
 
 from collections import defaultdict
 
+import pytest
+
 from vdsm.common.compat import get_args_spec
 from vdsm.common.exception import GeneralException
 from vdsm.common.exception import VdsmException
@@ -58,6 +60,11 @@ def test_collisions():
 
 def test_info():
     for obj in find_module_exceptions(storage_exception, VdsmException):
+        if obj == storage_exception.VolumeGroupDoesNotExist:
+            # Skip since a constructor parameter requires a specific type.
+            # This exception should be tested separately.
+            continue
+
         # Inspect exception object initialization parameters.
         args, varargs, kwargs = get_args_spec(obj.__init__)
 
@@ -75,6 +82,28 @@ def test_info():
             "code": e.code,
             "message": str(e)
         }
+
+
+def test_VolumeGroupDoesNotExist():
+    # Require a VG name or UUID at initialization.
+    # Empty constructor shall raise.
+    with pytest.raises(ValueError):
+        e = storage_exception.VolumeGroupDoesNotExist()
+
+    # Expected error type is LVMCommandError.
+    with pytest.raises(TypeError):
+        e = storage_exception.VolumeGroupDoesNotExist("vg-name", error="error")
+
+    # Correct initialization.
+    fake_error = storage_exception.LVMCommandError(
+        rc=5, cmd=["fake"], out=["fake output"], err=["fake error"])
+    e = storage_exception.VolumeGroupDoesNotExist("vg-name", error=fake_error)
+    assert e.error == fake_error
+    # Check error format
+    formatted = str(e)
+    assert "vg_name=vg-name" in formatted
+    assert f'error={fake_error}'.replace('\'', r'\'') in formatted
+    assert "vg_uuid=" not in formatted
 
 
 class FakeArg(int):


### PR DESCRIPTION
Currently, if we try to reload a non-existing VG that is not in the cache, we will not get any error, it will raise an exception without any context of the actual reason of the fail.

Furthermore, if the LVM command fails, it might go unnoticed, or trigger a single uninformative warning without the reason why it might have failed.

Make _reloadvgs to raise an exception if the LVM command failed and there is no output. Then, the caller will decide whether it is a real error or it was just probing.

Add tests to verify the behavior of all parts of `lvm` module that are affected by the error handling update.

Related https://github.com/oVirt/vdsm/pull/159
Signed-off-by: Albert Esteve <aesteve@redhat.com>