### PR TITLE
hsm: connectStorageServer receive device list

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -1130,9 +1130,9 @@ class StoragePool(APIBase):
         return self._irs.connectStoragePool(
             self._UUID, hostID, masterSdUUID, masterVersion, domainDict)
 
-    def connectStorageServer(self, domainType, connectionParams):
-        return self._irs.connectStorageServer(domainType, self._UUID,
-                                              connectionParams)
+    def connectStorageServer(self, domainType, connectionParams, devlist=None):
+        return self._irs.connectStorageServer(
+            domainType, self._UUID, connectionParams, devlist)
 
     def create(self, name, masterSdUUID, masterVersion, domainList,
                lockRenewalIntervalSec, leaseTimeSec, ioOpTimeoutSec,

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -10643,6 +10643,13 @@ StoragePool.connectStorageServer:
         name: connectionParams
         type:
         - *ConnectionRefParameters
+
+    -   defaultvalue: null
+        description: An array of device names with which the connections depend
+        name: devlist
+        added: '4.5'
+        type:
+        - string
     return:
         description: The status of each connection attempt
         type:

--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -2155,7 +2155,7 @@ class HSM(object):
 
     @deprecated
     @public
-    def connectStorageServer(self, domType, spUUID, conList):
+    def connectStorageServer(self, domType, spUUID, conList, guids=None):
         """
         Connects to a storage low level entity (server).
 
@@ -2165,6 +2165,8 @@ class HSM(object):
         :param conList: A list of connections. Each connection being a dict
                         with keys depending on the type
         :type conList: list
+        :param guids: List of device GUIDs to check.
+        :type guids: list
 
         :returns: a list of statuses status will be 0 if connection was
                   successful
@@ -2178,7 +2180,7 @@ class HSM(object):
                 "domType=%s, spUUID=%s, conList=%s" %
                 (domType, spUUID, conList)))
 
-        results = storageServer.connect(domType, conList)
+        results = storageServer.connect(domType, conList, guids)
 
         # In case there were changes in devices size
         # while the VDSM was not connected, we need to

--- a/tests/storage/storageserver_test.py
+++ b/tests/storage/storageserver_test.py
@@ -297,28 +297,30 @@ class TestGlusterFSNotAccessibleConnection:
         assert gluster.options == userMountOptions
 
 
-def test_prepare_connection_without_initiator_name():
-    con_def = [{
-        "password": "password",
-        "port": "3260",
-        "iqn": "iqn.2016-01.com.ovirt:444",
-        "connection": "192.168.1.2",
-        "ipv6_enabled": "false",
-        "id": "994a711a-60f3-411a-aca2-0b60f01e8b8c",
-        "user": "",
-        "tpgt": "1",
-    }]
+class TestIscsiConnection:
 
-    con_class, cons = storageServer._prepare_connections(
-        sd.ISCSI_DOMAIN, con_def)
-    con = cons[0]
+    def test_prepare_connection_without_initiator_name(self):
+        con_def = [{
+            "password": "password",
+            "port": "3260",
+            "iqn": "iqn.2016-01.com.ovirt:444",
+            "connection": "192.168.1.2",
+            "ipv6_enabled": "false",
+            "id": "994a711a-60f3-411a-aca2-0b60f01e8b8c",
+            "user": "",
+            "tpgt": "1",
+        }]
 
-    # Check we get right connection class.
-    assert con_class == IscsiConnection
+        con_class, cons = storageServer._prepare_connections(
+            sd.ISCSI_DOMAIN, con_def)
+        con = cons[0]
 
-    # Connection class has to be same type as actual connection object.
-    assert con_class == type(con)
+        # Check we get right connection class.
+        assert con_class == IscsiConnection
 
-    # Unset keys raise KeyError
-    with pytest.raises(KeyError):
-        con.iface.initiatorName
+        # Connection class has to be same type as actual connection object.
+        assert con_class == type(con)
+
+        # Unset keys raise KeyError
+        with pytest.raises(KeyError):
+            con.iface.initiatorName

--- a/tests/storage/storageserver_test.py
+++ b/tests/storage/storageserver_test.py
@@ -23,6 +23,7 @@ import random
 
 import pytest
 
+from vdsm.storage import iscsi
 from vdsm.storage import sd
 from vdsm.storage import storageServer
 from vdsm.storage.storageServer import GlusterFSConnection
@@ -301,6 +302,21 @@ class TestGlusterFSNotAccessibleConnection:
 
 
 class TestIscsiConnection:
+
+    class FakeIscsi():
+
+        def __init__(self):
+            self.connections = []
+
+        def loginToIscsiNode(self, iface, target):
+            self.connections.append(target)
+
+    @pytest.fixture
+    def fake_iscsi(self, monkeypatch):
+        fake_iscsi = self.FakeIscsi()
+        monkeypatch.setattr(
+            iscsi, 'loginToIscsiNode', fake_iscsi.loginToIscsiNode)
+        return fake_iscsi
 
     @pytest.fixture
     def fake_connection(self):


### PR DESCRIPTION
When connecting a device to a host, add an option for the
caller to specify the list of devices to wait for in
StoragePool.connectStorageServer.

By default, Vdsm uses udevadm settle and 5 seconds timeout
to make sure devices are settled before continuing after
setting up an iscsi device, but that is still not robust
enough and can break due to a race condition.

By telling Vdsm which devices must exist on the host
when connecting to a server for making a direct LUN
available, we can make the API more robust.

Bug-Url: https://bugzilla.redhat.com/2074029
Signed-off-by: Albert Esteve <aesteve@redhat.com>