### PR TITLE
tests: Test builtin lvmlocal.conf

### DIFF
--- a/tests/tool_configurators_lvm_test.py
+++ b/tests/tool_configurators_lvm_test.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Red Hat, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+
+from vdsm.tool import confmeta
+
+TOPDIR = os.path.dirname(os.path.dirname(__file__))
+
+
+def test_lvmlocal_conf():
+    lvmlocal_conf = os.path.join(
+        TOPDIR, "static/usr/share/vdsm/lvmlocal.conf")
+    md = confmeta.read_metadata(lvmlocal_conf)
+    assert md.revision >= 7
+    assert md.private is False

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,10 @@ commands =
         common/time_test.py \
         lib/ \
         hooking_test.py \
-        pywatch_test.py \
         prlimit_test.py \
-        ssl_test.py
+        pywatch_test.py \
+        ssl_test.py \
+        tool_configurators_lvm_test.py
 
 [testenv:network]
 passenv = {[base]passenv}


### PR DESCRIPTION
Recent change adding spdx headers broke OST. Add simple test ensuring that the builtin file can be parsed.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>