### PR TITLE
blockVolume: remove misleading comments

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -366,7 +366,7 @@ class BlockVolumeManifest(volume.VolumeManifest):
                                               "volume_utilization_chunk_mb")
                 alloc_size = chunk_size_mb * MiB
         else:
-            # Preallocated qcow2
+            # Preallocated raw or qcow2
             alloc_size = initial_size if initial_size else capacity
 
         return alloc_size


### PR DESCRIPTION
In calculate_volume_alloc_size, there are
a couple comments that hint for the volume
format being qcow.

However, the code that is executed below the
preallocated comment, can be reached
also with a raw volume.

Edit the comment to include preallocated
raw option to avoid confusion.

Signed-off-by: Albert Esteve <aesteve@redhat.com>