### PR TITLE
blockSD: avoid argument shadowing in validatePVs

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -521,7 +521,8 @@ class BlockStorageDomainManifest(sd.StorageDomainManifest):
                 "This PV is used by LVM to store the VG metadata")
 
     def _validatePVsPartOfVG(self, pv, dstPVs=None):
-        vgPvs = {os.path.basename(pv) for pv in lvm.listPVNames(self.sdUUID)}
+        vgPvs = {os.path.basename(path)
+                 for path in lvm.listPVNames(self.sdUUID)}
         if pv not in vgPvs:
             raise se.NoSuchPhysicalVolume(pv, self.sdUUID)
         if dstPVs:


### PR DESCRIPTION
BlockStorageDomainManifest._validatePVsPartOfVG receives
a 'pv' argument that is shadowed in a dict comprehension
in the first line of the method. It might be safe as it
is contained in the comprehension only, but shadowing
should be avoided anyway.

Also, 'pv' is wrong in the comprehension, since listPVNames
will return a PV path (not a PV namedtuple). So changing
'pv' for 'path' in the comprehension will both fix the
argument shadowing and use proper informative naming.

Signed-off-by: Albert Esteve <aesteve@redhat.com>