### PR TITLE
vdsm-tool: use standard logging

### DIFF
--- a/lib/vdsm/tool/__init__.py
+++ b/lib/vdsm/tool/__init__.py
@@ -4,7 +4,37 @@
 from __future__ import absolute_import
 from __future__ import division
 import functools
+import logging
 import os
+
+
+LOGGER_NAME = "vdsm-tool"
+
+
+def setup_logging(log_file, verbosity, append):
+    level = logging.DEBUG if verbosity else logging.INFO
+    root_logger = logging.getLogger(LOGGER_NAME)
+    root_logger.setLevel(level)
+
+    if root_logger.handlers:
+        return root_logger
+
+    if log_file is not None:
+        mode = append and 'a' or 'w'
+        file_handler = logging.FileHandler(log_file, mode=mode)
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s [%(levelname)-7s] %(message)s",
+                "%m/%d/%Y %I:%M:%S %p"))
+        # File logging always at DEBUG level
+        file_handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(file_handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)-7s | %(message)s"))
+    root_logger.addHandler(handler)
+
+    return root_logger
 
 
 class expose(object):

--- a/lib/vdsm/tool/configurators/managedvolumedb.py
+++ b/lib/vdsm/tool/configurators/managedvolumedb.py
@@ -4,8 +4,8 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import logging
 import os
-import sys
 
 from contextlib import closing
 
@@ -13,8 +13,12 @@ from vdsm import constants
 from vdsm.common import errors
 from vdsm.storage import fileUtils
 from vdsm.storage import managedvolumedb as mvdb
+from vdsm.tool import LOGGER_NAME
 
 from . import YES, NO
+
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 class IncorrectDBVersion(errors.Base):
@@ -27,8 +31,7 @@ def configure():
     Create database for managed volumes
     """
     if not _db_exists():
-        sys.stdout.write("Creating managed volumes database at %s\n" %
-                         mvdb.DB_FILE)
+        log.info("Creating managed volumes database at %s", mvdb.DB_FILE)
         mvdb.create_db()
         _set_db_ownership()
     else:
@@ -43,10 +46,10 @@ def isconfigured():
     Return YES if managedvolumedb is configured, otherwise NO
     """
     if _db_exists() and _db_owned_by_vdsm() and _db_version_correct():
-        sys.stdout.write("Managed volume database is already configured\n")
+        log.info("Managed volume database is already configured")
         return YES
     else:
-        sys.stdout.write("Managed volume database requires configuration\n")
+        log.error("Managed volume database requires configuration")
         return NO
 
 
@@ -55,13 +58,13 @@ def removeConf():
     Remove database file
     """
     if os.path.isfile(mvdb.DB_FILE):
-        sys.stdout.write("Removing database file %s\n" % mvdb.DB_FILE)
+        log.info("Removing database file %s", mvdb.DB_FILE)
         os.remove(mvdb.DB_FILE)
 
 
 def _set_db_ownership():
-    sys.stdout.write("Setting up ownership of database file to %s:%s\n" %
-                     (constants.VDSM_USER, constants.VDSM_GROUP))
+    log.info("Setting up ownership of database file to %s:%s",
+             constants.VDSM_USER, constants.VDSM_GROUP)
     fileUtils.chown(mvdb.DB_FILE, constants.VDSM_USER, constants.VDSM_GROUP)
 
 
@@ -69,7 +72,7 @@ def _db_exists():
     if os.path.isfile(mvdb.DB_FILE):
         return True
     else:
-        sys.stdout.write("DB file %s doesn't exists\n" % mvdb.DB_FILE)
+        log.warning("DB file %s doesn't exists", mvdb.DB_FILE)
         return False
 
 
@@ -83,10 +86,9 @@ def _db_owned_by_vdsm():
     if expected_uid == actual_uid and expected_gid == actual_gid:
         return True
     else:
-        sys.stdout.write("DB file %s doesn't have proper ownership %s:%s\n"
-                         "Actual ownership is %s:%s\n" %
-                         (mvdb.DB_FILE, expected_uid, expected_gid,
-                          actual_uid, actual_gid))
+        log.warning("DB file %s doesn't have proper ownership %s:%s",
+                    mvdb.DB_FILE, expected_uid, expected_gid)
+        log.warning("Actual ownership is %s:%s", actual_uid, actual_gid)
         return False
 
 
@@ -98,6 +100,6 @@ def _db_version_correct():
     if mvdb.VERSION == version["version"]:
         return True
     else:
-        sys.stdout.write("Database version (%s) is not the same as expected "
-                         "one (%s)\n" % (version["version"], mvdb.VERSION))
+        log.warning("Database version (%s) is not the same as expected "
+                    "one (%s)", version["version"], mvdb.VERSION)
         return False

--- a/lib/vdsm/tool/configurators/sebool.py
+++ b/lib/vdsm/tool/configurators/sebool.py
@@ -4,10 +4,11 @@
 from __future__ import absolute_import
 from __future__ import division
 
-import sys
+import logging
 
 from . import YES, NO, MAYBE
 from vdsm import utils
+from vdsm.tool import LOGGER_NAME
 
 SEBOOL_ENABLED = "on"
 SEBOOL_DISABLED = "off"
@@ -21,6 +22,8 @@ VDSM_SEBOOL_LIST = (
     "sanlock_use_nfs",
     "sanlock_use_samba",
 )
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 def _setup_booleans(status):
@@ -51,7 +54,7 @@ def isconfigured():
     ret = YES
     if utils.get_selinux_enforce_mode() == -1:
         ret = MAYBE
-        _log("WARNING: SELinux is disabled!")
+        log.warning("SELinux is disabled!")
     else:
         import seobject
         sebool_obj = seobject.booleanRecords()
@@ -71,8 +74,8 @@ def configure():
     if utils.get_selinux_enforce_mode() > -1:
         _setup_booleans(True)
     else:
-        _log(
-            "WARNING: SELinux is disabled! "
+        log.warning(
+            "SELinux is disabled! "
             "Skipping SELinux boolean configuration."
         )
 
@@ -84,12 +87,7 @@ def removeConf():
     if utils.get_selinux_enforce_mode() > -1:
         _setup_booleans(False)
     else:
-        _log(
-            "WARNING: SELinux is disabled! "
+        log.warning(
+            "SELinux is disabled! "
             "Skipping removal of SELinux booleans."
         )
-
-
-# TODO: use standard logging
-def _log(fmt, *args):
-    sys.stdout.write(fmt % args + "\n")

--- a/lib/vdsm/tool/nwfilter.py
+++ b/lib/vdsm/tool/nwfilter.py
@@ -8,7 +8,11 @@ import logging
 import libvirt
 
 from vdsm.common import libvirtconnection
+from . import LOGGER_NAME
 from . import expose, ExtraArgsError
+
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 @expose('nwfilter')
@@ -64,7 +68,7 @@ class NwFilter(object):
         define vdsm network filter on libvirt to control VM traffic
         """
         libvirt_filter = self.connection.nwfilterDefineXML(self.build_xml())
-        logging.debug("Filter %s was defined", libvirt_filter.name())
+        log.debug("Filter %s was defined", libvirt_filter.name())
 
 
 class NoMacSpoofingFilter(NwFilter):

--- a/lib/vdsm/tool/service.py
+++ b/lib/vdsm/tool/service.py
@@ -9,13 +9,17 @@ System service management utlities.
 '''
 
 import functools
+import logging
 import re
-import sys
 from collections import defaultdict
 
 from vdsm.common.cmdutils import CommandPath
 from vdsm.common.commands import execCmd as _execCmd
+from . import LOGGER_NAME
 from . import expose, UsageError, ExtraArgsError
+
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 def execCmd(argv, raw=True, *args, **kwargs):
@@ -214,7 +218,7 @@ def service_status(srvName, verbose=True):
         return _runAlts(_srvStatusAlts, srvName)
     except ServiceError as e:
         if verbose:
-            sys.stderr.write('service-status: %s\n' % e)
+            log.error('service-status: %s', e)
         return 1
 
 
@@ -290,5 +294,5 @@ def service_is_managed(srvName):
     try:
         return _runAlts(_srvIsManagedAlts, srvName)
     except ServiceError as e:
-        sys.stderr.write('service-is-managed: %s\n' % e)
+        log.error('service-is-managed: %s', e)
         return 1

--- a/lib/vdsm/tool/upgrade.py
+++ b/lib/vdsm/tool/upgrade.py
@@ -5,16 +5,15 @@ from __future__ import absolute_import
 from __future__ import division
 import argparse
 import logging
-import logging.config
 import os
 
 from vdsm.common import fileutils
 
+from . import LOGGER_NAME
 from ..constants import P_VDSM_LIB
 
 
-def _get_upgrade_log():
-    return logging.getLogger('upgrade')
+log = logging.getLogger(LOGGER_NAME)
 
 
 def _upgrade_seal_path(upgrade):
@@ -30,10 +29,9 @@ def _upgrade_seal(upgrade):
     try:
         fileutils.touch_file(seal_file)
     except (OSError, IOError):
-        _get_upgrade_log().exception("Failed to seal upgrade %s", upgrade.name)
+        log.exception("Failed to seal upgrade %s", upgrade.name)
     else:
-        _get_upgrade_log().debug("Upgrade %s successfully performed",
-                                 upgrade.name)
+        log.debug("Upgrade %s successfully performed", upgrade.name)
 
 
 def apply_upgrade(upgrade, *args):
@@ -72,11 +70,11 @@ def apply_upgrade(upgrade, *args):
         upgrade.extendArgParser(argparser)
     ns, args = argparser.parse_known_args(args[1:])
     if (_upgrade_needed(upgrade) or ns.runAgain):
-        _get_upgrade_log().debug("Running upgrade %s", upgrade.name)
+        log.debug("Running upgrade %s", upgrade.name)
         try:
             upgrade.run(ns, args)
         except Exception:
-            _get_upgrade_log().exception("Failed to run %s", upgrade.name)
+            log.exception("Failed to run %s", upgrade.name)
             return 1
         else:
             _upgrade_seal(upgrade)

--- a/lib/vdsm/tool/vdsm-id.py
+++ b/lib/vdsm/tool/vdsm-id.py
@@ -3,9 +3,15 @@
 
 from __future__ import absolute_import
 from __future__ import division
+
+import logging
+
 from .. import host
+from . import LOGGER_NAME
 from . import expose, ExtraArgsError
-import sys
+
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 @expose("vdsm-id")
@@ -19,5 +25,5 @@ def getUUID(*args):
     hostUUID = host.uuid()
     if hostUUID is None:
         raise EnvironmentError('Cannot retrieve host UUID')
-    sys.stdout.write(hostUUID + '\n')
+    log.info("%s", hostUUID)
     return 0

--- a/static/usr/bin/vdsm-tool
+++ b/static/usr/bin/vdsm-tool
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 import getopt
 import importlib
-import logging
 import os
 import sys
 import syslog
@@ -128,32 +127,6 @@ def usage_and_exit(exit_code):
     sys.exit(exit_code)
 
 
-def setup_logging(log_file, verbosity, append):
-    level = logging.DEBUG if verbosity else logging.INFO
-    root_logger = logging.getLogger("")
-    root_logger.setLevel(level)
-
-    if root_logger.handlers:
-        return root_logger
-
-    if log_file is not None:
-        mode = append and 'a' or 'w'
-        file_handler = logging.FileHandler(log_file, mode=mode)
-        file_handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s [%(levelname)-7s] %(message)s",
-                "%m/%d/%Y %I:%M:%S %p"))
-        # File logging always at DEBUG level
-        file_handler.setLevel(logging.DEBUG)
-        root_logger.addHandler(file_handler)
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(levelname)-7s | %(message)s"))
-    root_logger.addHandler(handler)
-
-    return root_logger
-
-
 def main():
     load_modules()
 
@@ -178,7 +151,7 @@ def main():
         elif opt[0] in ('-a', '--append'):
             append = True
 
-    log = setup_logging(log_file, verbosity, append)
+    log = vdsm.tool.setup_logging(log_file, verbosity, append)
 
     if len(args) < 1:
         usage_and_exit(1)

--- a/static/usr/bin/vdsm-tool
+++ b/static/usr/bin/vdsm-tool
@@ -116,10 +116,6 @@ def usage_and_exit(exit_code):
                      "  -l, --logfile <path>",
                      "\t\tRedirect logging to file.",
                      "  -v, --verbose",
-                     "\t\tInclude warning (and errors) messages in log.",
-                     "  -vv, --vverbose",
-                     "\t\tInclude information (and above) messages in log.",
-                     "  -vvv, --vvverbose",
                      "\t\tInclude debug (and above) messages in log.",
                      "  -a, --append",
                      "\t\tAppend to logfile instead of truncating it",
@@ -133,22 +129,29 @@ def usage_and_exit(exit_code):
 
 
 def setup_logging(log_file, verbosity, append):
+    level = logging.DEBUG if verbosity else logging.INFO
+    root_logger = logging.getLogger("")
+    root_logger.setLevel(level)
 
-    level = {0: logging.ERROR,
-             1: logging.WARNING,
-             2: logging.INFO}.get(verbosity, logging.DEBUG)
+    if root_logger.handlers:
+        return root_logger
 
     if log_file is not None:
-        handler = logging.FileHandler(log_file, mode=(append and 'a' or 'w'))
-    else:
-        handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(
-        "%(threadName)s::%(levelname)s::%(asctime)s::%(module)s::"
-        + "%(lineno)d::%(name)s::(%(funcName)s) %(message)s"))
+        mode = append and 'a' or 'w'
+        file_handler = logging.FileHandler(log_file, mode=mode)
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s [%(levelname)-7s] %(message)s",
+                "%m/%d/%Y %I:%M:%S %p"))
+        # File logging always at DEBUG level
+        file_handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(file_handler)
 
-    root_logger = logging.getLogger('')
-    root_logger.setLevel(level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)-7s | %(message)s"))
     root_logger.addHandler(handler)
+
+    return root_logger
 
 
 def main():
@@ -157,12 +160,12 @@ def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hl:av",
                                    ["help", "logfile=", "append",
-                                    "verbose", "vverbose", "vvverbose"])
+                                    "verbose"])
     except getopt.GetoptError:
         usage_and_exit(1)
 
     log_file = None
-    verbosity = 0
+    verbosity = False
     append = False
 
     for opt in opts:
@@ -170,18 +173,12 @@ def main():
             usage_and_exit(0)
         elif opt[0] in ('-l', '--logfile'):
             log_file = opt[1]
-        elif opt[0] in ('-v'):
-            verbosity += 1
-        elif opt[0] == '--verbose':
-            verbosity = 1
-        elif opt[0] == '--vverbose':
-            verbosity = 2
-        elif opt[0] == '--vvverbose':
-            verbosity = 3
+        elif opt[0] in ('-v', '--verbose'):
+            verbosity = True
         elif opt[0] in ('-a', '--append'):
             append = True
 
-    setup_logging(log_file, verbosity, append)
+    log = setup_logging(log_file, verbosity, append)
 
     if len(args) < 1:
         usage_and_exit(1)
@@ -197,13 +194,13 @@ def main():
         print_command_usage(tool_command[cmd]["command"], sys.stderr)
         return 1
     except vdsm.tool.UsageError as e:
-        print('Error: ', e, '\n', file=sys.stderr)
+        log.error('%s', e)
         return 1
     except Exception:
         traceback.print_exc(file=sys.stderr)
         return 1
     except KeyboardInterrupt:
-        print("Interrupted", file=sys.stderr)
+        log.warning("Interrupted")
         return 1
 
 


### PR DESCRIPTION
Update logging to have default INFO verbosity.
There is no reason to silence ERROR and WARNING,
and INFO is a good starting point for any CLI.
Therefore, only one verbosity increase is required,
for DEBUG level.

Update logging formatter to beautify and avoid logging
unuseful information.

Change file logging strategy:
- File logging always logs to DEBUG level
- Stdout logging is enabled even if file logging
  is set.

Use the global logger for all vdsm-tool
sub-modules. All logs will use standard
logging with consistent formatting.

Fixes: #258 
Signed-off-by: Albert Esteve <aesteve@redhat.com>