### PR TITLE
containers: Specify the chroot for COPR explicitly

### DIFF
--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
     && \
     dnf install -y ovirt-release-master \
     && \


### PR DESCRIPTION
DNF COPR started using 'epel-9-x86_64' chroot by default on CentOS 9 Stream since [this PR](https://github.com/rpm-software-management/dnf-plugins-core/pull/459) got merged. We publish built packages under 'centos-stream-9-x86_64', so let's select it explicitly.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
