### PR TITLE
lvm_test: increase vg test coverage

### DIFF
--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -605,7 +605,7 @@ class LVMCache(object):
                         logutils.Head(unreadable_vgs, max_items=20))
 
                 # NOTE: vgs may return useful output even on failure, so we
-                # don't retrun here.
+                # don't return here.
 
             updatedVGs = {}
             vgsFields = {}


### PR DESCRIPTION
This branch adds a couple tests to slightly improve code coverage for VG-handling methods in the `lvm` module.

Includes a small fix for a typo in the `lvm` library.

Signed-off-by: Albert Esteve <aesteve@redhat.com>