### PR TITLE
Fix reduce after active layer cold merge

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -437,9 +437,14 @@ class BlockVolumeManifest(volume.VolumeManifest):
 
         return optimal_size
 
-    def optimal_size(self):
+    def optimal_size(self, as_leaf=False):
         """
         Return the optimal size of the volume, based on actual allocation.
+
+        If as_leaf is True, calculate the optimal size as if this volume is a
+        leaf. This is used when calculating the optimal size for the base
+        volume after a merge, before the top volume is deleted and the base
+        volume becomes the leaf.
 
         NOTE: The volume must be prepared so we can check the actual
         allocation.
@@ -451,7 +456,9 @@ class BlockVolumeManifest(volume.VolumeManifest):
         else:
             check = qemuimg.check(self.getVolumePath(), qemuimg.FORMAT.QCOW2)
             return self.optimal_cow_size(
-                check['offset'], self.getCapacity(), self.isLeaf())
+                check['offset'],
+                self.getCapacity(),
+                self.isLeaf() or as_leaf)
 
 
 class BlockVolume(volume.Volume):

--- a/lib/vdsm/storage/merge.py
+++ b/lib/vdsm/storage/merge.py
@@ -274,8 +274,10 @@ def finalize(subchain):
                 _finalize_internal_merge(dom, subchain)
 
             if subchain.base_vol.chunked():
-                # optimal_size must be called when the volume is prepared
-                optimal_size = subchain.base_vol.optimal_size()
+                # If the top volume is leaf, the base volume will become a leaf
+                # after the top volume is deleted.
+                optimal_size = subchain.base_vol.optimal_size(
+                    as_leaf=subchain.top_vol.isLeaf())
                 actual_size = subchain.base_vol.getVolumeSize()
 
         if subchain.base_vol.chunked() and optimal_size < actual_size:


### PR DESCRIPTION
When computing optimal size during finalize, if the top volume is a leaf
(active layer merge), the base volume will become leaf after the merge.
Compute the optimal size as if the base volume is a leaf.

Fixes #179