### PR TITLE
lvmlocal.conf: remove global section

### DIFF
--- a/static/usr/share/vdsm/lvmlocal.conf
+++ b/static/usr/share/vdsm/lvmlocal.conf
@@ -26,12 +26,3 @@ devices {
     # is expected to be disabled by default for both lvm2-2.02 and lvm2-2.03.
     scan_lvs = 0
 }
-
-global {
-    # Disable activation of LVs based on system-generated device events.
-    # If the device is automatically activated, it can lead to data corruption,
-    # if the LVM filter it not setup properly or doesn't assume the such
-    # device will be added. Not to run into such issue, disable auto activation.
-    # This option is supported since lvm2-2.03 (CentOS/RHEL 8 and Fedora 31).
-    event_activation = 0
-}


### PR DESCRIPTION
The event_activation option set to 0 in the global
section of the lvmlocal.conf is causing el9nodes
to fail to boot after being installed by the engine.

LVM removed support for disabling event_activation in rhel9.
Existing systems with event_activation=0 that update lvm
will no longer have static autoactivation services, and
may fail to boot (if an LV required by fstab was not
activated by the initrd).

Removing the option solves the issue. The option was
not correct for el8 systems either, it is discouraged
to use since it is not reliable (may appear to work
based on timing of device attachement). Thus, this
option can be safely removed.

The global section is left with no options whatsoever,
so it can be completely removed alongside the
event_activation configuration.

Related-to: https://bugzilla.redhat.com/2038183
Signed-off-by: Albert Esteve <aesteve@redhat.com>