### PR TITLE
lvm: make reloadlvs consistent with VGs

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -215,7 +215,7 @@ def _getVolsTree(sdUUID):
 
 
 def _iter_volumes(sdUUID):
-    for lv in lvm.getLV(sdUUID):
+    for lv in lvm.getAllLVs(sdUUID):
         if lv.name in SPECIAL_LVS_V4:
             # Exclude special volumes.
             continue
@@ -1072,7 +1072,7 @@ class BlockStorageDomain(sd.StorageDomain):
         if set((STORAGE_UNREADY_DOMAIN_TAG,)) != set(vg.tags):
             raise se.VolumeGroupHasDomainTag(vgUUID)
         try:
-            lvm.getLV(vgName)
+            lvm.getAllLVs(vgName)
             raise se.StorageDomainNotEmpty(vgUUID)
         except se.LogicalVolumeDoesNotExistError:
             pass
@@ -1263,7 +1263,7 @@ class BlockStorageDomain(sd.StorageDomain):
         # Remove all volumes LV if exists
         _removeVMSfs(lvm.lvPath(sdUUID, MASTERLV))
         try:
-            lvs = lvm.getLV(sdUUID)
+            lvs = lvm.getAllLVs(sdUUID)
         except se.LogicalVolumeDoesNotExistError:
             lvs = ()  # No LVs in this VG (domain)
 

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -250,13 +250,13 @@ class TestGetAllVolumes:
     # TODO: add more tests, see fileSDTests.py
 
     def test_volumes_count(self, monkeypatch):
-        monkeypatch.setattr(lvm, 'getLV', fakeGetLV)
+        monkeypatch.setattr(lvm, 'getAllLVs', fakeGetLV)
         sdName = "3386c6f2-926f-42c4-839c-38287fac8998"
         allVols = blockSD.getAllVolumes(sdName)
         assert len(allVols) == 23
 
     def test_missing_tags(self, monkeypatch):
-        monkeypatch.setattr(lvm, 'getLV', fakeGetLV)
+        monkeypatch.setattr(lvm, 'getAllLVs', fakeGetLV)
         sdName = "f9e55e18-67c4-4377-8e39-5833ca422bef"
         allVols = blockSD.getAllVolumes(sdName)
         assert len(allVols) == 2
@@ -312,7 +312,7 @@ class TestIterVolumes:
             make_lv(name="lv2", tags=(sc.TAG_VOL_UNINIT,)),
             make_lv(name="lv3")
         ]
-        monkeypatch.setattr(lvm, 'getLV', lambda sd_uuid: lvs)
+        monkeypatch.setattr(lvm, 'getAllLVs', lambda sd_uuid: lvs)
 
         # Expecting to have only user initialized volumes.
         expected_lvs = [
@@ -352,7 +352,7 @@ class TestOccupiedSlots:
             id="missing-md-tag"),
     ])
     def test_occupied_slots(self, lvs, expected, monkeypatch):
-        monkeypatch.setattr(lvm, 'getLV', lambda sd_uuid: lvs)
+        monkeypatch.setattr(lvm, 'getAllLVs', lambda sd_uuid: lvs)
         occupied = blockSD._occupied_metadata_slots("sd-id")
         assert occupied == expected
 

--- a/tests/storage/storagefakelib.py
+++ b/tests/storage/storagefakelib.py
@@ -219,7 +219,7 @@ class FakeLVM(object):
             lv_md['tags'] = tuple(tags)
 
     def lvsByTag(self, vgName, tag):
-        return [lv for lv in self.getLV(vgName) if tag in lv.tags]
+        return [lv for lv in self.getAllLVs(vgName) if tag in lv.tags]
 
     def lvPath(self, vgName, lvName):
         return os.path.join(self.root, "dev", vgName, lvName)
@@ -276,11 +276,11 @@ class FakeLVM(object):
         return real_lvm.LV(**lv_md)
 
     def getLV(self, vgName, lvName=None):
-        if lvName is None:
-            return [self._getLV(vgName, lv)
-                    for vg, lv in self.lvmd if vg == vgName]
-        else:
-            return self._getLV(vgName, lvName)
+        return self._getLV(vgName, lvName)
+
+    def getAllLVs(self, vgName):
+        return [self._getLV(vgName, lv)
+                for vg, lv in self.lvmd if vg == vgName]
 
     def extendLV(self, vgName, lvName, size_mb, refresh=True):
         try:


### PR DESCRIPTION
LVMCache._reloadvgs has been recently refactored for better error handling.

This branch extends the same strategy to `reloadlvs`:
- Refactor the method, according to its function:
  - Run LVM command
  - Try to reload stale LVs
  - Update all LVs
- Split reload into single and multi LVs
- Raise exceptions for missing volumes from the LVMCache, only when looking for specific volumes
  - Callers should get either a valid volume or propagate an exception
  - Fixes #211

Signed-off-by: Albert Esteve <aesteve@redhat.com>