### PR TITLE
requirements: add userstorage

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,3 +1,4 @@
 nose==1.3.7
 tox
+userstorage>=0.5
 yappi


### PR DESCRIPTION
Add userstorage as a required package to allow
using the most recent version from PyPI.

Signed-off-by: Albert Esteve <aesteve@redhat.com>