### PR TITLE
virt: Replace CPU pinning when resuming snapshot with memory 

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -2829,13 +2829,6 @@ class Vm(object):
                             srcDomXML)
                 else:
                     srcDomXML = self._connection.saveImageGetXMLDesc(fname)
-                    # Modify CPU pinning -- remove pinning saved during
-                    # hibernation and replace it with pinning provided by
-                    # engine in API call.
-                    dom = xmlutils.fromstring(srcDomXML)
-                    dom = cpumanagement.replace_cpu_pinning(
-                        self, dom, self._initial_vcpupin)
-                    srcDomXML = xmlutils.tostring(dom)
                 # We need to set `passwd` attribute to graphics devices
                 # otherwise libvirt would remove the `passwdValidTo` attribute
                 # and that would cause other errors in our validation code
@@ -2845,6 +2838,13 @@ class Vm(object):
                 # does not bring any value and we risk leaking the password
                 # into the log.
                 srcDomXML = self._correctGraphicsConfiguration(srcDomXML)
+                # Modify CPU pinning -- remove pinning saved during
+                # hibernation/snapshot and replace it with pinning provided by
+                # engine in API call.
+                dom = xmlutils.fromstring(srcDomXML)
+                dom = cpumanagement.replace_cpu_pinning(
+                    self, dom, self._initial_vcpupin)
+                srcDomXML = xmlutils.tostring(dom)
                 hooks.before_vm_dehibernate(
                     srcDomXML, self._custom,
                     {'FROM_SNAPSHOT': str(fromSnapshot)})


### PR DESCRIPTION
When resuming a live snapshot with memory the domain XML contains CPU
pinning that has been used at the time the snapshot was taken. Such
pinning is likely to be invalid when the snapshot is resumed. Engine
passes new CPU pinning configuration in API and it should be honored.
