### PR TITLE
tox.ini: fix envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pylint, tests, storage, lib, network, virt, gluster, hooks
+envlist = flake8, pylint, tests, storage-user, storage-root, lib, network, virt, gluster, hooks
 
 skipsdist = true
 skip_missing_interpreters = True


### PR DESCRIPTION
Add storage-user and storage-root environments,
and remove storage in tox.ini, so that the listed
environments match the supported ones.

Fixes: 6fa5937a9b763ed0f9cbbf861e1ebd6b813d8074
Fixes: 395a3d6d54afc34781c19e09b3d6f8316f4593b7
Signed-off-by: Albert Esteve <aesteve@redhat.com>