### PR TITLE
storageServer: fix and improve iscsi connect error logging

### DIFF
--- a/lib/vdsm/storage/storageServer.py
+++ b/lib/vdsm/storage/storageServer.py
@@ -602,6 +602,9 @@ class IscsiConnection(Connection):
             else:
                 logins.append(con)
 
+        if not logins:
+            return results
+
         # Run login to nodes in parallel. This operations happen on remote
         # iscsi server and if the some targets are not available, the operation
         # can take quite some time (by default 120 seconds) and can cause

--- a/lib/vdsm/storage/storageServer.py
+++ b/lib/vdsm/storage/storageServer.py
@@ -595,8 +595,8 @@ class IscsiConnection(Connection):
                 con.setup_node()
             except Exception as err:
                 log.error(
-                    "Could configure connection to % and iface %s",
-                    con.target, con.iface)
+                    "Could not configure connection to %s and iface %s: %s",
+                    con.target, con.iface, err)
                 status, _ = cls.translate_error(err)
                 results.append((con, status))
             else:


### PR DESCRIPTION
When seting up an iscsi node for a connection fails, the error logged had a typo.

Fix and improve it by adding the reason of the error to the logs.

Fixes: https://github.com/oVirt/vdsm/issues/252
Signed-off-by: Albert Esteve <aesteve@redhat.com>