### PR TITLE
lvm_tests: use --devices instead of --config in commands

### DIFF
--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -1937,7 +1937,7 @@ def stale_lv(tmp_storage):
     commands.run([
         "lvremove",
         "--devices", dev,
-        "{}/{}".format(vg_name, stale_lv_name),
+        f"{vg_name}/{stale_lv_name}",
     ])
 
     # The cache still keeps both lvs.

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -1627,6 +1627,7 @@ def test_lv_activate_deactivate(tmp_storage):
 @requires_root
 @pytest.mark.root
 def test_lv_deactivate_in_use(tmp_storage):
+    # TODO: This test does not work in active hosts.
     dev_size = 1 * GiB
     dev = tmp_storage.create_device(dev_size)
     vg_name = str(uuid.uuid4())

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -1038,17 +1038,18 @@ def stale_pv(tmp_storage):
     pvs = sorted(pv.name for pv in lvm.getAllPVs())
     assert pvs == sorted([good_pv_name, stale_pv_name])
 
+    devices = ",".join([good_pv_name, stale_pv_name])
     # Simulate removal of the second PV on another host, leaving stale PV in
     # the cache.
     commands.run([
         "vgreduce",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", devices,
         vg_name,
         stale_pv_name,
     ])
     commands.run([
         "pvremove",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", devices,
         stale_pv_name,
     ])
 
@@ -1513,7 +1514,7 @@ def stale_vg(tmp_storage):
     # the cache.
     commands.run([
         "vgremove",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", dev2,
         stale_vg_name,
     ])
 
@@ -1753,7 +1754,7 @@ def test_lv_refresh(tmp_storage):
     # Simulate extending the LV on the SPM.
     commands.run([
         "lvextend",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", dev,
         "-L+1g",
         lv_fullname
     ])
@@ -1766,7 +1767,7 @@ def test_lv_refresh(tmp_storage):
     # Simulate extending the LV on the SPM.
     commands.run([
         "lvextend",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", dev,
         "-L+1g",
         lv_fullname
     ])
@@ -1935,7 +1936,7 @@ def stale_lv(tmp_storage):
     # the cache.
     commands.run([
         "lvremove",
-        "--config", tmp_storage.lvm_config(),
+        "--devices", dev,
         "{}/{}".format(vg_name, stale_lv_name),
     ])
 


### PR DESCRIPTION
Some commands in lvm_tests try to force the configuration by passing the `--config` option, whereas they should adapt to it and use `--devices` instead.

Fixes #163 (covers solution 1)