### PR TITLE
blockVolume: check parent tag and meta match

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -164,7 +164,21 @@ class BlockVolumeManifest(volume.VolumeManifest):
         """
         Return parent volume UUID
         """
-        return self.getParentTag()
+        parent_tag = self.getParentTag()
+        parent_meta = self.getParentMeta()
+        if parent_tag != parent_meta:
+            self.log.debug(
+                "Getting different PUUID LV from tag %s and metada %s for "
+                "volume %s, reloading volume tags",
+                parent_tag, parent_meta, self.volUUID)
+            lvm.invalidateVG(self.sdUUID)
+            parent_tag = self.getParentTag()
+            if parent_tag != parent_meta:
+                self.log.warning(
+                    "Getting volume %s PUUID: volume tag %s does not "
+                    "match metadata parent %s",
+                    self.volUUID, parent_tag, parent_meta)
+        return parent_meta
 
     def getChildren(self):
         """ Return children volume UUIDs.

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1872,9 +1872,12 @@ def test_sync_volume_chain_internal(
     # from the volume metadata.
     assert chain.top.getParentMeta() == chain.base.volUUID
 
-    # getParent() uses the lv tags, so it still returns the internal volume.
+    # Parent tag is still pointing to the internal volume.
     # This will be fixed later on the SPM when the internal volume is deleted.
-    assert chain.top.getParent() == chain.internal.volUUID
+    assert chain.top.getParentTag() == chain.internal.volUUID
+
+    # getParent() uses the metadata parent.
+    assert chain.top.getParent() == chain.base.volUUID
 
 
 @requires_root


### PR DESCRIPTION
blockVolume getParent method uses the volume tag
PU_<id> to obtain the parent. However, this tag
could be outdated. For example, when the host
syncs a volume chain after removing a volume,
it only updates the metadata. Afterwards,
the SPM will update the volume tag once the
volume is deleted.

To ensure we do not return outdated parent UUID,
we need to ensure that the parent UUID obtained
from the parent tag, and the UUID in the volume
metadata match, and log a warning and update
the volume otherwise.

Tested with ovirt-stress: https://gitlab.com/nirs/ovirt-stress/-/merge_requests/14
It consistently triggered the bug in each run. After upgrading with this
branch patch, it passed each iteration (tried 10 iterations).

In the logs it can be seen:
```
2022-07-21 16:30:21,503+0200 WARN  (jsonrpc/5) [storage.volumemanifest] volUUID=3a34c1b2-70a5-4b25-bf66-b3f3f0e21c70 parent in tag (e5710d00-ed07-4ae6-bfbf-e1dd37a601e7) and metadata (4cf4d502-dfed-491a-960c-142ada884fdc) differ (blockVolume:172)
2022-07-21 16:30:21,565+0200 WARN  (jsonrpc/5) [storage.lvm] Removing stale lv: a2ad7a23-96c5-4c23-9007-c0d1892ea07d/e5710d00-ed07-4ae6-bfbf-e1dd37a601e7 (lvm:784)
2022-07-21 16:30:21,565+0200 DEBUG  (jsonrpc/5) [storage.volumemanifest] Parent tag after reload LVs, pUUID=4cf4d502-dfed-491a-960c-142ada884fdc (blockVolume:175)
```

Bug-Url: https://bugzilla.redhat.com/2103582
Signed-off-by: Albert Esteve <aesteve@redhat.com>