### PR TITLE
fileVolume: consider preallocation for qcow

### DIFF
--- a/lib/vdsm/storage/fileVolume.py
+++ b/lib/vdsm/storage/fileVolume.py
@@ -31,7 +31,6 @@ from vdsm import constants
 from vdsm import utils
 from vdsm.common import cmdutils
 from vdsm.common import commands
-from vdsm.common import exception
 from vdsm.common.marks import deprecated
 from vdsm.common.threadlocal import vars
 from vdsm.common.units import MiB
@@ -580,9 +579,7 @@ class FileVolume(volume.Volume):
                             level=logging.INFO,
                             log=cls.log):
                         op.run()
-        except exception.ActionStopped:
-            raise
-        except Exception as e:
+        except cmdutils.Error as e:
             cls.log.error("Unexpected error: %s", e, exc_info=True)
             raise se.VolumeCreationError(vol_path) from e
 

--- a/lib/vdsm/storage/fileVolume.py
+++ b/lib/vdsm/storage/fileVolume.py
@@ -582,9 +582,9 @@ class FileVolume(volume.Volume):
                         op.run()
         except exception.ActionStopped:
             raise
-        except Exception:
-            cls.log.error("Unexpected error", exc_info=True)
-            raise se.VolumesZeroingError(vol_path)
+        except Exception as e:
+            cls.log.error("Unexpected error: %s", e, exc_info=True)
+            raise se.VolumeCreationError(vol_path) from e
 
     @classmethod
     def _set_permissions(cls, vol_path, dom):

--- a/tests/storage/localfssd_test.py
+++ b/tests/storage/localfssd_test.py
@@ -682,7 +682,6 @@ def test_volume_create_cow_sparse_with_parent(user_domain, local_fallocate):
     assert int(actual["truesize"]) == qemu_info['actual-size']
 
 
-@pytest.mark.xfail(reason='Preallocation for qcow2 not considered')
 def test_volume_create_cow_prealloc(user_domain, local_fallocate):
     img_uuid = str(uuid.uuid4())
     vol_uuid = str(uuid.uuid4())


### PR DESCRIPTION
File volume create calls do not consider
preallocation policy for qcow2 format, which
are thin provisioned regardless.

Vdsm should do as commanded by the engine and
create a preallocated volume, both for raw and
qcow2 volumes.

Fixes: https://github.com/oVirt/vdsm/issues/292
Signed-off-by: Albert Esteve <aesteve@redhat.com>