### PR TITLE
net: run tests on alma-linux 9.0 - fix makefile

### DIFF
--- a/docker/network/Makefile
+++ b/docker/network/Makefile
@@ -19,7 +19,7 @@
 CONTAINER_CMD := podman
 PREFIX := ovirt/vdsm-network-tests
 
-targets := centos-8 centos-9
+targets := alma-9 centos-8 centos-9
 types := functional integration unit
 
 .PHONY: $(targets) $(types)


### PR DESCRIPTION
Alma Linux 9.0 is more stable and should provide consistent feedback
for the tests until we fix all el9-stream issues related to networking.
Create Alma Linux 9.0 docker files, create corresponding containers
tagged alma-9 and publish them to quay; run all tests on the alma-9
containers.

Change-Id: I7e18a5e1c0cda6315339aeb3a61ae3768e2fe859

Signed-off-by: Eitan Raviv <eraviv@redhat.com>