### PR TITLE
virt: fix graphics configuration when resuming from hibernation

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -2827,7 +2827,6 @@ class Vm(object):
                     if 'vmName' in self.conf:
                         srcDomXML = self._correct_disk_volumes_from_conf(
                             srcDomXML)
-                    srcDomXML = self._correctGraphicsConfiguration(srcDomXML)
                 else:
                     srcDomXML = self._connection.saveImageGetXMLDesc(fname)
                     # Modify CPU pinning -- remove pinning saved during
@@ -2837,6 +2836,15 @@ class Vm(object):
                     dom = cpumanagement.replace_cpu_pinning(
                         self, dom, self._initial_vcpupin)
                     srcDomXML = xmlutils.tostring(dom)
+                # We need to set `passwd` attribute to graphics devices
+                # otherwise libvirt would remove the `passwdValidTo` attribute
+                # and that would cause other errors in our validation code
+                # elsewhere. We might call `saveImageGetXMLDesc()` with
+                # `VIR_DOMAIN_SAVE_IMAGE_XML_SECURE` flag to retrieve the
+                # stored password, but our passwords are temporary so this
+                # does not bring any value and we risk leaking the password
+                # into the log.
+                srcDomXML = self._correctGraphicsConfiguration(srcDomXML)
                 hooks.before_vm_dehibernate(
                     srcDomXML, self._custom,
                     {'FROM_SNAPSHOT': str(fromSnapshot)})


### PR DESCRIPTION
Somehow libvirt drops `passwdValidUntil` attribute from domain XML when
when we pass XML that has no `passwd` attribute to restoreFlags(). Same
happens when restoring from snapshot with memory and we can use the same
method to mitigate the problem.

An alternative would be to pass `VIR_DOMAIN_SAVE_IMAGE_XML_SECURE` flag
to `saveImageGetXMLDesc()` call. That way libvirt would not hide the
`passwd` from us. But since our passwords to graphics console are
temporary this does not add any value. Also we would leak the console
password to the logs which is not favorable even though the password is
likely to be invalid at the time of resume.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>