### PR TITLE
net: Add python3-libnmstate as explicit dependency

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -28,6 +28,7 @@ python3-decorator
 python3-devel
 python3-dmidecode
 python3-ioprocess
+python3-libnmstate
 python3-libselinux
 python3-libvirt
 python3-magic

--- a/docker/network/unit/Dockerfile.centos-8
+++ b/docker/network/unit/Dockerfile.centos-8
@@ -14,6 +14,7 @@ RUN dnf -y install dnf-plugins-core \
         libnl3 \
         nmstate \
         python3-devel \
+        python3-libnmstate \
         python3-six \
         python3-pip \
         systemd \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -23,6 +23,7 @@ RUN dnf -y install dnf-plugins-core \
         libnl3 \
         nmstate \
         python3-devel \
+        python3-libnmstate \
         python3-six \
         python3-pip \
         systemd \

--- a/vdsm.spec.in
+++ b/vdsm.spec.in
@@ -379,6 +379,7 @@ Requires:       ovirt-openvswitch >= 2.15
 Requires:       ovirt-python-openvswitch >= 2.15
 Requires:       nmstate >= 1.0
 Requires:       nmstate-plugin-ovsdb
+Requires:       python3-libnmstate
 Requires:       libnl3
 Requires:       lldpad
 Requires:       python3-six


### PR DESCRIPTION
With changes to nmstate-2.1 the python3-libnmstate
is not installed by default. This causes issues for
the unit tests as they need the library to work properly.

Add the python3-libnmstate as explicit dependency into
spec file as well, to be clear that this is required.

Signed-off-by: Ales Musil <amusil@redhat.com>