### PR TITLE
ci: split storage ci jobs for root and non-root testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run linters
       run: ./automation/lint.sh
+  # TODO: rename to 'test-storage-user' once the github settings allow it.
   test-storage:
     env:
       TRAVIS_CI: 1
@@ -20,8 +21,20 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v2
-    - name: Run storage tests
-      run: ./automation/tests-storage.sh
+    - name: Run storage tests as vdsm
+      run: ./automation/tests-storage.sh vdsm
+  test-storage-root:
+    env:
+      TRAVIS_CI: 1
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/ovirt/vdsm-test-centos-8
+      # Required to create loop devices.
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run storage tests as root
+      run: ./automation/tests-storage.sh root
   tests:
     env:
       TRAVIS_CI: 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -149,10 +149,6 @@ venv:
 tests: tox
 	tox -e "tests,lib,network,virt,gluster,hooks"
 
-.PHONY: tests-storage
-tests-storage: tox
-	tox -e "storage"
-
 .PHONY: tests-storage-user
 tests-storage-user: tox
 	tox -e "storage-user"

--- a/Makefile.am
+++ b/Makefile.am
@@ -153,6 +153,14 @@ tests: tox
 tests-storage: tox
 	tox -e "storage"
 
+.PHONY: tests-storage-user
+tests-storage-user: tox
+	tox -e "storage-user"
+
+.PHONY: tests-storage-root
+tests-storage-root: tox
+	tox -e "storage-root"
+
 .PHONY: storage
 storage:
 	python3 tests/storage/userstorage.py setup

--- a/tests/storage/blockdev_test.py
+++ b/tests/storage/blockdev_test.py
@@ -59,6 +59,7 @@ def loop_device(tmpdir):
 class TestZero:
 
     @requires_root
+    @pytest.mark.root
     def test_entire_device(self, loop_device):
         # Write some data to the device.
         with directio.open(loop_device.path, "r+") as f:
@@ -78,6 +79,7 @@ class TestZero:
             assert data == ZERO
 
     @requires_root
+    @pytest.mark.root
     def test_size(self, loop_device):
         # Write some data to the device.
         with directio.open(loop_device.path, "r+") as f:
@@ -94,6 +96,7 @@ class TestZero:
             assert data == DATA
 
     @requires_root
+    @pytest.mark.root
     @pytest.mark.parametrize("size", [
         sc.BLOCK_SIZE_4K,
         250 * sc.BLOCK_SIZE_4K
@@ -154,6 +157,7 @@ class TestDiscard:
             assert data == DATA
 
     @requires_root
+    @pytest.mark.root
     def test_supported(self, loop_device):
         # If the loop device backing file is on a file system that does not
         # support discard, discard is not supported.

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1616,6 +1616,7 @@ def test_dump_sd_metadata(
 
 
 @requires_root
+@pytest.mark.root
 @pytest.mark.parametrize("domain_version", [5])
 def test_create_illegal_volume(domain_factory, domain_version, fake_task,
                                fake_sanlock):
@@ -1644,6 +1645,7 @@ def test_create_illegal_volume(domain_factory, domain_version, fake_task,
 
 
 @requires_root
+@pytest.mark.root
 def test_reduce_volume_called(domain_factory, fake_task, fake_sanlock):
     sd_uuid = str(uuid.uuid4())
     dom = domain_factory.create_domain(sd_uuid=sd_uuid, version=5)
@@ -1676,6 +1678,7 @@ def test_reduce_volume_called(domain_factory, fake_task, fake_sanlock):
 
 
 @requires_root
+@pytest.mark.root
 def test_reduce_volume_skipped(domain_factory, fake_task, fake_sanlock):
     sd_uuid = str(uuid.uuid4())
     dom = domain_factory.create_domain(sd_uuid=sd_uuid, version=5)

--- a/tests/storage/devicemapper_test.py
+++ b/tests/storage/devicemapper_test.py
@@ -145,6 +145,7 @@ def test_get_paths_status_no_device(fake_dmsetup_status):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_remove_mapping(zero_dm_device):
     device_path = "{}{}".format(DMPATH_PREFIX, zero_dm_device)
     assert os.path.exists(device_path)
@@ -155,6 +156,7 @@ def test_remove_mapping(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_dm_id(zero_dm_device):
     # Resolve the dm link and get dm name of the device.
     device_path = "{}{}".format(DMPATH_PREFIX, zero_dm_device)
@@ -176,6 +178,7 @@ def test_dm_id(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_dev_name(zero_dm_device):
     dm_id = devicemapper.getDmId(zero_dm_device)
     device_name = devicemapper.getDevName(dm_id)
@@ -184,6 +187,7 @@ def test_dev_name(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_is_virtual_device(zero_dm_device):
     dm_id = devicemapper.getDmId(zero_dm_device)
     assert devicemapper.isVirtualDevice(dm_id)
@@ -191,6 +195,7 @@ def test_is_virtual_device(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_is_block_device(zero_dm_device):
     dm_id = devicemapper.getDmId(zero_dm_device)
     assert devicemapper.isBlockDevice(dm_id)
@@ -198,6 +203,7 @@ def test_is_block_device(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_is_dm_device(zero_dm_device):
     dm_id = devicemapper.getDmId(zero_dm_device)
     assert devicemapper.isDmDevice(dm_id)
@@ -205,6 +211,7 @@ def test_is_dm_device(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_get_all_mapped_devices(zero_dm_device):
     devices = devicemapper.getAllMappedDevices()
     assert zero_dm_device in devices
@@ -212,6 +219,7 @@ def test_get_all_mapped_devices(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_get_all_slaves(zero_dm_device):
     slaves = devicemapper.getAllSlaves()
     assert zero_dm_device in slaves
@@ -221,6 +229,7 @@ def test_get_all_slaves(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_get_slaves(zero_dm_device):
     slaves = devicemapper.getSlaves(zero_dm_device)
     # Zero device mapping has no slaves.
@@ -229,6 +238,7 @@ def test_get_slaves(zero_dm_device):
 
 @broken_on_ci
 @requires_root
+@pytest.mark.root
 def test_get_holders(zero_dm_device):
     holders = devicemapper.getHolders(zero_dm_device)
     # Zero device mapping has no holders.

--- a/tests/storage/dmsetup_test.py
+++ b/tests/storage/dmsetup_test.py
@@ -70,6 +70,7 @@ def fake_dmsetup(monkeypatch, fake_executable):
 
 
 @requires_root
+@pytest.mark.root
 def test_status(fake_dmsetup):
     fake_dmsetup.write(DMSETUP_SCRIPT.format(FAKE_DMSETUP_OUTPUT))
 

--- a/tests/storage/fileutil_test.py
+++ b/tests/storage/fileutil_test.py
@@ -156,6 +156,7 @@ def test_createdir_file_exists_no_mode():
 
 
 @requires_root
+@pytest.mark.root
 def test_chown():
     targetId = 666
     with temporaryPath() as srcPath:
@@ -165,6 +166,7 @@ def test_chown():
 
 
 @requires_root
+@pytest.mark.root
 def test_chown_names():
     # I convert to some id because I have no
     # idea what users are defined and what

--- a/tests/storage/iscsiadm_test.py
+++ b/tests/storage/iscsiadm_test.py
@@ -22,12 +22,15 @@ from __future__ import division
 
 import six
 
+import pytest
+
 from vdsm.storage import iscsiadm
 
 from . marks import requires_root
 
 
 @requires_root
+@pytest.mark.root
 def test_run_cmd():
     out = iscsiadm.run_cmd(["--version"])
     assert isinstance(out, six.text_type)

--- a/tests/storage/loopback_test.py
+++ b/tests/storage/loopback_test.py
@@ -41,6 +41,7 @@ AFTER = b"b" * 10
 
 
 @requires_root
+@pytest.mark.root
 @pytest.mark.parametrize("sector_size", [
     None,
     pytest.param(sc.BLOCK_SIZE_512, marks=requires_loopback_sector_size),
@@ -67,6 +68,7 @@ def test_with_device(tmpdir, sector_size):
 
 
 @requires_root
+@pytest.mark.root
 def test_attach_detach_manually(tmpdir):
     filename = str(tmpdir.join("file"))
     prepare_backing_file(filename)
@@ -82,6 +84,7 @@ def test_attach_detach_manually(tmpdir):
 
 
 @requires_root
+@pytest.mark.root
 @pytest.mark.stress
 def test_many_devices(tmpdir):
     filename = str(tmpdir.join("file"))

--- a/tests/storage/lvmfilter_test.py
+++ b/tests/storage/lvmfilter_test.py
@@ -162,6 +162,7 @@ def test_format_option():
 
 
 @requires_root
+@pytest.mark.root
 def test_real_find_lvm_mounts():
     mounts = lvmfilter.find_lvm_mounts()
     # This will return different results on any host, but we expect to find a
@@ -172,6 +173,7 @@ def test_real_find_lvm_mounts():
 
 
 @requires_root
+@pytest.mark.root
 def test_real_build_filter():
     mounts = lvmfilter.find_lvm_mounts()
     lvm_filter = lvmfilter.build_filter(mounts)

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -122,6 +122,7 @@ def fake_supervdsm(monkeypatch):
 
 
 @requires_root
+@pytest.mark.root
 def test_connector_info_not_installed(monkeypatch):
     # Simulate missing os_brick.
     monkeypatch.setattr(managedvolume, "os_brick", None)
@@ -130,12 +131,14 @@ def test_connector_info_not_installed(monkeypatch):
 
 
 @requires_root
+@pytest.mark.root
 def test_connector_info_ok(monkeypatch, fake_os_brick):
     monkeypatch.setenv("FAKE_CONNECTOR_INFO_RESULT", "OK")
     assert managedvolume.connector_info() == {"multipath": True}
 
 
 @requires_root
+@pytest.mark.root
 def test_connector_info_fail(monkeypatch, fake_os_brick):
     monkeypatch.setenv("FAKE_CONNECTOR_INFO_RESULT", "FAIL")
     with pytest.raises(se.ManagedVolumeHelperFailed):
@@ -143,6 +146,7 @@ def test_connector_info_fail(monkeypatch, fake_os_brick):
 
 
 @requires_root
+@pytest.mark.root
 def test_connector_info_fail_json(monkeypatch, fake_os_brick):
     monkeypatch.setenv("FAKE_CONNECTOR_INFO_RESULT", "FAIL_JSON")
     with pytest.raises(se.ManagedVolumeHelperFailed):
@@ -150,6 +154,7 @@ def test_connector_info_fail_json(monkeypatch, fake_os_brick):
 
 
 @requires_root
+@pytest.mark.root
 def test_connector_info_raise(monkeypatch, fake_os_brick):
     monkeypatch.setenv("FAKE_CONNECTOR_INFO_RESULT", "RAISE")
     with pytest.raises(se.ManagedVolumeHelperFailed) as e:
@@ -158,6 +163,7 @@ def test_connector_info_raise(monkeypatch, fake_os_brick):
 
 
 @requires_root
+@pytest.mark.root
 def test_attach_volume_not_installed_attach(monkeypatch):
     # Simulate missing os_brick.
     monkeypatch.setattr(managedvolume, "os_brick", None)
@@ -166,6 +172,7 @@ def test_attach_volume_not_installed_attach(monkeypatch):
 
 
 @requires_root
+@pytest.mark.root
 def test_attach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
                                 fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
@@ -206,6 +213,7 @@ def test_attach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
 
 
 @requires_root
+@pytest.mark.root
 @pytest.mark.xfail(reason='RBD monkeypatching not implemented yet')
 def test_attach_volume_ok_rbd(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
                               fake_supervdsm):
@@ -244,6 +252,7 @@ def test_attach_volume_ok_rbd(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
 
 
 @requires_root
+@pytest.mark.root
 @pytest.mark.parametrize("vol_type", ["iscsi", "fibre_channel"])
 def test_attach_volume_no_multipath_id(monkeypatch, fake_os_brick, tmp_db,
                                        vol_type, fake_lvm, fake_supervdsm):
@@ -273,6 +282,7 @@ def test_attach_volume_no_multipath_id(monkeypatch, fake_os_brick, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_reattach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmpdir, tmp_db,
                                   fake_lvm, fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
@@ -305,6 +315,7 @@ def test_reattach_volume_ok_iscsi(monkeypatch, fake_os_brick, tmpdir, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_attach_volume_fail_update(monkeypatch, fake_os_brick, tmpdir, tmp_db,
                                    fake_lvm, fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
@@ -336,6 +347,7 @@ def test_attach_volume_fail_update(monkeypatch, fake_os_brick, tmpdir, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_reattach_volume_other_connection(monkeypatch, fake_os_brick, tmp_db,
                                           fake_lvm, fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
@@ -368,6 +380,7 @@ def test_reattach_volume_other_connection(monkeypatch, fake_os_brick, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_detach_volume_iscsi_not_attached(monkeypatch, fake_os_brick, tmp_db,
                                           fake_lvm, fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
@@ -394,6 +407,7 @@ def test_detach_volume_iscsi_not_attached(monkeypatch, fake_os_brick, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_detach_volume_not_installed(monkeypatch, fake_os_brick, tmp_db,
                                      fake_lvm):
     # Simulate missing os_brick.
@@ -410,6 +424,7 @@ def test_detach_volume_not_installed(monkeypatch, fake_os_brick, tmp_db,
 
 
 @requires_root
+@pytest.mark.root
 def test_detach_not_in_db(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
                           fake_supervdsm):
     managedvolume.detach_volume("sd_id", "fake_vol_id")
@@ -426,6 +441,7 @@ def test_detach_not_in_db(monkeypatch, fake_os_brick, tmp_db, fake_lvm,
 
 
 @requires_root
+@pytest.mark.root
 def test_detach_volume_iscsi_attached(monkeypatch, fake_os_brick, tmpdir,
                                       tmp_db, fake_lvm, fake_supervdsm):
     monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")

--- a/tests/storage/misc_test.py
+++ b/tests/storage/misc_test.py
@@ -586,6 +586,7 @@ class TestExecCmd(VdsmTestCase):
         self.assertEqual(stderr[0].decode("ascii"), "it works!")
 
     @requires_root
+    @pytest.mark.root
     def testSudo(self):
         """
         Tests that when running with sudo the user really is root (or other

--- a/tests/storage/mount_test.py
+++ b/tests/storage/mount_test.py
@@ -137,6 +137,7 @@ def loop_mount(m):
 class TestMount(VdsmTestCase):
 
     @requires_root
+    @pytest.mark.root
     @broken_on_ci("mount check fails after successful mount", name="TRAVIS_CI")
     def testLoopMount(self):
         with namedTemporaryDir() as mpath:
@@ -147,6 +148,7 @@ class TestMount(VdsmTestCase):
                     self.assertTrue(m.isMounted())
 
     @requires_root
+    @pytest.mark.root
     @broken_on_ci("mount check fails after successful mount", name="TRAVIS_CI")
     def testSymlinkMount(self):
         with namedTemporaryDir() as root_dir:

--- a/tests/storage/multipath_test.py
+++ b/tests/storage/multipath_test.py
@@ -116,12 +116,14 @@ def fake_scsi_id(monkeypatch, fake_executable):
 
 
 @requires_root
+@pytest.mark.root
 def test_resize_map(fake_multipathd):
     fake_multipathd.write(MULTIPATHD_SCRIPT.format("ok"))
     multipath.resize_map("fake_device")
 
 
 @requires_root
+@pytest.mark.root
 def test_resize_map_failed(fake_multipathd):
     fake_multipathd.write(MULTIPATHD_SCRIPT.format("fail"))
 
@@ -130,6 +132,7 @@ def test_resize_map_failed(fake_multipathd):
 
 
 @requires_root
+@pytest.mark.root
 def test_scsi_id(fake_scsi_id):
     fake_scsi_id.write(SCSI_ID_SCRIPT.format(FAKE_SCSI_ID_OUTPUT))
 
@@ -138,6 +141,7 @@ def test_scsi_id(fake_scsi_id):
 
 
 @requires_root
+@pytest.mark.root
 def test_scsi_id_no_serial(fake_scsi_id):
     fake_scsi_id.write(SCSI_ID_SCRIPT.format(FAKE_SCSI_ID_NO_SERIAL))
 
@@ -151,6 +155,7 @@ def test_scsi_id_no_serial(fake_scsi_id):
 
 
 @requires_root
+@pytest.mark.root
 def test_scsi_id_fails(fake_scsi_id):
     fake_scsi_id.write("#!/bin/sh\nexit 1\n")
 

--- a/tests/storage/outofprocess_test.py
+++ b/tests/storage/outofprocess_test.py
@@ -521,6 +521,7 @@ def test_fileutils_pathexists(oop_cleanup, tmpdir):
 
 
 @requires_root
+@pytest.mark.root
 def test_fileutils_validateqemureadable_other_group(oop_cleanup, tmpdir):
     iop = oop.getProcessPool("test")
 
@@ -544,6 +545,7 @@ def test_fileutils_validateqemureadable_other_group(oop_cleanup, tmpdir):
     (36, 0o750),    # kvm
 ])
 @requires_root
+@pytest.mark.root
 def test_fileutils_validateqemureadable_qemu_or_kvm_group(
         oop_cleanup, tmpdir, gid, mode):
     iop = oop.getProcessPool("test")

--- a/tests/storage/qemuimg_test.py
+++ b/tests/storage/qemuimg_test.py
@@ -1663,6 +1663,7 @@ class TestMeasure:
         self.check_measure(filename, compat, format, compressed)
 
     @requires_root
+    @pytest.mark.root
     def test_block(self, block_chain):
         # Creating a block chain is very slow, so we reuse it for many tests.
 

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,36 @@ commands =
     --cov-fail-under={env:STORAGE_COVERAGE:68} \
     {posargs:storage}
 
+[testenv:storage-user]
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+    COVERAGE_FILE=.coverage-storage-user
+deps = {[base]deps}
+changedir = {[base]changedir}
+commands =
+    python profile {envname} pytest -m {[base]markers}" and not root" \
+    --durations=20 \
+    --cov=vdsm.storage \
+    --cov-report=html:htmlcov-storage-user \
+    --cov-fail-under={env:STORAGE_USER_COVERAGE:61} \
+    {posargs:storage}
+
+[testenv:storage-root]
+passenv = {[base]passenv}
+setenv =
+    {[base]setenv}
+    COVERAGE_FILE=.coverage-storage-root
+deps = {[base]deps}
+changedir = {[base]changedir}
+commands =
+    python profile {envname} pytest -m {[base]markers}" and root" \
+    --durations=20 \
+    --cov=vdsm.storage \
+    --cov-report=html:htmlcov-storage-root \
+    --cov-fail-under={env:STORAGE_ROOT_COVERAGE:47} \
+    {posargs:storage}
+
 [testenv:virt]
 passenv = {[base]passenv}
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -81,22 +81,6 @@ commands =
         network/integration \
         network/unit
 
-[testenv:storage]
-passenv = {[base]passenv}
-setenv =
-    {[base]setenv}
-    COVERAGE_FILE=.coverage-storage
-deps = {[base]deps}
-changedir = {[base]changedir}
-# TODO: Remove --ignore
-commands =
-    python profile {envname} pytest -m {[base]markers} \
-    --durations=20 \
-    --cov=vdsm.storage \
-    --cov-report=html:htmlcov-storage \
-    --cov-fail-under={env:STORAGE_COVERAGE:68} \
-    {posargs:storage}
-
 [testenv:storage-user]
 passenv = {[base]passenv}
 setenv =


### PR DESCRIPTION
Split storage CI jobs between unprivileged `vdsm` user tests (mark non-root) and root tests.

## Comparison

With the numbers below we end up executing 50 more tests that were skipped before and safe more than 2 minutes in execution time.

Numbers are not averaged, only the last run is considered.

### Before

__All storage tests__
collected 2702 items / 101 deselected / 2601 selected
Required test coverage of 68% reached. Total coverage: 68.87%
`= 2472 passed, 123 skipped, 101 deselected, 5 xfailed, 1 xpassed, 1 warning in 371.31s (0:06:11) =`

### After

__Non-root tests__
collected 2700 items / 235 deselected / 2465 selected
Required test coverage of 61% reached. Total coverage: 61.87%
`= 2402 passed, 59 skipped, 235 deselected, 4 xfailed, 1 warning in 164.30s (0:02:44) =`

__Root tests__
collected 2700 items / 2566 deselected / 134 selected
Required test coverage of 47% reached. Total coverage: 47.76%
`= 120 passed, 12 skipped, 2566 deselected, 1 xfailed, 1 xpassed, 1 warning in 211.60s (0:03:31) =`

__Total__
`= 2522 passed, 71 skipped, 5 xfailed, 1 xpassed, in max time 211.60s (0:03:31) =`

Fixes: https://github.com/oVirt/vdsm/issues/128
Signed-off-by: Albert Esteve <aesteve@redhat.com>