### PR TITLE
blockVolume: fix over allocation of small volumes

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -364,7 +364,7 @@ class BlockVolumeManifest(volume.VolumeManifest):
             else:
                 chunk_size_mb = config.getint("irs",
                                               "volume_utilization_chunk_mb")
-                alloc_size = chunk_size_mb * MiB
+                alloc_size = min(chunk_size_mb * MiB, capacity)
         else:
             # Preallocated raw or qcow2
             alloc_size = initial_size if initial_size else capacity

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -866,7 +866,6 @@ def test_volume_metadata(tmp_storage, tmp_repo, fake_access, fake_rescan,
 
 @requires_root
 @pytest.mark.root
-@pytest.mark.xfail(reason='Vdsm over-allocates small volumes', strict=False)
 def test_cow_small_volume(domain_factory, fake_task, fake_sanlock):
     """
     Test added to verify fix for https://bugzilla.redhat.com/2094576.

--- a/tests/storage/blockvolume_test.py
+++ b/tests/storage/blockvolume_test.py
@@ -45,8 +45,9 @@ from testlib import permutations, expandPermutations
 from testlib import VdsmTestCase
 
 
+CHUNK_SIZE_MB = 1024
 CONFIG = make_config([
-    ('irs', 'volume_utilization_chunk_mb', '1024'),
+    ('irs', 'volume_utilization_chunk_mb', str(CHUNK_SIZE_MB)),
     ('irs', 'volume_utilizzation_precent', '50'),
 ])
 
@@ -71,9 +72,9 @@ class TestBlockVolumeSize(VdsmTestCase):
         [(sc.PREALLOCATED_VOL, sc.COW_FORMAT, GiB, None), GiB],
         # Sparse, cow, capacity config.volume_utilization_chunk_mb - 1,
         # No initial size.
-        # Expected 1024 MiB allocated (config.volume_utilization_chunk_mb)
-        [(sc.SPARSE_VOL, sc.COW_FORMAT, (CONFIG.getint(
-            "irs", "volume_utilization_chunk_mb") - 1) * MiB, None), GiB],
+        # Expected 1023 MiB allocated (config.volume_utilization_chunk_mb - 1)
+        [(sc.SPARSE_VOL, sc.COW_FORMAT, (CHUNK_SIZE_MB - 1) * MiB, None),
+         (CHUNK_SIZE_MB - 1) * MiB],
         # Sparse, cow, capacity 4 GiB, initial size 952320 B.
         [(sc.SPARSE_VOL, sc.COW_FORMAT, 4 * GiB, 952320),
          int(952320 * blockVolume.QCOW_OVERHEAD_FACTOR)],


### PR DESCRIPTION
For block sparse volumes, if no initial_size is
defined, Vdsm allocates one chunk (2.5G), without
considering the virtual size of the volume.
This results in wasted space if the requested
volume is smaller.

Instead, we can allocate the capacity when
it is smaller than one chunk, to avoid wasting
space for small volumes.
Note than any size smaller than one extent
(128M) will be rounded to the extent size.

Bug-Url: https://bugzilla.redhat.com/2094576
Signed-off-by: Albert Esteve <aesteve@redhat.com>