### PR TITLE
hook-log-console: Don't require exact vdsm match

### DIFF
--- a/vdsm.spec.in
+++ b/vdsm.spec.in
@@ -502,7 +502,7 @@ The VM must be pinned to the host.
 %package hook-log-console
 Summary:        Log VM's serial console to a file
 BuildArch:      noarch
-Requires:       %{name} == %{version}
+Requires:       %{name}
 
 %description hook-log-console
 This hook allows logging a VM serial console to a file.


### PR DESCRIPTION
There's no reason to require exactly the same vdsm version
for the hook to work. It causes issues when installing on top of
node/rhvh, so let's use a more relaxed requirement.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
