### PR TITLE
docker: add vdsm user to container image

### DIFF
--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -60,6 +60,9 @@ RUN dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
         xfsprogs \
     && dnf clean all
 
+# Create vdsm user with groups kvm,qemu,sanlock
+RUN useradd --system -m -u 36 -N -G 36,107,179 vdsm
+
 # Add gdb python support.
 RUN debuginfo-install -y python3 \
     && dnf clean all

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -1,8 +1,8 @@
 FROM quay.io/centos/centos:stream8
 
 # Add runtime dependencies.
-RUN dnf install -y \
-        http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
+RUN dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8 \
+    && dnf install -y ovirt-release-master \
     && dnf update -y \
     && dnf install -y \
         autoconf \
@@ -49,7 +49,7 @@ RUN dnf install -y \
         python3-sanlock \
         python3-six \
         python3-yaml \
-        qemu-img-6.0.0 \
+        qemu-img \
         redhat-rpm-config \
         rpm-build \
         sanlock \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -30,5 +30,5 @@ $(targets):
 
 push:
 	for name in $(targets); do \
-		podman push $(prefix)-$$name ovirtorg/$(prefix)-$$name; \
+		podman push $(prefix)-$$name quay.io/ovirt/$(prefix)-$$name; \
 	done


### PR DESCRIPTION
Create an unprivileged vdsm user in the container image to enable running tests as non-root.

This could be achieved by using other unprivileged user, e.g., `nobody`, but creating vdsm allows creating tests specific for vdsm user that run both in the pipelines and in the test VMs.

Signed-off-by: Albert Esteve <aesteve@redhat.com>