### PR TITLE
tox.ini: allow newer black version to match click version

### DIFF
--- a/lib/vdsm/network/link/nic.py
+++ b/lib/vdsm/network/link/nic.py
@@ -47,7 +47,7 @@ def read_speed_using_sysfs(nic_name):
     # the device may have been disabled/downed after checking
     # so we validate the return value as sysfs may return
     # special values to indicate the device is down/disabled
-    if s in (2 ** 16 - 1, 2 ** 32 - 1) or s <= 0:
+    if s in (2**16 - 1, 2**32 - 1) or s <= 0:
         raise ReadSpeedValueError(s)
     return s
 

--- a/lib/vdsm/network/tc/_parser.py
+++ b/lib/vdsm/network/tc/_parser.py
@@ -47,15 +47,15 @@ def parse_rate(tokens):
     """Returns a numerical bit representation of the textual rate in tokens"""
     rate = next(tokens)
     if rate[-5:] == 'Gibit':
-        return int(float(rate[:-5]) * 1024 ** 3)
+        return int(float(rate[:-5]) * 1024**3)
     elif rate[-5:] == 'Mibit':
-        return int(float(rate[:-5]) * 1024 ** 2)
+        return int(float(rate[:-5]) * 1024**2)
     elif rate[-5:] == 'Kibit':
         return int(float(rate[:-5]) * 1024)
     elif rate[-4:] == 'Gbit':
-        return int(float(rate[:-4]) * 1000 ** 3)
+        return int(float(rate[:-4]) * 1000**3)
     elif rate[-4:] == 'Mbit':
-        return int(float(rate[:-4]) * 1000 ** 2)
+        return int(float(rate[:-4]) * 1000**2)
     elif rate[-4:] == 'Kbit':
         return int(float(rate[:-4]) * 1000)
     else:
@@ -77,11 +77,11 @@ def parse_time(tokens):
     """Returns a numerical µs representation of the textual size in tokens"""
     size = next(tokens)
     if size[-2:] == 'ms':
-        return int(float(size[:-2]) * 10 ** 3)
+        return int(float(size[:-2]) * 10**3)
     elif size[-2:] == 'us':
         return int(size[:-2])
     else:  # s
-        return int(float(size[:-1]) * 10 ** 6)
+        return int(float(size[:-1]) * 10**6)
 
 
 def parse_int(tokens, base=10):

--- a/tests/network/functional/net_qos_test.py
+++ b/tests/network/functional/net_qos_test.py
@@ -198,4 +198,4 @@ class TestNetworkHostQos(object):
 
 
 def rate(rate_in_mbps):
-    return rate_in_mbps * 1000 ** 2
+    return rate_in_mbps * 1000**2

--- a/tests/network/integration/tc_test.py
+++ b/tests/network/integration/tc_test.py
@@ -230,11 +230,11 @@ class TestPortMirror(object):
 
 HOST_QOS_OUTBOUND = {
     'ls': {
-        'm1': 4 * 1000 ** 2,  # 4Mbit/s
+        'm1': 4 * 1000**2,  # 4Mbit/s
         'd': 100 * 1000,  # 100 microseconds
-        'm2': 3 * 1000 ** 2,
+        'm2': 3 * 1000**2,
     },  # 3Mbit/s
-    'ul': {'m2': 8 * 1000 ** 2},
+    'ul': {'m2': 8 * 1000**2},
 }  # 8Mbit/s
 
 TcClasses = namedtuple('TcClasses', 'classes, default_class, root_class')
@@ -385,7 +385,7 @@ class TestConfigureOutbound(object):
                 max_rate = max(
                     [
                         float(interval['streams'][0]['bits_per_second'])
-                        // (2 ** 10)
+                        // (2**10)
                         for interval in client.out['intervals']
                     ]
                 )

--- a/tests/network/unit/netinfo_test.py
+++ b/tests/network/unit/netinfo_test.py
@@ -106,8 +106,8 @@ class TestNetinfo(object):
         values = (
             (b'0', IS_UP, 0),
             (b'-10', IS_UP, 0),
-            (str(2 ** 16 - 1).encode("utf8"), IS_UP, 0),
-            (str(2 ** 32 - 1).encode("utf8"), IS_UP, 0),
+            (str(2**16 - 1).encode("utf8"), IS_UP, 0),
+            (str(2**32 - 1).encode("utf8"), IS_UP, 0),
             (b'123', IS_UP, 123),
             (b'', IS_UP, 0),
             (b'', not IS_UP, 0),

--- a/tox.ini
+++ b/tox.ini
@@ -169,7 +169,7 @@ commands=
 sitepackages = false
 skip_install = true
 deps =
-    black==21.6b0
+    black==22.3.0
 commands =
     black \
         -l 79 \


### PR DESCRIPTION
Latest click versions are not compatible with black
version used by tox (21.6b0). To fix it we either
have to move to a more recent version of black, which
currently breaks the linter in some tests, or we downgrade
the version of click to 8.0.2.

See https://github.com/psf/black/issues/2964 for context.

Error seen when running `make lint`:
```
Traceback (most recent call last):
  File "/home/aesteve/Work/ws1/vdsm/.tox/black/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/aesteve/Work/ws1/vdsm/.tox/black/lib/python3.9/site-packages/black/__init__.py", line 1127, in patched_main
    patch_click()
  File "/home/aesteve/Work/ws1/vdsm/.tox/black/lib/python3.9/site-packages/black/__init__.py", line 1113, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/aesteve/Work/ws1/vdsm/.tox/black/lib/python3.9/site-packages/click/__init__.py)
```

This patch allows newer black versions and fixes the linting problems found.

Signed-off-by: Albert Esteve <aesteve@redhat.com>