### PR TITLE
lvmlocal.conf: Bump revision to fix upgrade

### DIFF
--- a/static/usr/share/vdsm/lvmlocal.conf
+++ b/static/usr/share/vdsm/lvmlocal.conf
@@ -4,7 +4,7 @@
 #   revision    used by vdsm during upgrade to determine file revision
 #   private     if set to YES, vdsm will never upgrade this file
 #
-#REVISION: 5
+#REVISION: 6
 #PRIVATE: NO
 
 devices {


### PR DESCRIPTION
When we change the content of the lvmlocal.conf file, we must bump the
revision. This is used by the lvm configurator to upgrade the file when
running `vdsm-tool configure` during upgrade.

Fixes: 4ec21db8ae83 (lvmlocal.conf: remove global section)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>