### PR TITLE
ci: update test-storage job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run linters
       run: ./automation/lint.sh
-  # TODO: rename to 'test-storage-user' once the github settings allow it.
-  test-storage:
+  test-storage-user:
     env:
       TRAVIS_CI: 1
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update ci job test-storage to test-storage-user
to be consistent with its test-storage-root counterpart.

Signed-off-by: Albert Esteve <aesteve@redhat.com>