### PR TITLE
lvm: remove renameLV and support for single LV reloading

### DIFF
--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1770,18 +1770,6 @@ def deactivateLVs(vgName, lvNames):
         _setLVAvailability(vgName, toDeactivate, "n")
 
 
-def renameLV(vg, oldlv, newlv):
-    log.info("Renaming LV (vg=%s, oldlv=%s, newlv=%s)", vg, oldlv, newlv)
-    cmd = ("lvrename",) + LVM_NOBACKUP + (vg, oldlv, newlv)
-    try:
-        _lvminfo.run_command(cmd, devices=_lvminfo._getVGDevs((vg, )))
-    except se.LVMCommandError as e:
-        raise se.LogicalVolumeRenameError.from_lvmerror(e)
-    else:
-        _lvminfo._removelvs(vg, oldlv)
-        _lvminfo._reloadlvs(vg, newlv)
-
-
 def refreshLVs(vgName, lvNames):
     log.info("Refreshing LVs (vg=%s, lvs=%s)", vgName, lvNames)
     _refreshLVs(vgName, lvNames)


### PR DESCRIPTION
`LVM.removeLV` is not used anymore and can be safely removed.

As a consequence, `LVMCache._reloadlvs` is used only for reloading all the LVs (the cost is roughly the same as reloading only one), so we can drop the support for reloading a single LV.