### PR TITLE
lvm: make SPM host check for VGs autoactivation field

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -1457,7 +1457,7 @@ class BlockStorageDomain(sd.StorageDomain):
                (constants.METADATA_USER, constants.METADATA_GROUP), masterDir]
         (rc, out, err) = misc.execCmd(cmd, sudo=True)
         if rc != 0:
-            self.log.error("failed to chown %s", masterDir)
+            self.log.error("failed to chown %s: %s", masterDir, err)
 
     @classmethod
     def __handleStuckUmount(cls, masterDir):

--- a/lib/vdsm/storage/exception.py
+++ b/lib/vdsm/storage/exception.py
@@ -1442,6 +1442,11 @@ class VolumeGroupReduceError(LVMCommandError):
     msg = "Cannot reduce the Volume Group"
 
 
+class VolumeGroupDisableOptionError(LVMCommandError):
+    code = 520
+    msg = "Disable a Volume Group option error"
+
+
 class CannotCreateLogicalVolume(LVMCommandError):
     code = 550
     msg = "Cannot create Logical Volume"

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -42,6 +42,7 @@ from vdsm.storage import fileSD
 from vdsm.storage import fileUtils
 from vdsm.storage import guarded
 from vdsm.storage import image
+from vdsm.storage import lvm
 from vdsm.storage import mailbox
 from vdsm.storage import merge
 from vdsm.storage import misc
@@ -1360,7 +1361,7 @@ class StoragePool(object):
         # We want to avoid looking up (vgs) of unknown block domains.
         # domUUIDs includes all the domains, file or block.
         block_mountpoint = os.path.join(sc.REPO_MOUNT_DIR, sd.BLOCKSD_DIR)
-        blockDomUUIDs = [vg.name for vg in blockSD.lvm.getVGs(domUUIDs)]
+        blockDomUUIDs = [vg.name for vg in lvm.getVGs(domUUIDs)]
         domDirs = {}  # {domUUID: domaindir}
         # Add the block domains
         for domUUID in blockDomUUIDs:

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -392,6 +392,10 @@ class StoragePool(object):
                 else:
                     self.spmMailer = None
 
+                # As SPM we can check for VGs autoactivation field and
+                # and repair them as needed.
+                lvm.check_vgs_autoactivation()
+
                 # Restore tasks is last because tasks are spm ops (spm has to
                 # be started)
                 self.taskMng.recoverDumpedTasks()
@@ -1205,6 +1209,11 @@ class StoragePool(object):
 
         if dom.getDomainClass() == sd.DATA_DOMAIN:
             self._convertDomain(dom)
+
+        # If running as SPM, check that autoactivation is disabled for all VGs
+        # before activating the SD.
+        if self.spmRole == SPM_ACQUIRED:
+            lvm.check_single_vg_autoactivation(sdUUID)
 
         dom.activate()
         # set domains also do rebuild

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -212,6 +212,7 @@ def fake_sanlock(monkeypatch):
     fs = FakeSanlock()
     monkeypatch.setattr(clusterlock, "sanlock", fs)
     monkeypatch.setattr(clusterlock, "supports_lvb", True)
+    monkeypatch.setattr(clusterlock.SANLock, "_process_fd", None)
     monkeypatch.setattr(blockSD, "sanlock", fs)
     monkeypatch.setattr(fileVolume, "sanlock", fs)
     monkeypatch.setattr(xlease, "sanlock", fs)

--- a/tests/storage/lvm_test.py
+++ b/tests/storage/lvm_test.py
@@ -1696,6 +1696,32 @@ def test_vg_no_autoactivation(tmp_storage):
 
 @requires_root
 @pytest.mark.root
+def test_vg_autoactivation_check_disabled(tmp_storage):
+    dev_size = 10 * GiB
+    dev = tmp_storage.create_device(dev_size)
+    vg_name = str(uuid.uuid4())
+    lv1_name = str(uuid.uuid4())
+    lv2_name = str(uuid.uuid4())
+
+    lvm.createVG(vg_name, [dev], "initial-tag", 128)
+    lvm.createLV(vg_name, lv1_name, 1024, activate=False)
+    lvm.createLV(vg_name, lv2_name, 1024, activate=False)
+
+    # Enable autoactivation for the VG.
+    commands.run(
+        ["vgchange", "--setautoactivation", "y", "--devices", dev, vg_name])
+
+    # Check should detect the VG with enabled autoactivation and disable it.
+    lvm.check_vgs_autoactivation()
+
+    # LVM command to autoactivate all LVs of the VG, but is disabled.
+    commands.run(["vgchange", "--devices", dev, "-a", "ay", vg_name])
+    assert not lvm.getLV(vg_name, lv1_name).active
+    assert not lvm.getLV(vg_name, lv2_name).active
+
+
+@requires_root
+@pytest.mark.root
 def test_lv_activate_deactivate(tmp_storage):
     dev_size = 10 * GiB
     dev = tmp_storage.create_device(dev_size)


### PR DESCRIPTION
Add a check for the autoactivation attribute of the VGs. For each VGs in the LVMCache:

1. Obtain the autoactivation field of each VG
   a. If it fails (LVM exception), raise `VolumeGroupDoesNotExist`
2. Check if the retrieved autoactivation is enabled, and if so:
   a. Log a warning and try to disable it
   b. If it fails at disabling the option, raise a `VolumeGroupDisableOptionError` <-- __new exception__ (will it cause problems in the engine side raising a new exception type? @bennyz @barpavel )

Changing VGs can be done only by the SPM host. Other hosts cannot fix this issue.
Add a flow on the SPM checking VG configuration and fixing it:
- When starting the SPM. All VGs available in the host are checked.
  - If an error occurs (e.g., LVM error), log a warning but do not raise.
  - Since we check all VGs the error may be unrelated (e.g., stall LVMCache), and raising would break the whole SPM start flow.
- When activating a storage domain. Only the associated VG is checked.
  - If an error occurs, we raise.
  - In this case it will fail to activate the volume from the engine, and it’ll have to be retried. Either way, if the VG is not available in the LVM, the SD activation would fail nonetheless.

_Does it affect detach storage domain and attaching to an older system?_

No real change has done to the SD. It should not cause any trouble. The only thing to consider may be the new Exception added. But given that the new checks will not run in older systems, they will not trigger the Exception. So to my understanding it shall have back compatibility.

_How this change should be tested?_

Added lvm and blocksd tests to verify the new flow.

It may also be nice to verify it in a VM (not done yet):
- Have a cluster with hosts in maintenance mode
- Manually enable autoactivation in one of the SDs in the host (will the VG be available in maintenance mode?)
- Activate a host, it will start the SPM and log a warning.
- Detach the SD.
- Enable autoactivation for the detached SD.
- Reattach the SD, it will succeed and log a warning.

Depends on https://github.com/oVirt/vdsm/pull/234 (should be integrated first) -- _DONE_.
Fixes: https://github.com/oVirt/vdsm/issues/237
Signed-off-by: Albert Esteve [aesteve@redhat.com](mailto:aesteve@redhat.com)
