### PR TITLE
containers: Don't use arch in COPR chroot name

### DIFF
--- a/docker/network/functional/Dockerfile.alma-9
+++ b/docker/network/functional/Dockerfile.alma-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/functional/Dockerfile.centos-9
+++ b/docker/network/functional/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/integration/Dockerfile.alma-9
+++ b/docker/network/integration/Dockerfile.alma-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/integration/Dockerfile.centos-9
+++ b/docker/network/integration/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/unit/Dockerfile.alma-9
+++ b/docker/network/unit/Dockerfile.alma-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/docker/network/unit/Dockerfile.centos-9
+++ b/docker/network/unit/Dockerfile.centos-9
@@ -9,7 +9,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # Add runtime dependencies.
 RUN dnf -y install dnf-plugins-core \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9-x86_64 \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \


### PR DESCRIPTION
Turns out there's no need to specify the architecture in COPR's chroot
names, so let's not do this.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
