### PR TITLE
virt: Fix long VNC passwords in vm_libvirt_hook.py

### DIFF
--- a/lib/vdsm/virt/libvirthook/vm_libvirt_hook.py
+++ b/lib/vdsm/virt/libvirthook/vm_libvirt_hook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2016-2019 Red Hat, Inc.
+# Copyright 2016-2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,12 +19,8 @@
 # Refer to the README and COPYING files for full details of the license
 #
 
-from __future__ import absolute_import
-
 import sys
 import xml.etree.ElementTree as ET
-
-import six
 
 from vdsm.virt.vmdevices import storage
 
@@ -49,8 +45,7 @@ def main(domain, event, phase, stdin=sys.stdin, stdout=sys.stdout):
         sys.exit(0)
     tree = ET.parse(stdin)
     _process_domxml(tree)
-    encoding = None if six.PY2 else 'unicode'
-    tree.write(stdout, encoding=encoding)
+    tree.write(stdout, encoding='unicode')
 
 
 if __name__ == '__main__':

--- a/lib/vdsm/virt/libvirthook/vm_libvirt_hook.py
+++ b/lib/vdsm/virt/libvirthook/vm_libvirt_hook.py
@@ -27,7 +27,7 @@ from vdsm.virt.vmdevices import storage
 
 # dynamic_ownership workaround (required for 4.2 incoming migrations)
 # not needed once we only support https://bugzilla.redhat.com/1666795
-def _process_domxml(tree):
+def _dynamic_ownership(tree):
     for xpath in (
             "./devices//disk[@type='%s']//source" %
             (storage.DISK_TYPE.BLOCK,),
@@ -40,11 +40,24 @@ def _process_domxml(tree):
             storage.disable_dynamic_ownership(element)
 
 
+# Newer versions of libvirt accept VNC passwords of the maximum length 8,
+# because QEMU uses only the first 8 characters anyway. When migrating VMs
+# from older versions with long VNC passwords, the VM fails to start. Let's
+# remove the extra unused characters to make libvirt happy.
+def _graphics_password(tree):
+    graphics = tree.find("./devices/graphics[@type='vnc'][@passwd]")
+    if graphics is not None:
+        passwd = graphics.attrib['passwd']
+        if len(passwd) > 8:
+            graphics.set('passwd', passwd[:8])
+
+
 def main(domain, event, phase, stdin=sys.stdin, stdout=sys.stdout):
     if event not in ('migrate', 'restore') or phase != 'begin':
         sys.exit(0)
     tree = ET.parse(stdin)
-    _process_domxml(tree)
+    _dynamic_ownership(tree)
+    _graphics_password(tree)
     tree.write(stdout, encoding='unicode')
 
 

--- a/tests/virt/vm_libvirt_hook_test.py
+++ b/tests/virt/vm_libvirt_hook_test.py
@@ -21,7 +21,7 @@ import io
 
 from vdsm.virt.libvirthook import vm_libvirt_hook
 
-from testlib import XMLTestCase
+from testlib import normalized
 
 
 _DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
@@ -154,14 +154,14 @@ _MODIFIED_DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
 '''
 
 
-class MigrateHookTestCase(XMLTestCase):
+class TestMigrateHook:
 
     def _test_hook(self, xml, modified_xml,
                    domain='foo', event='migrate', phase='begin'):
         stdin = io.StringIO(xml)
         stdout = io.StringIO()
         vm_libvirt_hook.main(domain, event, phase, stdin=stdin, stdout=stdout)
-        self.assertXMLEqual(stdout.getvalue(), modified_xml)
+        assert normalized(stdout.getvalue()) == normalized(modified_xml)
 
     def test_empty(self):
         xml = '<domain/>'

--- a/tests/virt/vm_libvirt_hook_test.py
+++ b/tests/virt/vm_libvirt_hook_test.py
@@ -24,7 +24,7 @@ from vdsm.virt.libvirthook import vm_libvirt_hook
 from testlib import normalized
 
 
-_DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
+_ORIG_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
                        xmlns:ovirt-vm="http://ovirt.org/vm/1.0" type="kvm">
     <name>test</name>
     <devices>
@@ -71,6 +71,19 @@ _DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
             <link state="up" />
             <source bridge="ovirtmgmt" />
         </interface>
+        <graphics autoport="yes" passwd="12characters"
+                  passwdValidTo="1970-01-01T00:00:01"
+                  port="-1" tlsPort="-1" type="vnc">
+            <channel mode="secure" name="main"/>
+            <channel mode="secure" name="inputs"/>
+            <channel mode="secure" name="cursor"/>
+            <channel mode="secure" name="playback"/>
+            <channel mode="secure" name="record"/>
+            <channel mode="secure" name="display"/>
+            <channel mode="secure" name="smartcard"/>
+            <channel mode="secure" name="usbredir"/>
+            <listen network="vdsm-ovirtmgmt" type="network"/>
+        </graphics>
     </devices>
     <metadata>
         <ns0:qos />
@@ -86,7 +99,7 @@ _DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
 </domain>
 '''
 
-_MODIFIED_DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
+_MODIFIED_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
                            xmlns:ovirt-vm="http://ovirt.org/vm/1.0" type="kvm">
     <name>test</name>
     <devices>
@@ -138,6 +151,19 @@ _MODIFIED_DISK_XML = '''<domain xmlns:ns0="http://ovirt.org/vm/tune/1.0"
             <link state="up" />
             <source bridge="ovirtmgmt" />
         </interface>
+        <graphics autoport="yes" passwd="12charac"
+                  passwdValidTo="1970-01-01T00:00:01"
+                  port="-1" tlsPort="-1" type="vnc">
+            <channel mode="secure" name="main"/>
+            <channel mode="secure" name="inputs"/>
+            <channel mode="secure" name="cursor"/>
+            <channel mode="secure" name="playback"/>
+            <channel mode="secure" name="record"/>
+            <channel mode="secure" name="display"/>
+            <channel mode="secure" name="smartcard"/>
+            <channel mode="secure" name="usbredir"/>
+            <listen network="vdsm-ovirtmgmt" type="network"/>
+        </graphics>
     </devices>
     <metadata>
         <ns0:qos />
@@ -167,5 +193,5 @@ class TestMigrateHook:
         xml = '<domain/>'
         self._test_hook(xml, xml)
 
-    def test_disks(self):
-        self._test_hook(_DISK_XML, _MODIFIED_DISK_XML)
+    def test_modifications(self):
+        self._test_hook(_ORIG_XML, _MODIFIED_XML)

--- a/tests/virt/vm_libvirt_hook_test.py
+++ b/tests/virt/vm_libvirt_hook_test.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright 2019-2020 Red Hat, Inc.
+# Copyright 2019-2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,8 +16,6 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
-
-from __future__ import absolute_import
 
 import io
 


### PR DESCRIPTION
Newer versions of libvirt accept VNC passwords of the maximum length 8,
because QEMU uses only the first 8 characters anyway.  We have already
fixed the password length in Engine but if we migrate VMs created by
older Engines they may fail to start on the destination due to the
long VNC password.

Let’s make those VMs migratable to newer hosts by fixing the password
in the libvirt hook.  We can simply remove the extra unused characters
from the password to make libvirt happy.

Bug-Url: https://bugzilla.redhat.com/2090156
