### PR TITLE
storage.exceptions: add generic class to except with an LVM error

### DIFF
--- a/lib/vdsm/storage/exception.py
+++ b/lib/vdsm/storage/exception.py
@@ -1628,9 +1628,18 @@ class MissingTagOnLogicalVolume(StorageException):
     msg = "Missing logical volume tag."
 
 
-class LogicalVolumeDoesNotExistError(StorageException):
+class LogicalVolumeDoesNotExistError(_HoldingLVMCommandError):
     code = 610
     msg = "Logical volume does not exist"
+
+    def __init__(self, vg_name, lv_name, error=None):
+        super().__init__(error)
+        self.vg_name = vg_name
+        self.lv_name = lv_name
+
+    @classmethod
+    def from_error(cls, vg_name, lv_name, error):
+        return cls(vg_name, lv_name, error=error).with_exception(error)
 
 
 class LogicalVolumeCachingError(StorageException):

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1409,7 +1409,7 @@ def getLV(vgName, lvName=None):
     lv = _lvminfo.getLv(vgName, lvName)
     # getLV() should not return None
     if not lv:
-        raise se.LogicalVolumeDoesNotExistError("%s/%s" % (vgName, lvName))
+        raise se.LogicalVolumeDoesNotExistError(vgName, lvName)
     else:
         return lv
 

--- a/tests/storage/exception_test.py
+++ b/tests/storage/exception_test.py
@@ -88,6 +88,25 @@ def test_info():
         }
 
 
+def test_LogicalVolumeDoesNotExistError():
+    # Expected error type is LVMCommandError.
+    with pytest.raises(TypeError):
+        e = storage_exception.LogicalVolumeDoesNotExistError(
+            "vg-name", "lv-name", error="error")
+
+    # Correct initialization.
+    fake_error = storage_exception.LVMCommandError(
+        rc=5, cmd=["fake"], out=["fake output"], err=["fake error"])
+    e = storage_exception.LogicalVolumeDoesNotExistError(
+        "vg-name", "lv-name", error=fake_error)
+    assert e.error == fake_error
+    # Check error format
+    formatted = str(e)
+    assert "vg_name=vg-name" in formatted
+    assert "lv_name=lv-name" in formatted
+    assert "error=" in formatted
+
+
 def test_VolumeGroupDoesNotExist():
     # Require a VG name or UUID at initialization.
     # Empty constructor shall raise.

--- a/tests/storage/storagefakelib.py
+++ b/tests/storage/storagefakelib.py
@@ -269,7 +269,7 @@ class FakeLVM(object):
         try:
             lv = self.lvmd[(vgName, lvName)]
         except KeyError:
-            raise se.LogicalVolumeDoesNotExistError("%s/%s" % (vgName, lvName))
+            raise se.LogicalVolumeDoesNotExistError(vgName, lvName)
         lv_md = deepcopy(lv)
         lv_attr = real_lvm.LV_ATTR(**lv_md['attr'])
         lv_md['attr'] = lv_attr


### PR DESCRIPTION
`VolumeGroupDoesNotExist` exception have been recently modified so that it can hold an optional `LVMCommandError` and print the attributes in an informative manner.

Take those changes to a generic class (i.e., `_HoldingLVMCommandError`) so that we can inherit from it and have the error attribute, parameter verification and consistent logging across all classes that may need to hold an LVMCommandError.

This PR also changes `LogicalVolumeDoesNotExists` to inherit from the new generic exception to hold the LVMCommandError.

Tests have been updated accordingly.

Depends on: https://github.com/oVirt/vdsm/pull/216