### PR TITLE
Fix a busy loop after socket is closed

### DIFF
--- a/lib/yajsonrpc/betterAsyncore.py
+++ b/lib/yajsonrpc/betterAsyncore.py
@@ -122,11 +122,11 @@ class Dispatcher(asyncore.dispatcher):
     def recv(self, buffer_size):
         try:
             data = self.socket.recv(buffer_size)
-            if data == "":
+            if data == b'':
                 # a closed connection is indicated by signaling
                 # a read condition, and having recv() return 0.
                 self.handle_close()
-                return ''
+                return b''
             else:
                 return data
         except sslutils.SSLError as e:
@@ -134,7 +134,7 @@ class Dispatcher(asyncore.dispatcher):
                 return None
             self._log.debug('SSL error receiving from %s: %s', self, e)
             self.handle_close()
-            return ''
+            return b''
         except socket.error as why:
             # winsock sometimes raises ENOTCONN
             # according to asyncore.dispatcher#recv docstring
@@ -143,7 +143,7 @@ class Dispatcher(asyncore.dispatcher):
                 return None
             elif why.args[0] in asyncore._DISCONNECTED:
                 self.handle_close()
-                return ''
+                return b''
             else:
                 raise
 

--- a/lib/yajsonrpc/betterAsyncore.py
+++ b/lib/yajsonrpc/betterAsyncore.py
@@ -52,7 +52,10 @@ class Dispatcher(asyncore.dispatcher):
         self._delegate_call("handle_connect")
 
     def handle_close(self):
-        self._delegate_call("handle_close")
+        try:
+            self._delegate_call("handle_close")
+        finally:
+            self.close()
 
     def handle_accept(self):
         self._delegate_call("handle_accept")

--- a/lib/yajsonrpc/betterAsyncore.py
+++ b/lib/yajsonrpc/betterAsyncore.py
@@ -46,6 +46,7 @@ class Dispatcher(asyncore.dispatcher):
         asyncore.dispatcher.__init__(self, sock=sock, map=map)
         if impl is not None:
             self.switch_implementation(impl)
+        self._log.debug("Initialized dispatcher %s", self)
 
     def handle_connect(self):
         self._delegate_call("handle_connect")
@@ -77,6 +78,7 @@ class Dispatcher(asyncore.dispatcher):
     def close(self):
         if self.closing:
             return
+        self._log.debug("Closing dispatcher %s", self)
         self.closing = True
         asyncore.dispatcher.close(self)
 


### PR DESCRIPTION
Caused by incomplete python 3 porting of the betterAsyncore module.

Also fix handle_close to always close the dispatcher. The underlying 
dispatcher implementation was not closing the dispatcher.

Log dispatcher lifetime events to make it easier to debug next time. 

Bug-Url: https://bugzilla.redhat.com/2102678