### PR TITLE
volume: Requires create for qcow2 image without a parent

### DIFF
--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -850,24 +850,21 @@ class VolumeManifest(object):
            NFS < 4.2). qemu-img convert will fully allocate the entire image
            when trying to punch holes in the unallocated areas.
 
-        2. qcow2 compat=0.10 when volume does not have a parent. qemu-img
-           convert will fully allocate the image instead of skipping the
-           unallocated areas.
-           TODO: Remove when qemu-5.1.0 is available.
-           https://bugzilla.redhat.com/1858632
+        2. qcow2 image when volume does not have a parent. qemu-img convert
+           writes zero clusters for unallocated areas which is very slow with
+           a big image.
 
         When qemu-img convert creates the target image it knows that the image
         is zeroed so it can skip the unallocated areas.
+
+        For qcow2 images, creating a new image during convert creates a sparse
+        image.  This is not a problem since we don't support yet preallocated
+        qcow2 images.
         """
         if self.getFormat() == sc.RAW_FORMAT:
             return self.isSparse()
         else:
-            puuid = self.getParent()
-            if puuid and puuid != sc.BLANK_UUID:
-                return False
-
-            dom = sdCache.produce(self.sdUUID)
-            return dom.qcow2_compat() == "0.10"
+            return self.getParent() == sc.BLANK_UUID
 
     @classmethod
     def zero_initialized(cls):


### PR DESCRIPTION
Previously we requires create=True only for qcow2 images using
compat=0.10 that do not support zero clusters. This issue is not
relevant since RHEL 8.4.

Testing convert of big qcow2 image (8 TiB) show that writing zero
clusters is not fast enough for big images. When qemu-img convert
creates the target image, it knows that the image is zeroed, so it can
skip unallocated areas instead of zeroing them.

Testing copy of 8 TiB empty image shows that without -n the copy is 700
times faster:

    # time qemu-img convert -f qcow2 -O qcow2 -t none -T none -n src dst

    real    2m1.839s
    user    0m10.383s
    sys     0m7.563s

    # time qemu-img convert -f qcow2 -O qcow2 -t none -T none src dst

    real    0m0.171s
    user    0m0.111s
    sys     0m0.011s

With real images we see much lower speedup. Here is an example copy with
a 8 TiB image created with virt-builder:

    # virt-builder fedora-35 \
        --output fedora-35-8t.raw \
        --hostname=fedora-35 \
        --ssh-inject=root \
        --root-password=password:root \
        --selinux-relabel \
        --install=qemu-guest-agent \
        --size=8192G
        ...
                       Output file: /var/tmp/fedora-35-8t.raw
                       Output size: 8192.0G
                     Output format: raw
                Total usable space: 8192.0G
                        Free space: 8133.1G (99%)

    # qemu-img info /var/tmp/fedora-35-8t.raw
    image: /var/tmp/fedora-35-8t.raw
    file format: raw
    virtual size: 8 TiB (8796093022208 bytes)
    disk size: 1.5 GiB

    # qemu-img measure -O qcow2 /var/tmp/fedora-35-8t.raw
    required size: 3228303360
    fully allocated size: 8797435527168

The image was converted to qcow2 format to block volume:

    # time qemu-img convert -f raw -O qcow2 -t none -T none /var/tmp/fedora-35-8t.raw src

    real 0m35.979s
    user 0m3.303s
    sys 0m2.179s

In qcow2 format the image uses 2.2 GiB:

    # qemu-img check src
    No errors were found on the image.
    28746/134217728 = 0.02% allocated, 0.00% fragmented, 0.00% compressed clusters
    Image end offset: 2314469376

Creating new qcow2 image on destination block volume:

    # qemu-img create -f qcow2 dst 8t
    Formatting 'dst', fmt=qcow2 cluster_size=65536 extended_l2=off
    compression_type=zlib size=8796093022208 lazy_refcounts=off
    refcount_bits=16

Copying image from block volume to block volume with -n:

    # time qemu-img convert -f qcow2 -O qcow2 -t none -T none -n src dst

    real 3m7.006s
    user 0m18.817s
    sys 0m11.929s

Same copy without -n (creating new qcow2 image):

    # time qemu-img convert -f qcow2 -O qcow2 -t none -T none src dst

    real 0m59.822s
    user 0m7.632s
    sys 0m5.197s

Change Volume.requires_create() to return True for qcow2 images without
a parent.

Testing creating VM from template with the image tested above shows that
copy time decreased from 280 to 95 seconds (2.9 faster).

Fixes: #221
Fixes: 2bbe66274524 (volume: Be more careful with create=False)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>