### PR TITLE
panic: Fix panic when logging.shutdown hang

### DIFF
--- a/lib/vdsm/vdsmd.py
+++ b/lib/vdsm/vdsmd.py
@@ -78,10 +78,6 @@ def serve_clients(log):
             irs.spmStop(
                 irs.getConnectedStoragePoolsList()['poollist'][0])
 
-    def sigalrmHandler(signum, frame):
-        # Used in panic.panic() when shuting down logging, must not log.
-        raise RuntimeError("Alarm timeout")
-
     sigutils.register()
     signal.signal(signal.SIGTERM, sigtermHandler)
     signal.signal(signal.SIGUSR1, sigusr1Handler)

--- a/tests/storage/stress/release-spm-lease.py
+++ b/tests/storage/stress/release-spm-lease.py
@@ -1,0 +1,22 @@
+"""
+Release the SPM lease behind vdsm back.
+"""
+import subprocess
+import sys
+
+import sanlock
+
+print("Looking up vdsm pid")
+out = subprocess.check_output(["pgrep", "^vdsmd"]).decode("utf-8")
+vdsm_pid = int(out)
+
+print("Inquiring process {} resoruces".format(vdsm_pid))
+for r in sanlock.inquire(pid=vdsm_pid):
+    if r["resource"] == b"SDM":
+        break
+else:
+    print("Not SPM host", file=sys.stderr)
+    sys.exit(1)
+
+print("Releasing SPM lease {}".format(r))
+sanlock.release(r["lockspace"], r["resource"], r["disks"], pid=vdsm_pid)


### PR DESCRIPTION
We tried to add a timeout using signal.alarm() to make that vdsm will
panic if shutting down logging hangs. However this does not work, since
the alarm is delivered to the main thread instead of the thread setting
the alarm.

What actually happened after we added the alarm was:

1. Panic thread: calls signal.alarm(10)
2. Panic thread: calls logging.shutdown(), call hangs
3. Main thread: crash with "RuntimeError: Alarm timeout"

When we removed zombiereaper, we also removed the SIGALRM signal handler
by mistake, so what happens in current code is:

1. Panic thread: calls signal.alarm(10)
2. Panic thread: calls logging.shutdown(), call hangs
3. Unhandled SIGALRM terminates the process

Replace the broken alarm with a thread waiting on an event.

Fixes: 56ed0796259a (panic: Limit time spent shutting down logging)
Fixes: c0a67a0a3094 (zombiereaper: Reap out last traces of it)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>