### PR TITLE
lvmlocal.conf: fix header metadata

### DIFF
--- a/static/usr/share/vdsm/lvmlocal.conf
+++ b/static/usr/share/vdsm/lvmlocal.conf
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
-
+#
 # Vdsm local lvm configuration.
 #
 # Options:


### PR DESCRIPTION
Metadata header comments of the lvmlocal.conf
file are parsed by the vdsm-tool when running
the is-configured command. This check is
failing due to an empty line between the license
headers and the actual header with the metadata,
which is processed as a premature end of the
header.

Connect the SPDX header lines with the rest of
the header by adding a `#` character at the
beginning.

Signed-off-by: Albert Esteve <aesteve@redhat.com>