### PR TITLE
tox: fix path in the posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,8 @@ commands =
     --cov=vdsm.storage \
     --cov-report=html:htmlcov-storage \
     --cov-fail-under={env:STORAGE_COVERAGE:68} \
-    {posargs:storage}
+    {posargs} \
+    storage
 
 [testenv:virt]
 passenv = {[base]passenv}
@@ -109,7 +110,8 @@ commands =
         --durations=5 \
         --cov=vdsm.virt \
         --cov-report=html:htmlcov-virt \
-        {posargs:virt}
+        {posargs} \
+        virt
 
 [testenv:gluster]
 passenv = {[base]passenv}
@@ -123,7 +125,8 @@ commands =
         --durations=5 \
         --cov=vdsm.gluster \
         --cov-report=html:htmlcov-gluster \
-        {posargs:gluster}
+        {posargs} \
+        gluster
 
 [testenv:hooks]
 passenv = {[base]passenv}


### PR DESCRIPTION
In the tox.ini we use the posargs to pass the search path
with the syntax '{posargs:path}'. In the cases where
we had multiple search paths, we use '{posargs} path1 path2'.

The first case was not working and causing the path to be lost
in the pytest command. In general, this was not detected because
we either execute all tests in an environment, or a specific test,
so the search path is not used. The issue arises when the search
path is required, e.g., passing an additional marker without
specifying a single test to be run:

  $ tox -e storage -- -m 'not root'

Will result in a failure when looking for tests with the specified
marker in path that pertains to a different environment.

We need to use the syntax '{posargs} path' to fix the issue.

Signed-off-by: Albert Esteve <aesteve@redhat.com>