### PR TITLE
iscsi: Keep existing session on "session exists"

### DIFF
--- a/lib/vdsm/storage/iscsi.py
+++ b/lib/vdsm/storage/iscsi.py
@@ -231,6 +231,10 @@ def loginToIscsiNode(iface, target):
     log.info("Logging in to iscsi target %s via iface %s", target, iface.name)
     try:
         iscsiadm.node_login(iface.name, target.address, target.iqn)
+    except iscsiadm.IscsiSessionExists:
+        # We are already logged in to this node, fail the request keeping the
+        # existing session.
+        raise
     except:
         removeIscsiNode(iface, target)
         raise

--- a/lib/vdsm/storage/iscsiadm.py
+++ b/lib/vdsm/storage/iscsiadm.py
@@ -90,6 +90,10 @@ class IscsiNodeError(IscsiError):
     pass
 
 
+class IscsiSessionExists(IscsiError):
+    pass
+
+
 class IscsiSessionNotFound(IscsiError):
     pass
 
@@ -322,6 +326,9 @@ def node_login(iface, portal, targetName):
 
         if e.rc == ISCSI_ERR_LOGIN_AUTH_FAILED:
             raise IscsiAuthenticationError(e.rc, e.out, e.err)
+
+        if e.rc == ISCSI_ERR_SESS_EXISTS:
+            raise IscsiSessionExists(e.rc, e.out, e.err)
 
         raise IscsiNodeError(e.rc, e.out, e.err)
 


### PR DESCRIPTION
If logging in to a node fails with "session exists" (error 15):

    iscsiadm: initiator reported error (15 - session exists)

We use to remove the node, which disconnects the node and remove it.
This is not new behavior, but it seems that in 4.4 this cleanup was not
effective in the case of logging in to the same connection more than
once, and now it reliably disconnect the first node and leave the host
without any nodes, which makes it non operational.

Change iscsiadm to raise new IscsiSessionExists error, and keep the
existing session when handling this error.

With this change, if you try to connect to the same target more than
once, the host should end with one connected target.

Bug-Url: https://bugzilla.redhat.com/2083271
Signed-off-by: Nir Soffer <nsoffer@redhat.com>