### PR TITLE
spec: Use COPR versioning in COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -13,6 +13,6 @@ srpm: installdeps
 	make dist
 	rpmbuild \
 		-D "_topdir tmp.repos" \
-		-D "release_suffix ${SUFFIX}" \
+		-D "vdsm_release ${SUFFIX}" \
 		-ts ./*.tar.gz
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
Our COPR builds are not distinguishable on a per-commit basis - they all
end up having the same version, i.e.:

 4.50.1.1-1.fc35

Because of this the newer versions are never picked up by OST.
Let's align our versioning with the rest of the projects and use
the '%{?release_suffix}' variable when it's defined.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
