### PR TITLE
mpathconf: move logic from tools.multipath to mpathconf

### DIFF
--- a/lib/vdsm/storage/mpathconf.py
+++ b/lib/vdsm/storage/mpathconf.py
@@ -22,6 +22,7 @@
 This module provides multipath configuration functionality over the host:
 - Blacklist configuration for setting WWIDs of disk devices
   which should be excluded from multipath management.
+- Vdsm-supported multipathd configuration.
 - Configuration metadata parser.
 """
 import io
@@ -30,6 +31,7 @@ import os
 import re
 
 from collections import namedtuple
+from string import Template
 
 from . import fileUtils
 
@@ -82,6 +84,215 @@ _PRIVATE_TAGS = (_PRIVATE_TAG, _OLD_PRIVATE_TAG)
 REVISION_OK = "OK"
 REVISION_OLD = "OLD"
 REVISION_MISSING = "MISSING"
+
+# Once multipathd notices that the last path has failed, it will check
+# all paths "no_path_retry" more times. If no paths are up, it will tell
+# the kernel to stop queuing.  After that, all outstanding and future
+# I/O will immediately be failed, until a path is restored. Once a path
+# is restored the delay is reset for the next time all paths fail.
+_NO_PATH_RETRY = 16
+
+_CONF_DATA = Template("""\
+$current_tag
+
+# This file is managed by vdsm.
+#
+# The recommended way to add configuration for your storage is to add a
+# drop-in configuration file in "/etc/multipath/conf.d/<mydevice>.conf".
+# Settings in drop-in configuration files override settings in this
+# file.
+#
+# If you want to modify this file, you must make it private so vdsm will
+# never modify it. To make the file private, set the second line of this
+# file to "# VDSM PRIVATE".
+
+defaults {
+
+    # Ensures fast detection of path failures.
+    #
+    # Interval between two path checks in seconds. If polling interval
+    # is longer, it will take more time to discover that a path failed
+    # or was reinstated.
+
+    polling_interval            5
+
+    # Ensure the minimal time I/O is queued when no path is available.
+    #
+    # The number of retries until disable queueing, or "fail" for
+    # immediate failure (no queueing), or "queue" for unlimited timeout.
+    #
+    # Using "queue" will cause commands run by vdsm (e.g. lvm) to get
+    # stuck for unlimited time, causing timeouts in various flows, and
+    # may cause a host to become non-responsive.
+    #
+    # Using "fail" will cause VMs to pause shortly after all paths have
+    # failed. When using a HA VM with a storage lease, the lease will be
+    # released. This may delay the time to restart the VM on another
+    # host.
+    #
+    # The recommended setting is number of retries, keeping the VM
+    # running during storage outage, for example during storage server
+    # upgrades or failover scenarios.
+    #
+    # This value should be synchronized with sanlock lease renewal
+    # timeout (8 * sanlock:io_timeout). This ensures that HA VMs with a
+    # storage lease will be terminated by sanlock if their storage lease
+    # expire, and will be started quickly on another host. If you change
+    # sanlock:io_timeout you need to update this value.
+    #
+    # This value also depends on polling_interval (5 seconds). If you
+    # change polling interval you need to update this value.
+    #
+    # The recommended setting:
+    #
+    #   8 * sanlock:io_timeout / polling_interval
+
+    no_path_retry               $no_path_retry
+
+    # Required for having same device names on all hosts.
+    # DO NOT CHANGE!
+
+    user_friendly_names         no
+
+    # Helps propagating I/O errors to processes when the last path
+    # failed.  Not necessary when using "no_path_retry fail".
+
+    flush_on_last_del           yes
+
+    # Ensures fast failover between paths.
+    #
+    # the  number  of seconds the scsi layer will wait after a problem
+    # has been detected before failing IO to devices.
+    #
+    # With iSCSI, multipath uses this value to change the iSCSI session
+    # timeout, which is 120 seconds by default.
+    #
+    # With FC, multipath sets the sysfs fast_io_fail_tmo value for the
+    # remote ports associated with the path devices.  Multipath sets
+    # this value whenever a device is reloaded (e.g. when a new path is
+    # added or removed). This will override any change made in
+    # /sys/class/fc_remote_ports/rport-*/fast_io_fail_tmo.
+    #
+    # This setting is not applicable to SAS devices.
+
+    fast_io_fail_tmo            5
+
+    # The number of seconds the scsi layer will wait after a problem has
+    # been detected before removing a device from the system.
+    #
+    # For FC this is setting the sysfs dev_loss_tmo value for
+    # the remote ports associated with the path devices.
+    #
+    # For SAS devices it is setting the I_T_nexus_loss_timeout value.
+    #
+    # There is no equivalent settable parameter for iSCSI devices so
+    # this parameter is only applicable to FC and SAS devices.
+    #
+    # Usage:
+    #
+    # - Set this if you want failed devices to be removed from the system.
+    # - Do not set this is you want failed devices to stay around, since
+    #   after they are removed, they need to be rediscovered to get them
+    #   back.
+    # - Do not set this if the root file system is multipathed. In this
+    #   case you want to set dev_loss_tmo to "infinity".  If you don't,
+    #   then if all the path devices for your root file system disappear,
+    #   udev will not be able to run to send the event to multipath to
+    #   bring the device back.
+
+    dev_loss_tmo                30
+
+    # Supports large number of paths.
+    #
+    # The maximum number of file descriptors that can be opened by
+    # multipath and multipathd. Should be set to the maximum number of
+    # paths plus 32.
+
+    max_fds                     4096
+}
+
+# Blacklist local devices, obsolete protocols, and device nodes which
+# should not be used with multipath.
+#
+# Complete list of protocols recognized by multipath:
+# scsi:fcp        Fibre Channel
+# scsi:spi        Parallel SCSI
+# scsi:ssa        Serial Storage Architecture
+# scsi:sbp        Firewire
+# scsi:srp        Infiniband RDMA
+# scsi:iscsi      Internet SCSI
+# scsi:sas        Serial Attached Storage
+# scsi:adt        Automation Drive Interface
+# scsi:ata        Advanced Technology Attachment
+# scsi:unspec     multipath unable to determine scsi transport
+# ccw             Channel Command Words
+# cciss           Command and Control Interface Subsystem
+# nvme            Non-Volatile Memory Express
+# undef           multipath unable to determine protocol
+#
+# We blacklist following protocols:
+# scsi:adt  local storage protocol
+# scsi:sbp  local storage protocol
+#
+# Other protocols are not blacklisted for following reasons:
+# scsi:fcp      officially supported
+# scsi:iscsi    officially supported
+# scsi:sas      not supported, but not blacklisting it to avoid breaking
+#               existing user setup, known to be used by users
+# cciss         not supported, but not blacklisting it to avoid breaking
+#               existing user setup, known to be used by users
+# scsi:srp      not supported, but not blacklisting it to avoid breaking
+#               existing user setup
+# ccw           not supported, but not blacklisting it to avoid breaking
+#               existing user setup
+# nvme          can be used with multipath setup, protocols like NVMe-oF will
+#               come up as nvme
+# scsi:spi      superseded by scsi:fcp, not a local device, no need to
+#               blacklist it
+# scsi:ssa      superseded by scsi:fcp, not a local device, no need to
+#               blacklist it
+#
+# Devices running scsi:ata and scsi:unspec are quite common and almost always
+# cannot create multipath, so it would be good to blacklist them. But in
+# general multipath can be create on top either of these devices, so we don't
+# black list them to avoid breaking anyone's setup.
+#
+# You can make blacklist more restrictive by creating drop-in config file,
+# e.g. /etc/multipath/conf.d/local.conf, and extend blacklist
+# according to your needs, e.g.
+#
+#   blacklist {
+#       protocol "(scsi:ata|scsi:unspec)"
+#   }
+#
+# You can also add exceptions to blacklist (see man(5) multipath.conf for more
+# details) by adding blacklist_exceptions to your drop-in configuration file,
+# e.g.
+#
+#   blacklist_exceptions {
+#       protocol "(scsi:spi|scsi:ssa)"
+#   }
+#
+# We blacklist all RADOS Block Device (RBD) devices.
+# When using Ceph, multipath prevents the rbd devices from being unmapped
+# and the devices remain busy.
+
+blacklist {
+    protocol "(scsi:adt|scsi:sbp)"
+    devnode "^(rbd)[0-9]*"
+}
+
+# Options defined here override device specific options embedded into
+# multipathd.
+
+overrides {
+    # NOTE: see comments in default section how to compute this value.
+    no_path_retry   $no_path_retry
+}
+
+""").substitute({"current_tag": CURRENT_TAG,
+                 "no_path_retry": _NO_PATH_RETRY})
+
 
 log = logging.getLogger("storage.mpathconf")
 
@@ -175,6 +386,21 @@ def read_blacklist():
         wwids.add(wwid)
 
     return wwids
+
+
+def configure_multipathd():
+    """
+    Set up multipath daemon configuration to the known and supported state.
+    The original configuration, if any, is saved.
+
+    Returns:
+        str: The path to the copy of the old multipath.conf. Can be empty.
+    """
+    backup = fileUtils.backup_file(CONF_FILE)
+
+    data = _CONF_DATA.encode('utf-8')
+    fileUtils.atomic_write(CONF_FILE, data, relabel=True)
+    return backup
 
 
 def read_metadata():

--- a/lib/vdsm/storage/mpathconf.py
+++ b/lib/vdsm/storage/mpathconf.py
@@ -414,14 +414,11 @@ def read_metadata():
     Returns:
         vdsm.storage.mpathconf.Metadata
     """
-    first = second = ''
     with open(CONF_FILE) as f:
-        mpathconf = [x.strip("\n") for x in f.readlines()]
-    try:
-        first = mpathconf[0]
-        second = mpathconf[1]
-    except IndexError:
-        pass
+        # Read only the lines that are going to be processed
+        first = f.readline()
+        second = f.readline()
+
     private = second.startswith(_PRIVATE_TAGS)
 
     if first.startswith(CURRENT_TAG):

--- a/lib/vdsm/storage/multipath.py
+++ b/lib/vdsm/storage/multipath.py
@@ -209,6 +209,14 @@ def is_ready():
     return "busy: false" in status
 
 
+def reconfigure():
+    """
+    Invoke multipathd to reconfigure the multipaths.
+    Must run as root.
+    """
+    commands.run([_MULTIPATHD.cmd, "reconfigure"])
+
+
 def resize_devices():
     """
     This is needed in case a device has been increased on the storage server

--- a/lib/vdsm/tool/configurators/multipath.py
+++ b/lib/vdsm/tool/configurators/multipath.py
@@ -22,14 +22,11 @@ from __future__ import division
 import os
 import sys
 
-from vdsm.common import cmdutils
-from vdsm.common import commands
 from vdsm.storage import mpathconf
+from vdsm.storage import multipath
 from vdsm.tool import service
 
 from . import YES, NO
-
-_MULTIPATHD = cmdutils.CommandPath("multipathd", "/usr/sbin/multipathd")
 
 
 # If multipathd is up, it will be reloaded after configuration,
@@ -76,7 +73,7 @@ def configure():
     # If any of those steps fails, we want to fail the configuration.
 
     service.service_start("multipathd")
-    commands.run([_MULTIPATHD.cmd, "reconfigure"])
+    multipath.reconfigure()
 
 
 def isconfigured():

--- a/lib/vdsm/tool/configurators/multipath.py
+++ b/lib/vdsm/tool/configurators/multipath.py
@@ -24,7 +24,6 @@ import sys
 
 from vdsm.common import cmdutils
 from vdsm.common import commands
-from vdsm.storage import fileUtils
 from vdsm.storage import mpathconf
 from vdsm.tool import service
 
@@ -32,213 +31,6 @@ from . import YES, NO
 
 _MULTIPATHD = cmdutils.CommandPath("multipathd", "/usr/sbin/multipathd")
 
-# Once multipathd notices that the last path has failed, it will check
-# all paths "no_path_retry" more times. If no paths are up, it will tell
-# the kernel to stop queuing.  After that, all outstanding and future
-# I/O will immediately be failed, until a path is restored. Once a path
-# is restored the delay is reset for the next time all paths fail.
-_NO_PATH_RETRY = 16
-
-_CONF_DATA = """\
-%(current_tag)s
-
-# This file is managed by vdsm.
-#
-# The recommended way to add configuration for your storage is to add a
-# drop-in configuration file in "/etc/multipath/conf.d/<mydevice>.conf".
-# Settings in drop-in configuration files override settings in this
-# file.
-#
-# If you want to modify this file, you must make it private so vdsm will
-# never modify it. To make the file private, set the second line of this
-# file to "# VDSM PRIVATE".
-
-defaults {
-
-    # Ensures fast detection of path failures.
-    #
-    # Interval between two path checks in seconds. If polling interval
-    # is longer, it will take more time to discover that a path failed
-    # or was reinstated.
-
-    polling_interval            5
-
-    # Ensure the minimal time I/O is queued when no path is available.
-    #
-    # The number of retries until disable queueing, or "fail" for
-    # immediate failure (no queueing), or "queue" for unlimited timeout.
-    #
-    # Using "queue" will cause commands run by vdsm (e.g. lvm) to get
-    # stuck for unlimited time, causing timeouts in various flows, and
-    # may cause a host to become non-responsive.
-    #
-    # Using "fail" will cause VMs to pause shortly after all paths have
-    # failed. When using a HA VM with a storage lease, the lease will be
-    # released. This may delay the time to restart the VM on another
-    # host.
-    #
-    # The recommended setting is number of retries, keeping the VM
-    # running during storage outage, for example during storage server
-    # upgrades or failover scenarios.
-    #
-    # This value should be synchronized with sanlock lease renewal
-    # timeout (8 * sanlock:io_timeout). This ensures that HA VMs with a
-    # storage lease will be terminated by sanlock if their storage lease
-    # expire, and will be started quickly on another host. If you change
-    # sanlock:io_timeout you need to update this value.
-    #
-    # This value also depends on polling_interval (5 seconds). If you
-    # change polling interval you need to update this value.
-    #
-    # The recommended setting:
-    #
-    #   8 * sanlock:io_timeout / polling_interval
-
-    no_path_retry               %(no_path_retry)d
-
-    # Required for having same device names on all hosts.
-    # DO NOT CHANGE!
-
-    user_friendly_names         no
-
-    # Helps propagating I/O errors to processes when the last path
-    # failed.  Not necessary when using "no_path_retry fail".
-
-    flush_on_last_del           yes
-
-    # Ensures fast failover between paths.
-    #
-    # the  number  of seconds the scsi layer will wait after a problem
-    # has been detected before failing IO to devices.
-    #
-    # With iSCSI, multipath uses this value to change the iSCSI session
-    # timeout, which is 120 seconds by default.
-    #
-    # With FC, multipath sets the sysfs fast_io_fail_tmo value for the
-    # remote ports associated with the path devices.  Multipath sets
-    # this value whenever a device is reloaded (e.g. when a new path is
-    # added or removed). This will override any change made in
-    # /sys/class/fc_remote_ports/rport-*/fast_io_fail_tmo.
-    #
-    # This setting is not applicable to SAS devices.
-
-    fast_io_fail_tmo            5
-
-    # The number of seconds the scsi layer will wait after a problem has
-    # been detected before removing a device from the system.
-    #
-    # For FC this is setting the sysfs dev_loss_tmo value for
-    # the remote ports associated with the path devices.
-    #
-    # For SAS devices it is setting the I_T_nexus_loss_timeout value.
-    #
-    # There is no equivalent settable parameter for iSCSI devices so
-    # this parameter is only applicable to FC and SAS devices.
-    #
-    # Usage:
-    #
-    # - Set this if you want failed devices to be removed from the system.
-    # - Do not set this is you want failed devices to stay around, since
-    #   after they are removed, they need to be rediscovered to get them
-    #   back.
-    # - Do not set this if the root file system is multipathed. In this
-    #   case you want to set dev_loss_tmo to "infinity".  If you don't,
-    #   then if all the path devices for your root file system disappear,
-    #   udev will not be able to run to send the event to multipath to
-    #   bring the device back.
-
-    dev_loss_tmo                30
-
-    # Supports large number of paths.
-    #
-    # The maximum number of file descriptors that can be opened by
-    # multipath and multipathd. Should be set to the maximum number of
-    # paths plus 32.
-
-    max_fds                     4096
-}
-
-# Blacklist local devices, obsolete protocols, and device nodes which
-# should not be used with multipath.
-#
-# Complete list of protocols recognized by multipath:
-# scsi:fcp        Fibre Channel
-# scsi:spi        Parallel SCSI
-# scsi:ssa        Serial Storage Architecture
-# scsi:sbp        Firewire
-# scsi:srp        Infiniband RDMA
-# scsi:iscsi      Internet SCSI
-# scsi:sas        Serial Attached Storage
-# scsi:adt        Automation Drive Interface
-# scsi:ata        Advanced Technology Attachment
-# scsi:unspec     multipath unable to determine scsi transport
-# ccw             Channel Command Words
-# cciss           Command and Control Interface Subsystem
-# nvme            Non-Volatile Memory Express
-# undef           multipath unable to determine protocol
-#
-# We blacklist following protocols:
-# scsi:adt  local storage protocol
-# scsi:sbp  local storage protocol
-#
-# Other protocols are not blacklisted for following reasons:
-# scsi:fcp      officially supported
-# scsi:iscsi    officially supported
-# scsi:sas      not supported, but not blacklisting it to avoid breaking
-#               existing user setup, known to be used by users
-# cciss         not supported, but not blacklisting it to avoid breaking
-#               existing user setup, known to be used by users
-# scsi:srp      not supported, but not blacklisting it to avoid breaking
-#               existing user setup
-# ccw           not supported, but not blacklisting it to avoid breaking
-#               existing user setup
-# nvme          can be used with multipath setup, protocols like NVMe-oF will
-#               come up as nvme
-# scsi:spi      superseded by scsi:fcp, not a local device, no need to
-#               blacklist it
-# scsi:ssa      superseded by scsi:fcp, not a local device, no need to
-#               blacklist it
-#
-# Devices running scsi:ata and scsi:unspec are quite common and almost always
-# cannot create multipath, so it would be good to blacklist them. But in
-# general multipath can be create on top either of these devices, so we don't
-# black list them to avoid breaking anyone's setup.
-#
-# You can make blacklist more restrictive by creating drop-in config file,
-# e.g. /etc/multipath/conf.d/local.conf, and extend blacklist
-# according to your needs, e.g.
-#
-#   blacklist {
-#       protocol "(scsi:ata|scsi:unspec)"
-#   }
-#
-# You can also add exceptions to blacklist (see man(5) multipath.conf for more
-# details) by adding blacklist_exceptions to your drop-in configuration file,
-# e.g.
-#
-#   blacklist_exceptions {
-#       protocol "(scsi:spi|scsi:ssa)"
-#   }
-#
-# We blacklist all RADOS Block Device (RBD) devices.
-# When using Ceph, multipath prevents the rbd devices from being unmapped
-# and the devices remain busy.
-
-blacklist {
-    protocol "(scsi:adt|scsi:sbp)"
-    devnode "^(rbd)[0-9]*"
-}
-
-# Options defined here override device specific options embedded into
-# multipathd.
-
-overrides {
-    # NOTE: see comments in default section how to compute this value.
-    no_path_retry   %(no_path_retry)d
-}
-
-""" % {"current_tag": mpathconf.CURRENT_TAG,
-       "no_path_retry": _NO_PATH_RETRY}
 
 # If multipathd is up, it will be reloaded after configuration,
 # or started before vdsm starts, so service should not be stopped
@@ -248,15 +40,11 @@ services = []
 
 def configure():
     """
-    Set up the multipath daemon configuration to the known and
-    supported state. The original configuration, if any, is saved
+    Set up the multipath daemon configuration and start the service.
     """
-    backup = fileUtils.backup_file(mpathconf.CONF_FILE)
+    backup = mpathconf.configure_multipathd()
     if backup:
-        sys.stdout.write("Previous multipath.conf copied to %s\n" % backup)
-
-    data = _CONF_DATA.encode('utf-8')
-    fileUtils.atomic_write(mpathconf.CONF_FILE, data, relabel=True)
+        sys.stdout.write(f"Previous multipath.conf copied to {backup}\n")
 
     # We want to handle these cases:
     #

--- a/tests/storage/mpathconf_test.py
+++ b/tests/storage/mpathconf_test.py
@@ -111,6 +111,15 @@ def fake_mpath_conf(tmpdir, monkeypatch):
     return fake_conf
 
 
+def test_mpath_conf_create(fake_mpath_conf):
+    # Generated multipath configuration shall contain a valid revision number.
+    mpathconf.configure_multipathd()
+    assert mpathconf.read_metadata() == mpathconf.Metadata(
+        revision=mpathconf.REVISION_OK,
+        private=False,
+    )
+
+
 def test_mpath_current_tag_conf(fake_mpath_conf):
     data = f"""\
 {mpathconf.CURRENT_TAG}


### PR DESCRIPTION
Move all the logic to handle, write, and check multipathd configuration from the tools.multipath module to mpathconf.

The multipath module will act as a wrapper of the mpathconf module for the vdsm-tool, and it may add some logging and
extra functionality on top of it, but the logic shall be kept in the storage.mpathconf module.

Add some tests to verify the functions that were moved.

Update/homogenize some minor parts of the code.

Signed-off-by: Albert Esteve <aesteve@redhat.com>