### PR TITLE
lvm: error handling in reloadpvs consistent with VGs

### DIFF
--- a/lib/vdsm/storage/exception.py
+++ b/lib/vdsm/storage/exception.py
@@ -1590,10 +1590,26 @@ class CouldNotRetrieveLogicalVolumesList(StorageException):
 
 
 class InaccessiblePhysDev(StorageException):
-    def __init__(self, devices):
-        self.value = "devices=%s" % (devices,)
     code = 606
     msg = "Multipath cannot access physical device(s)"
+
+    def __init__(self, devices, error=None):
+        if error is not None and not isinstance(error, LVMCommandError):
+            raise TypeError(
+                f"Expecting instance of LVMCommandError, got {type(error)}")
+        self.devices = devices
+        self.error = error
+
+    @property
+    def value(self):
+        ret_value = f"devices={self.devices}"
+        if self.error:
+            ret_value += f", error={self.error}"
+        return ret_value
+
+    @classmethod
+    def from_error(cls, devices, error):
+        return cls(devices=devices, error=error).with_exception(error)
 
 
 class PartitionedPhysDev(StorageException):


### PR DESCRIPTION
`LVMCache._reloadvgs` has been recently refactored for better error handling.

This branch extends the same strategy to `reloadpvs`:

- Refactor the method, according to its function:
  - Run LVM command
  - Try to reload stale PVs
  - Update all PVs
- Split reload into single and multi PVs
- Raise exceptions for missing volumes from the LVMCache, only when looking for specific volumes
  - Callers should get either a valid volume or propagate an exception

Signed-off-by: Albert Esteve [aesteve@redhat.com](mailto:aesteve@redhat.com)