### PR TITLE
Makefile: add venv target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,9 @@ SUBDIRS = \
 # prepared before running.
 SUBDIRS += tests
 
+VENV_DIR = $(HOME)/.venv/vdsm
+VENV = $(VENV_DIR)/bin
+
 include $(top_srcdir)/build-aux/Makefile.subs
 
 # This is an *exception*, we ship also vdsm.spec so it's possible to build the
@@ -134,6 +137,12 @@ check-unit:
 
 .PHONY: lint
 lint: gitignore execcmd black flake8 pylint
+
+.PHONY: venv
+venv:
+	python3 -m venv $(VENV_DIR) && \
+	$(VENV)/python3 -m pip install --upgrade pip && \
+	$(VENV)/python3 -m pip install -r docker/requirements.txt
 
 .PHONY: tests
 tests: tox

--- a/doc/development.md
+++ b/doc/development.md
@@ -30,11 +30,7 @@ Install additional packages for Fedora, CentOS, and RHEL:
 
 Create virtual environment for vdsm:
 
-    python3 -m venv ~/.venv/vdsm
-    source ~/.venv/vdsm/bin/activate
-    pip install --upgrade pip
-    pip install -r docker/requirements.txt
-    deactivate
+    make venv
 
 
 ## Building Vdsm


### PR DESCRIPTION
Add `venv` target to the main Makefile to create a virtual environment and install the dependencies.