### PR TITLE
virt: store some guest stats during migration

### DIFF
--- a/lib/vdsm/virt/guestagent.py
+++ b/lib/vdsm/virt/guestagent.py
@@ -161,8 +161,8 @@ class GuestAgent(object):
     MAX_MESSAGE_SIZE = 1 * MiB  # for now
 
     def __init__(self, socketName, channelListener, log, onStatusChange,
-                 qgaGuestInfo, api_version=None, user='Unknown',
-                 ips=''):
+                 qgaGuestInfo, api_version=None, username='Unknown',
+                 ips='', guestFQDN='', netIfaces=[]):
         self.effectiveApiVersion = min(
             api_version or _IMPLICIT_API_VERSION_ZERO,
             _MAX_SUPPORTED_API_VERSION)
@@ -175,15 +175,15 @@ class GuestAgent(object):
         self.guestDiskMapping = {}
         self.oVirtGuestDiskMapping = {}
         self.guestInfo = {
-            'username': user,
+            'username': username,
             'memUsage': 0,
             'guestCPUCount': -1,
             'guestIPs': ips,
-            'guestFQDN': '',
+            'guestFQDN': guestFQDN,
             'session': 'Unknown',
             'appsList': (),
             'disksUsage': [],
-            'netIfaces': [],
+            'netIfaces': netIfaces,
             'memoryStats': {}}
         self._agentTimestamp = 0
         self._channelListener = channelListener
@@ -476,8 +476,13 @@ class GuestAgent(object):
                 info['appsList'] = self.guestInfo['appsList']
             if len(self.guestInfo['guestIPs']) > 0:
                 info['guestIPs'] = self.guestInfo['guestIPs']
+            # The following may be passed from migration source
             if len(self.guestInfo['guestFQDN']) > 0:
                 info['guestFQDN'] = self.guestInfo['guestFQDN']
+            if len(self.guestInfo['netIfaces']) > 0:
+                info['netIfaces'] = self.guestInfo['netIfaces']
+            if self.guestInfo['username'] != "Unknown":
+                info['username'] = self.guestInfo['username']
         qga = self._qgaGuestInfo()
         if qga is not None:
             if 'diskMapping' in qga:


### PR DESCRIPTION
We used to transfer some guest statistics to destination host before
migration. This disappeared from the code for non-obvious reasons while
moving to domain XML on engine (commit 88c6922f). Stored statistics
where username (logged in user), guestFQDN (hostname) and guestIPs
(network addresses). This commit restores transfer of username and
guestFQDN. Instead of guestIPs we transfer netIfaces, which provides
more detailed information about interfaces, and also because guestIPs is
not used in engine since 4.2.

Bug-Url: https://bugzilla.redhat.com/1853897
Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>