### PR TITLE
 net: run tests on alma-linux 9.0 

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -30,7 +30,7 @@ jobs:
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ovirt/vdsm-network-tests-${{ matrix.container }}
-          tags: centos-8 centos-9
+          tags: alma-9 centos-8 centos-9
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         type: [ unit, integration, functional ]
-        tag: [ centos-8 ]
+        tag: [ alma-9, centos-8 ]
         include:
           - type: unit
             tag: centos-9

--- a/docker/network/functional/Dockerfile.alma-9
+++ b/docker/network/functional/Dockerfile.alma-9
@@ -1,0 +1,46 @@
+FROM quay.io/almalinux/almalinux:9.0
+
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
+# Add runtime dependencies.
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
+    && \
+    # Without it the ovirt-openvswitch fails to install
+    # It seems that the el8s container has systemd installed by default
+    dnf install -y systemd \
+    && \
+    dnf install -y \
+        autoconf \
+        automake \
+        dnsmasq \
+        git \
+        make \
+        python3 \
+        python3-devel \
+        python3-pip \
+        python3-yaml \
+        systemd \
+        systemd-udev \
+        # Install vdsm-network for its dependencies
+        vdsm-network \
+    && \
+    dnf remove -y --noautoremove vdsm-network \
+    && \
+    dnf clean all
+
+# Add pytest
+RUN python3 -m pip install --upgrade pip \
+    && \
+    python3 -m pip install pytest
+
+CMD ["/usr/sbin/init"]

--- a/docker/network/integration/Dockerfile.alma-9
+++ b/docker/network/integration/Dockerfile.alma-9
@@ -1,0 +1,43 @@
+FROM quay.io/almalinux/almalinux:9.0
+
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
+# Add runtime dependencies.
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
+    && \
+    # Without it the ovirt-openvswitch fails to install
+    # It seems that the el8s container has systemd installed by default
+    dnf install -y systemd \
+    && \
+    dnf install -y \
+        autoconf \
+        automake \
+        dnsmasq \
+        git \
+        make \
+        python3-devel \
+        python3-pip \
+        systemd \
+        # Install vdsm-network for its dependencies
+        vdsm-network \
+    && \
+    dnf remove -y --noautoremove vdsm-network \
+    && \
+    dnf clean all
+
+# Add pytest
+RUN python3 -m pip install --upgrade pip \
+    && \
+    python3 -m pip install pytest
+
+CMD ["/usr/sbin/init"]

--- a/docker/network/unit/Dockerfile.alma-9
+++ b/docker/network/unit/Dockerfile.alma-9
@@ -1,0 +1,38 @@
+FROM quay.io/almalinux/almalinux:9.0
+
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
+# Add runtime dependencies.
+RUN dnf -y install dnf-plugins-core \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    && \
+    dnf install -y ovirt-release-master \
+    && \
+    dnf update -y \
+    && \
+    # el9s does not have modprobe installed by default
+    dnf install -y kmod \
+    && \
+    dnf install -y \
+        iproute-tc \
+        libnl3 \
+        nmstate \
+        python3-devel \
+        python3-libnmstate \
+        python3-six \
+        python3-pip \
+        systemd \
+    && \
+    dnf clean all
+
+# Add pytest
+RUN python3 -m pip install --upgrade pip \
+    && \
+    python3 -m pip install pytest
+
+CMD ["/usr/sbin/init"]


### PR DESCRIPTION
 net: run tests on alma-linux 9.0

Alma Linux 9.0 is more stable and should provide consistent feedback
for the tests until we fix all el9-stream issues related to networking.
Create an Alma Linux 9.0 docker file, create a container from this file
and publish it to quay; run all tests in this container.