### PR TITLE
net: Fix the tuple assign

### DIFF
--- a/lib/vdsm/network/netswitch/configurator.py
+++ b/lib/vdsm/network/netswitch/configurator.py
@@ -205,7 +205,9 @@ def netinfo(vdsmnets=None, compatibility=None):
     ovs_nets, _ = util.split_switch_type(
         running_config.networks, running_config={}
     )
-    ovs_bonds = util.split_switch_type(running_config.bonds, running_config={})
+    ovs_bonds, _ = util.split_switch_type(
+        running_config.bonds, running_config={}
+    )
     if ovs_nets or ovs_bonds:
         state = nmstate.get_current_state()
         nmstate.ovs_netinfo(_netinfo, running_config.networks, state)


### PR DESCRIPTION
The tuple returned from split_switch_type
was not properly assigned to variables.
This caused the if statement to be always true,
it did not cause any issues, but the network capabilities
were also getting OvS info which wasn't necessary.

Assign it properly so only the first dictionary is used.

Signed-off-by: Ales Musil <amusil@redhat.com>