### PR TITLE
pylint: ignore no-member

### DIFF
--- a/lib/vdsm/virt/vmdevices/lease.py
+++ b/lib/vdsm/virt/vmdevices/lease.py
@@ -138,6 +138,7 @@ class Device(core.Base):
     """
     VM lease device.
     """
+    # pylint: disable=no-member
     __slots__ = ("lease_id", "sd_id", "path", "offset")
 
     @classmethod

--- a/lib/vdsm/virt/vmdevices/network.py
+++ b/lib/vdsm/virt/vmdevices/network.py
@@ -52,6 +52,7 @@ class MissingNetwork(Exception):
 
 
 class Interface(core.Base):
+    # pylint: disable=no-member
     __slots__ = ('nicModel', 'macAddr', 'network', 'bootOrder', 'address',
                  'linkActive', 'portMirroring', 'filter', 'filterParameters',
                  'sndbufParam', 'driver', 'name', 'vlanId', 'hostdev', 'mtu',

--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -119,6 +119,7 @@ VolumeChainEntry = collections.namedtuple(
 
 
 class Drive(core.Base):
+    # pylint: disable=no-member
     __slots__ = ('iface', '_path', 'readonly', 'bootOrder', 'domainID',
                  'poolID', 'imageID', 'UUID', 'volumeID', 'format',
                  'propagateErrors', 'address', 'apparentsize', 'volumeInfo',


### PR DESCRIPTION
A few classes in vm devices use `__slots__`
to define class attributes that are not properly
detected by pylint, causing false positive
no-member errors:
```
lib/vdsm/virt/vmdevices/lease.py:175:46: E1101: Instance of 'Device' has no 'lease_id' member (no-member)
lib/vdsm/virt/vmdevices/lease.py:176:52: E1101: Instance of 'Device' has no 'sd_id' member (no-member)
...
lib/vdsm/virt/vmdevices/network.py:55:32: E1101: Instance of 'Interface' has no 'macAddr' member (no-member)
lib/vdsm/virt/vmdevices/network.py:153:29: E1101: Instance of 'Interface' has no 'device' member (no-member)
...
lib/vdsm/virt/vmdevices/storage.py:239:47: E1101: Instance of 'Drive' has no 'index' member (no-member)
lib/vdsm/virt/vmdevices/storage.py:239:47: E1101: Instance of 'Drive' has no 'iface' member (no-member)
...
```
Since no-member is an interesting error that
we do not want to disable project-wide, better
to just add pylint ignore comments in the classes
that use this strategy.

Signed-off-by: Albert Esteve <aesteve@redhat.com>