### PR TITLE
tool.multipath: warn when user_friendly_names is enabled

### DIFF
--- a/lib/vdsm/storage/multipath.py
+++ b/lib/vdsm/storage/multipath.py
@@ -209,6 +209,18 @@ def is_ready():
     return "busy: false" in status
 
 
+def show_config_local():
+    """
+    Obtain the local configuration of the multipath daemon.
+    Must run as root.
+
+    Returns:
+        str: Output of the multipathd show command.
+    """
+    return commands.run(
+        [_MULTIPATHD.cmd, "show", "config", "local"]).decode('ascii')
+
+
 def reconfigure():
     """
     Invoke multipathd to reconfigure the multipaths.

--- a/tests/storage/mpathconf_test.py
+++ b/tests/storage/mpathconf_test.py
@@ -246,3 +246,143 @@ section5 {
             ])
         ]),
     ]
+
+
+def test_mpathd_ufn_enabled_single():
+    fake_conf = [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'yes'),
+        ]),
+        Section('devices', [
+            Section('device', [
+                Pair('user_friendly_names', 'no'),
+                Pair('key', 'value'),
+            ]),
+            Section('device', [
+                Pair('key', 'value')
+            ])
+        ]),
+    ]
+    issues = mpathconf._check_conf(fake_conf)
+    assert issues == [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'yes'),
+        ])
+    ]
+
+
+def test_mpathd_ufn_enabled_multiple():
+    fake_conf = [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'yes'),
+        ]),
+        Section('overrides', [
+            Pair('user_friendly_names', 'yes'),
+        ]),
+        Section('devices', [
+            Section('device', [
+                Pair('user_friendly_names', 'yes'),
+                Pair('key', 'value'),
+            ]),
+            Section('device', [
+                Pair('key1', 'value1'),
+                Pair('user_friendly_names', 'yes'),
+                Pair('key2', 'value2'),
+            ]),
+            Section('device', [
+                Pair('key', 'value')
+            ])
+        ]),
+    ]
+    issues = mpathconf._check_conf(fake_conf)
+    assert issues == [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'yes'),
+        ]),
+        Section('overrides', [
+            Pair('user_friendly_names', 'yes'),
+        ]),
+        Section('device', [
+            Pair('user_friendly_names', 'yes'),
+            Pair('key', 'value'),
+        ]),
+        Section('device', [
+            Pair('key1', 'value1'),
+            Pair('user_friendly_names', 'yes'),
+            Pair('key2', 'value2'),
+        ]),
+    ]
+
+
+def test_mpathd_ufn_blacklist():
+    fake_conf = [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'no'),
+        ]),
+        Section('blacklist', [
+            Pair('key', 'value'),
+            Section('name1', [
+                Pair('key1', 'value1'),
+                Pair('key2', 'value2'),
+            ]),
+            Section('name2', [
+                Pair('key', 'value')
+            ])
+        ]),
+        Section('blacklist_exceptions', [
+            Pair('key', 'value'),
+            Section('name3', [
+                Pair('key1', 'value1'),
+                Pair('key2', 'value2'),
+            ]),
+            Section('name4', [
+                Pair('key', 'value')
+            ])
+        ]),
+    ]
+    issues = mpathconf._check_conf(fake_conf)
+    assert not issues
+
+
+def test_mpathd_ufn_no_pairs():
+    fake_conf = [
+        Section('section1', [])
+    ]
+    issues = mpathconf._check_conf(fake_conf)
+    assert not issues
+
+
+def test_mpathd_ufn_empty():
+    fake_conf = []
+    issues = mpathconf._check_conf(fake_conf)
+    assert not issues
+
+
+def test_mpathd_ufn_all_disabled():
+    fake_conf = [
+        Section('defaults', [
+            Pair('key', 'value'),
+            Pair('user_friendly_names', 'no'),
+        ]),
+        Section('overrides', [
+            Pair('key1', 'value1'),
+            Pair('user_friendly_names', 'no'),
+            Pair('key2', 'value2'),
+        ]),
+        Section('devices', [
+            Section('device', [
+                Pair('user_friendly_names', 'no'),
+                Pair('key', 'value'),
+            ]),
+            Section('device', [
+                Pair('key', 'value')
+            ])
+        ]),
+    ]
+    issues = mpathconf._check_conf(fake_conf)
+    assert not issues


### PR DESCRIPTION
This PR updates the isconfigured check for the multipath in the vdsm-tool,
so that running:

    # vdsm-tool is-configured --module multipath

Will print a WARN message if there is any device or section in the multipath daemon configuration that enables 'user_friendly_names', as in:

```
WARNING: Invalid configuration: 'user_friendly_names' is enabled in multipath configuration:
  defaults {
    key value
    user_friendly_names yes
  }
  device {
    user_friendly_names yes
    key value
  }
This configuration is not supported and may lead to storage domain corruption.
```