### PR TITLE
iscsiadm: Consider session exists as success

### DIFF
--- a/lib/vdsm/storage/iscsi.py
+++ b/lib/vdsm/storage/iscsi.py
@@ -231,10 +231,6 @@ def loginToIscsiNode(iface, target):
     log.info("Logging in to iscsi target %s via iface %s", target, iface.name)
     try:
         iscsiadm.node_login(iface.name, target.address, target.iqn)
-    except iscsiadm.IscsiSessionExists:
-        # We are already logged in to this node, fail the request keeping the
-        # existing session.
-        raise
     except:
         removeIscsiNode(iface, target)
         raise


### PR DESCRIPTION
If logging in to target fails with "session exist" error, consider the
login successful.

The issue happens when a host has duplicate portals with the same
address, port, iface:

    # iscsiadm -m node -P1
    Target: iqn.2003-01.org.alpine.01
            Portal: 192.168.122.34:3260,1
                    Iface Name: default
            Portal: 192.168.122.34:3260,2
                    Iface Name: default

iscsiadm tries to login to both portals, but it cannot create more than
one session for the same address, port, iface, so it logs in the one of
the portals and complain about the second:

    # iscsiadm -m node -T iqn.2003-01.org.alpine.01 -p 192.168.122.34:3260,1 -l
    Logging in to [iface: default, target: iqn.2003-01.org.alpine.01, portal: 192.168.122.34,3260]
    Logging in to [iface: default, target: iqn.2003-01.org.alpine.01, portal: 192.168.122.34,3260]
    Login to [iface: default, target: iqn.2003-01.org.alpine.01, portal: 192.168.122.34,3260] successful.
    iscsiadm: Could not login to [iface: default, target: iqn.2003-01.org.alpine.01, portal: 192.168.122.34,3260].
    iscsiadm: initiator reported error (15 - session exists)
    iscsiadm: Could not log into all portals

After the failure, we are left with connected session:

    # iscsiadm -m session
    tcp: [27] 192.168.122.34:3260,1 iqn.2003-01.org.alpine.01 (non-flash)

So while the host iscsi db needs fixing, the host can function normally
and we don't want to make it non-operational.

To help users fix the bad configuration, we log a new warning:

2022-06-20 18:47:23,308+0300 WARN  (iscsi-login/2) [storage.iscsiadm] Duplicate portals
for target iqn.2003-01.org.alpine.01 iface default portal 192.168.122.34:3260,1:
Command ... failed with rc=15 out=... err=b'iscsiadm: Could not login to [iface: default,
target: iqn.2003-01.org.alpine.01, portal: 192.168.122.34,3260].\niscsiadm: initiator
reported error (15 - session exists)\niscsiadm: Could not log into all portals\n'

Bug-Url: https://bugzilla.redhat.com/2097614
Signed-off-by: Nir Soffer <nsoffer@redhat.com>