### PR TITLE
Makefile: add upgrade target and custom rpm build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache
+build
 build-aux/compile
 build-aux/config.guess
 build-aux/config.sub

--- a/Makefile.am
+++ b/Makefile.am
@@ -166,6 +166,10 @@ all-local: \
 
 clean-local: clean-build
 
+.PHONY: upgrade
+upgrade:
+	sudo dnf upgrade $(RPM_TOPDIR)/RPMS/*/*.rpm
+
 .PHONY: srpm rpm clean-build
 
 srpm: clean-build dist

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ SUBDIRS += tests
 
 VENV_DIR = $(HOME)/.venv/vdsm
 VENV = $(VENV_DIR)/bin
+RPM_TOPDIR = $(PWD)/build
 
 include $(top_srcdir)/build-aux/Makefile.subs
 
@@ -163,14 +164,18 @@ clean-storage:
 all-local: \
 	vdsm.spec
 
-.PHONY: srpm rpm
+clean-local: clean-build
 
-srpm: dist
+.PHONY: srpm rpm clean-build
+
+srpm: clean-build dist
 	rpmbuild -ts $(if $(BUILDID),--define="extra_release .$(BUILDID)") \
+		--define="_topdir $(RPM_TOPDIR)" \
 		$(DIST_ARCHIVES)
 
-rpm: dist
+rpm: clean-build dist
 	rpmbuild -ta $(if $(BUILDID),--define="extra_release .$(BUILDID)") \
+		--define="_topdir $(RPM_TOPDIR)" \
 		--define="qemu_user $(QEMUUSER)" \
 		--define="qemu_group $(QEMUGROUP)" \
 		--define="with_ovirt_vmconsole $(OVIRT_VMCONSOLE)" \
@@ -180,6 +185,9 @@ rpm: dist
 		--define="vdsm_version $(PACKAGE_VERSION)" \
 		--define="vdsm_release $(PACKAGE_RELEASE)" \
 		$(DIST_ARCHIVES)
+
+clean-build:
+	rm -rf $(RPM_TOPDIR)
 
 dist-hook: gen-VERSION gen-ChangeLog
 .PHONY: gen-VERSION gen-ChangeLog

--- a/automation/rpm.sh
+++ b/automation/rpm.sh
@@ -20,7 +20,7 @@ mkdir -p ${EXPORT_DIR}
 
 cp $PWD/lib/vdsm/api/vdsm-api.html "${EXPORT_DIR}"
 
-find ~/rpmbuild \
+find $PWD/build \
     -iname '*.rpm' \
     -exec mv {} "${EXPORT_DIR}/" \;
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -47,12 +47,11 @@ To test Vdsm (refer to tests/README for further tests information):
 
 To create an RPM:
 
-    rm -rf ~/rpmbuild/RPMS/*/vdsm*.rpm
     make rpm
 
-To update your system with local build's RPM:
+To upgrade your system with local build's RPM:
 
-    (cd ~/rpmbuild/RPMS && sudo dnf upgrade */vdsm*.rpm)
+    make upgrade
 
 
 ## Making new releases


### PR DESCRIPTION
Add the `upgrade` target to the makefile to be able to upgrade the system with the built rpm packages by just doing:

    make upgrade

Also, we move the built rpm packages from the default directory at `~/rpmbuilds` to a project-specific `build` folder, and add a `clean-build` target that is executed before building. This way we don't need to clean the folder manually, it gets cleaned when we execute `make clean` or `make rpm`.

With both new targets we can just build and deploy (upgrade) the system by doing:

    make rpm upgrade