### PR TITLE
Fix over extend in live merge

### DIFF
--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -2827,7 +2827,7 @@ class HSM(object):
             sdUUID (str): The UUID of the storage domain that owns the volume.
             imgUUID (str): The UUID of the image contained on the volume.
             volUUID (str): The UUID of the volume you want to get the info on.
-            dest_format (str): The output format we want to measure for
+            dest_format (int): The output format we want to measure for.
             backing (bool): True if we want to measure the volume with its
                 backing chain, False otherwise. (Default: True)
             baseUUID (str): If specified, only the sub-chain will be measured.

--- a/lib/vdsm/virt/livemerge.py
+++ b/lib/vdsm/virt/livemerge.py
@@ -473,8 +473,9 @@ class DriveMerger:
             job_id=job.id,
             attempt=job.extend["attempt"])
 
-        self._vm.extend_volume(
-            drive, job.base, max_alloc, capacity, callback=callback)
+        # New size includes one chunk of free space.
+        new_size = drive.getNextVolumeSize(max_alloc, capacity)
+        self._vm.extend_volume(drive, job.base, new_size, callback=callback)
 
     def _retry_extend(self, job):
         """

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -81,6 +81,7 @@ from vdsm.common.logutils import SimpleLogAdapter, Suppressed
 from vdsm.network import api as net_api
 
 # TODO: remove these imports, code using this should use storage apis.
+from vdsm.storage import constants as sc
 from vdsm.storage import qemuimg
 from vdsm.storage import sdc
 
@@ -6067,6 +6068,27 @@ class Vm(object):
         self._updateDomainDescriptor()
 
     # Accessing storage
+
+    def measure(self, domainID, imageID, topID, dest_format, backing=True,
+                baseID=None):
+        """
+        Measure size required for merging top into base.
+        """
+        res = self.cif.irs.measure(
+            domainID,
+            imageID,
+            topID,
+            sc.name2type(dest_format),
+            backing=backing,
+            baseUUID=baseID)
+
+        if res['status']['code'] != 0:
+            message = res['status']['message']
+            raise errors.StorageUnavailableError(
+                f"Unable to measure domain {domainID} image {imageID} top "
+                f"{topID} base {baseID}: {message}")
+
+        return res['result']
 
     def getVolumeSize(self, domainID, poolID, imageID, volumeID):
         """ Return volume size info by accessing storage """

--- a/tests/virt/vmfakelib.py
+++ b/tests/virt/vmfakelib.py
@@ -57,6 +57,7 @@ class IRS(object):
         self.prepared_volumes = {}
         self.extend_requests = []
         self.sd_types = {}
+        self.measure_info = {}
 
     def getDeviceVisibility(self, guid):
         pass
@@ -66,6 +67,13 @@ class IRS(object):
 
     def inappropriateDevices(self, ident):
         pass
+
+    def measure(self, sdUUID, imgUUID, volUUID, dest_format, backing=True,
+                baseUUID=None):
+        # Return fake measure set up by the test. Not setting up anyting will
+        # fail; this is a good way to simulate measure error.
+        measure = self.measure_info[(volUUID, baseUUID)]
+        return response.success(result=measure)
 
     def getVolumeSize(self, domainID, poolID, imageID, volumeID):
         key = (domainID, imageID, volumeID)


### PR DESCRIPTION
In live merge we used a dumb way to extend the base volume before the merge, resulting
in growing the active volume by at lest 2 chunks for every live merge.

Fix by measuring the required size before the merge using the new capability to measure
a sub chain and active volume (#101).

With this change the active volume grows only if there is less then one chunk of free
space after the merge, and there is no need to shutdown the VM to reclaim unused space.

Fixes #188
Related-to: https://bugzilla.redhat.com/1993235