### PR TITLE
vdsmd: Document why we handle SIGUSR1 signal

### DIFF
--- a/lib/vdsm/vdsmd.py
+++ b/lib/vdsm/vdsmd.py
@@ -67,6 +67,9 @@ def serve_clients(log):
         running[0] = False
 
     def sigusr1Handler(signum, frame):
+        """
+        Called during fencing from spmprotect.sh when using export domain.
+        """
         if irs:
             log.info("Received signal %s, stopping SPM" % signum)
             # pylint: disable=no-member


### PR DESCRIPTION
When using export domain we use safelease instead of sanlock. During
fencing flows, it sends SIGUSR1 signal to vdsm to stop the SPM.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>