### PR TITLE
contrib/target: Support non-default tpgt

### DIFF
--- a/contrib/target
+++ b/contrib/target
@@ -92,6 +92,12 @@ def main():
              "detault portal (0.0.0.0:3260). The default portal does"
              "not work with existing targets with non default portals.")
 
+    parser.add_argument(
+        "--tpgt",
+        type=int,
+        default=1,
+        help="Target portal group tag (default 1).")
+
     args = parser.parse_args()
 
     host_name = platform.node()
@@ -159,6 +165,7 @@ def create_target(args, target_iqn, target_dir, exists=False):
     print("  exists:        %s" % args.exists)
     print("  portals:       %s" % ", ".join(
         format_portal(p) for p in args.portal))
+    print("  tpgt:          %s" % args.tpgt)
     print()
 
     if not confirm("Create target? [N/y]: "):
@@ -170,7 +177,17 @@ def create_target(args, target_iqn, target_dir, exists=False):
     print("Creating target %r" % target_iqn)
     subprocess.check_call(["targetcli", "/iscsi", "create", target_iqn])
 
-    portals_path = "/iscsi/%s/tpg1/portals" % target_iqn
+    iqn_path = "/iscsi/%s" % target_iqn
+    tpg_path = iqn_path + "/tpg%s" % args.tpgt
+
+    # New target always use tpgt=1. If the user want a different tpgt, we need
+    # to remove /tpg1 and create a new one instead.
+    if args.tpgt != 1:
+        subprocess.check_call(["targetcli", iqn_path, "delete", "tpg1"])
+        subprocess.check_call(
+            ["targetcli", iqn_path, "create", "tpg%s" % args.tpgt])
+
+    portals_path = tpg_path + "/portals"
 
     print("Checking if target has the default portal")
     cp = subprocess.run(
@@ -190,8 +207,7 @@ def create_target(args, target_iqn, target_dir, exists=False):
             ["targetcli", portals_path, "create", str(address), str(port)])
 
     print("Setting permissions (any host can access this target)")
-    tpg1_path = "/iscsi/%s/tpg1" % target_iqn
-    subprocess.check_call(["targetcli", tpg1_path, "set", "attribute",
+    subprocess.check_call(["targetcli", tpg_path, "set", "attribute",
                            "authentication=0",
                            "demo_mode_write_protect=0",
                            "generate_node_acls=1",
@@ -201,7 +217,7 @@ def create_target(args, target_iqn, target_dir, exists=False):
     print("Creating disks")
 
     fileio_path = "/backstores/fileio"
-    luns_path = "/iscsi/%s/tpg1/luns" % target_iqn
+    luns_path = tpg_path + "/luns"
     write_back = "write_back={}".format("true" if args.cache else "false")
 
     for n in range(args.lun_count):


### PR DESCRIPTION
New targets always use tpgt=1, which makes it hard to simulate issues
with server that use unique tpgt tags (e.g. 1034). Add --tpgt argument
to allow creating targets with custom tpgt.

Here is an example create a target with custom tpgt:

    # ./target create 05 --lun-count 2 --cache --portal 192.168.122.34 --portal 192.168.122.35 --tpgt 50

    Creating target
      target_name:   05
      target_iqn:    iqn.2003-01.org.alpine.05
      target_dir:    /target/05
      lun_count:     2
      lun_size:      100 GiB
      cache:         True
      exists:        False
      portals:       192.168.122.34:3260, 192.168.122.35:3260
      tpgt:          50

    Create target? [N/y]: y

This creates a target with:

    alpine:~# targetcli ls /iscsi/iqn.2003-01.org.alpine.05
    o- iqn.2003-01.org.alpine.05 ............................ [TPGs: 1]
      o- tpg50 .................................... [gen-acls, no-auth]
        o- acls ............................................. [ACLs: 0]
        o- luns ............................................. [LUNs: 2]
        | o- lun0 ... [fileio/05-00 (/target/05/00) (default_tg_pt_gp)]
        | o- lun1 ... [fileio/05-01 (/target/05/01) (default_tg_pt_gp)]
        o- portals ....................................... [Portals: 2]
          o- 192.168.122.34:3260 ................................. [OK]
          o- 192.168.122.35:3260 ................................. [OK]

Related-to: https://bugzilla.redhat.com/2097614
Signed-off-by: Nir Soffer <nsoffer@redhat.com>