### PR TITLE
lvmlocal.conf: Disable multipath_wwids_file usage

### DIFF
--- a/static/usr/share/vdsm/lvmlocal.conf
+++ b/static/usr/share/vdsm/lvmlocal.conf
@@ -4,7 +4,7 @@
 #   revision    used by vdsm during upgrade to determine file revision
 #   private     if set to YES, vdsm will never upgrade this file
 #
-#REVISION: 6
+#REVISION: 7
 #PRIVATE: NO
 
 devices {
@@ -25,4 +25,11 @@ devices {
     # causing a performance issue. Hence we disable this option, though it
     # is expected to be disabled by default for both lvm2-2.02 and lvm2-2.03.
     scan_lvs = 0
+
+    # Disable multipath component detection using /etc/multipath/wwids file.
+    # This feature is need only when not using lvm filter or lvm devices.
+    # Enabling it may casue lvm to ignore devices in the wwids file even if
+    # they are blacklisted in multipath cofiguration. The result is a host
+    # failing to boot.
+    multipath_wwids_file = ""
 }


### PR DESCRIPTION
In RHEL 8.6, LVM added detection of multipath components using the
multipath wwids file (/etc/multipath/wwids). Unfortunately this
incorrectly detect blacklist multipath devices. This causes
vgimportdevices to skip the devices when adding to the devices file, and
the result is host failing to boot.

Since we always use lvm devices or filter, this feature is not helpful
for our use case, and can be safely disabled.

Bug-Url: https://bugzilla.redhat.com/2090169
Related-to: https://bugzilla.redhat.com/2076262

Signed-off-by: Nir Soffer <nsoffer@redhat.com>