### PR TITLE
merge_test: increase reduce vol size

### DIFF
--- a/tests/storage/merge_test.py
+++ b/tests/storage/merge_test.py
@@ -368,7 +368,7 @@ class TestFinalizeMerge:
             format='raw',
             prealloc=sc.SPARSE_VOL,
             chain_len=2):
-        size = 2 * GiB
+        size = 10 * GiB
         base_fmt = sc.name2type(format)
         with fake_env(sd_type) as env:
             with MonkeyPatch().context() as mp:
@@ -539,10 +539,10 @@ class TestFinalizeMerge:
             fake_sd = env.sdcache.domains[env.sd_manifest.sdUUID]
             fake_base_vol = fake_sd.produceVolume(subchain.img_id,
                                                   subchain.base_id)
-
-            assert fake_base_vol.__calls__ == [
-                ('reduce', (base_vol.optimal_size(as_leaf=True),), {}),
-            ]
+            # Chunked leaf volumes add one chunk of free space as condition
+            # to reduce, so the VM will not pause quickly when it is started.
+            # Consequently, cold merges will not call reduce.
+            assert getattr(fake_base_vol, "__calls__", []) == []
 
     @pytest.mark.parametrize("sd_type, format, prealloc", [
         # Not chunked, reduce not called


### PR DESCRIPTION
Increase the size of the volumes created in the
reduce tests in the merge_test module, so that
volume sizes are more realistic.

Consequently, chunked leaf volumes do not reduce
anymore in the test. Chunked leaf volumes add an
extra chunk to the required size as the condition
to call reduce.

The test relied in the allocation
that Vdsm does when the volume is created
in `calculate_volume_alloc_size` if the create
call does not specify an initial size.
In that case, Vdsm allocates an entire chunk,
whereas the requested capacity was smaller (test
requested 2 GiB volumes, Vdsm allocated 2.5 GiB).

As long as the required size is smaller
than the difference between capacity and
chunk size (0.5 GiB), reduce will be called
during finalizeMerge.

In a real setup, tests show that leaf volumes
are not reduced during finalizeMerge except if
they have been extended previously. Thus, increasing 
the size of the volumes and changing the expectation
in the test matches real scenario.

Signed-off-by: Albert Esteve <aesteve@redhat.com>