### PR TITLE
CIs: test with el9stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: quay.io/ovirt/vdsm-test-centos-8
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [centos-8, centos-9]
+    container: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
     steps:
     - uses: ovirt/checkout-action@main
     - name: Run linters
@@ -17,8 +21,12 @@ jobs:
     env:
       TRAVIS_CI: 1
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-centos-8
+      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
       # Required to create loop devices.
       options: --privileged
     steps:
@@ -29,8 +37,12 @@ jobs:
     env:
       TRAVIS_CI: 1
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-centos-8
+      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
       # Required to create loop devices.
       options: --privileged
     steps:
@@ -41,8 +53,12 @@ jobs:
     env:
       TRAVIS_CI: 1
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-centos-8
+      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
       # Needed for many operations, i.e. creating bridges
       options: --privileged
     steps:

--- a/docker/Dockerfile.centos-9
+++ b/docker/Dockerfile.centos-9
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Red Hat, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+FROM quay.io/centos/centos:stream9
+
+# Add runtime dependencies.
+RUN dnf install -y 'dnf-command(copr)' \
+    && dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
+    && dnf install -y ovirt-release-master \
+    && dnf update -y \
+    && dnf install -y \
+        autoconf \
+        automake \
+        createrepo_c \
+        dnf-utils \
+        dosfstools \
+        e2fsprogs \
+        gcc \
+        gdb \
+        genisoimage \
+        git \
+        glusterfs-api \
+        iproute-tc \
+        iscsi-initiator-utils \
+        lshw \
+        lsof \
+        lvm2 \
+        make \
+        mom \
+        NetworkManager \
+        nmstate \
+        nmstate-plugin-ovsdb \
+        openssl \
+        ovirt-imageio-client \
+        psmisc \
+        python3 \
+        python3-augeas \
+        python3-blivet \
+        python3-cryptography \
+        python3-dateutil \
+        python3-dbus \
+        python3-decorator \
+        python3-devel \
+        python3-dmidecode \
+        python3-ioprocess \
+        python3-libselinux \
+        python3-libvirt \
+        python3-magic \
+        python3-nose \
+        python3-pip \
+        python3-requests \
+        python3-rpm \
+        python3-sanlock \
+        python3-six \
+        python3-yaml \
+        qemu-img \
+        redhat-rpm-config \
+        rpm-build \
+        sanlock \
+        sudo \
+        systemd \
+        systemd-udev \
+        which \
+        xfsprogs \
+    && dnf clean all
+
+# Create vdsm user with groups kvm,qemu,sanlock
+RUN useradd --system -m -u 36 -N -G 36,107,179 vdsm
+
+# Add gdb python support.
+RUN debuginfo-install -y python3 \
+    && dnf clean all
+
+# Add development packages
+COPY requirements.txt requirements.txt
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --requirement requirements.txt
+
+# Add lvm configuration.
+COPY lvmlocal.conf /etc/lvm/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-targets := centos-8
+targets := centos-8 centos-9
 prefix := vdsm-test
 
 .PHONY: $(targets) push


### PR DESCRIPTION
Add centos-stream-9 Dockerfile to the
docker folder so that it can be built,
and used in the pipelines.

Signed-off-by: Albert Esteve <aesteve@redhat.com>