### PR TITLE
merge: consider type when reducing a volume

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -1601,7 +1601,8 @@ class BlockStorageDomain(sd.StorageDomain):
     def reduceVolume(self, imgUUID, volUUID, allowActive=False):
         with self.manifest.metadata_lock:
             vol = self.produceVolume(imgUUID, volUUID)
-            vol.reduce(vol.optimal_size(), allowActive=allowActive)
+            if vol.can_reduce():
+                vol.reduce(vol.optimal_size(), allowActive=allowActive)
 
     @staticmethod
     def findDomainPath(sdUUID):

--- a/lib/vdsm/storage/merge.py
+++ b/lib/vdsm/storage/merge.py
@@ -273,14 +273,17 @@ def finalize(subchain):
             else:
                 _finalize_internal_merge(dom, subchain)
 
-            if subchain.base_vol.chunked():
+            if subchain.base_vol.can_reduce():
                 # If the top volume is leaf, the base volume will become a leaf
                 # after the top volume is deleted.
                 optimal_size = subchain.base_vol.optimal_size(
                     as_leaf=subchain.top_vol.isLeaf())
                 actual_size = subchain.base_vol.getVolumeSize()
 
-        if subchain.base_vol.chunked() and optimal_size < actual_size:
+        # Optimal size must be computed while the image is prepared, but
+        # reducing with the volume still active will issue a warning from LVM.
+        # Thus, reduce after having teardown the volume.
+        if subchain.base_vol.can_reduce() and optimal_size < actual_size:
             _shrink_base_volume(subchain, optimal_size)
 
 


### PR DESCRIPTION
When finalizing a merge, only the format (cow) and the `optimal_size` are considered to discern when to reduce a volume. However, calculating the optimal size can be avoided in the case of a preallocated block volume, as it cannot be reduced.

Also, in the StorageDomain, `reduceVolume` can be called with no check at all, which is dangerous.

Use the volume `can_reduce` check before obtaining the optimal size, and before reducing the volume (both in the cold merge and the storage domain), so that we consider the type of volume before reducing it.

Fixes: https://github.com/oVirt/vdsm/issues/185
Bug-Url: https://bugzilla.redhat.com/2081493
Signed-off-by: Albert Esteve <aesteve@redhat.com>