### PR TITLE
network: test support for all stp attributes on bridge

### DIFF
--- a/tests/network/functional/bridge_test.py
+++ b/tests/network/functional/bridge_test.py
@@ -67,7 +67,15 @@ class TestBridge(object):
 
     @nftestlib.parametrize_legacy_switch
     def test_add_bridge_with_custom_opts(self, adapter, switch, nic0):
-        opts = 'multicast_snooping=0 multicast_router=0 priority=1'
+        opts = (
+            'multicast_snooping=0 '
+            'multicast_router=0 '
+            'priority=1 '
+            'stp_state=0 '
+            'forward_delay=14 '
+            'max_age=2000 '
+            'hello_time=200'
+        )
         NET_ATTRS = {
             'nic': nic0,
             'switch': switch,


### PR DESCRIPTION
Test that setup networks can set all stp attributes on a bridge.

Change-Id: Ie35518a72d082287f582dff31bfe55842b587ea4
Bug-Url: https://bugzilla.redhat.com/2108974
Signed-off-by: Eitan Raviv <eraviv@redhat.com>