### PR TITLE
check: Fix fd leak when child process fails

### DIFF
--- a/lib/vdsm/storage/check.py
+++ b/lib/vdsm/storage/check.py
@@ -331,6 +331,13 @@ class DirectioChecker(object):
         """
         assert self._state is not IDLE
         self._reader = None
+
+        # Avoid leaking self._proc.stderr. The pipe should be closed
+        # automatically after we clear the reference to self._proc, but we see
+        # clear leak for every failing check.
+        # See https://bugzilla.redhat.com/2075795
+        self._proc.stderr.close()
+
         self._err = data
         rc = self._proc.poll()
         # About 95% of runs, the process has terminated at this point. If not,

--- a/tests/storage/check_test.py
+++ b/tests/storage/check_test.py
@@ -68,6 +68,18 @@ class TestDirectioChecker:
         with pytest.raises(exception.MiscFileReadException):
             result.delay()
 
+    @pytest.mark.xfail(reason="bug reproduced")
+    def test_path_missing_leak(self):
+        fds_before = set(os.listdir("/proc/self/fd"))
+        self.checks = 10
+        checker = check.DirectioChecker(
+            self.loop, "/no/such/path", self.complete, interval=0.1)
+        checker.start()
+        self.loop.run_forever()
+        pprint.pprint(self.results)
+        fds_after = set(os.listdir("/proc/self/fd"))
+        assert fds_before == fds_after
+
     def test_path_ok(self):
         self.checks = 1
         with temporaryPath(data=b"blah") as path:
@@ -79,6 +91,19 @@ class TestDirectioChecker:
             delay = result.delay()
             print("delay:", delay)
             assert type(delay) == float
+
+    @pytest.mark.xfail(reason="bug reproduced")
+    def test_path_ok_leak(self):
+        fds_before = set(os.listdir("/proc/self/fd"))
+        self.checks = 10
+        with temporaryPath(data=b"blah") as path:
+            checker = check.DirectioChecker(
+                self.loop, path, self.complete, interval=0.1)
+            checker.start()
+            self.loop.run_forever()
+            pprint.pprint(self.results)
+        fds_after = set(os.listdir("/proc/self/fd"))
+        assert fds_before == fds_after
 
     def test_executable_missing(self, monkeypatch):
         monkeypatch.setattr(constants, "EXT_DD", "/no/such/executable")

--- a/tests/storage/check_test.py
+++ b/tests/storage/check_test.py
@@ -68,7 +68,6 @@ class TestDirectioChecker:
         with pytest.raises(exception.MiscFileReadException):
             result.delay()
 
-    @pytest.mark.xfail(reason="bug reproduced")
     def test_path_missing_leak(self):
         fds_before = set(os.listdir("/proc/self/fd"))
         self.checks = 10
@@ -92,7 +91,6 @@ class TestDirectioChecker:
             print("delay:", delay)
             assert type(delay) == float
 
-    @pytest.mark.xfail(reason="bug reproduced")
     def test_path_ok_leak(self):
         fds_before = set(os.listdir("/proc/self/fd"))
         self.checks = 10


### PR DESCRIPTION
When using Popen.communicate() the process pipes are closed when the
child closes its end of the pipe. But in the check module we run
multiple processes in the same thread, and we read from the pipe using
asynchronous I/O. In this case we never close the child process pipe.
This should not be an issue, since the pipe should be closed
automatically when we remove the reference to the process, and we never
notice any file descriptor leak in this code.

However we see clear leak in the case when a storage domain becomes
inaccessible. Strangely, only failing checks from inaccessible storage
domains leak, and we see very clear leak of one file descriptor every 10
seconds:

    for i in $(seq 3600); do
        echo "$(date --rfc-3339=seconds), $(readlink /proc/$(pidof -x vdsmd)/fd/* | wc -l)"
        sleep 10
    done
    ...
    2022-06-07 22:52:14+03:00, 374
    2022-06-07 22:52:24+03:00, 375
    2022-06-07 22:52:34+03:00, 376
    2022-06-07 22:52:44+03:00, 377
    2022-06-07 22:52:54+03:00, 378
    2022-06-07 22:53:04+03:00, 379
    2022-06-07 22:53:14+03:00, 379
    2022-06-07 22:53:24+03:00, 380
    2022-06-07 22:53:34+03:00, 381
    2022-06-07 22:53:44+03:00, 384
    2022-06-07 22:53:54+03:00, 383
    2022-06-07 22:54:04+03:00, 384
    2022-06-07 22:54:14+03:00, 385
    2022-06-07 22:54:24+03:00, 386
    2022-06-07 22:54:34+03:00, 387
    2022-06-07 22:54:44+03:00, 388
    2022-06-07 22:54:54+03:00, 388
    2022-06-07 22:55:04+03:00, 389

I cannot explain why this happen only when the process fail and we read
an error message from stderr.

Fix by explicitly closing the child process stderr pipe when we finish
reading from it.

Bug-Url: https://bugzilla.redhat.com/2075795
Signed-off-by: Nir Soffer <nsoffer@redhat.com>