### PR TITLE
Backport: lvmdevices: always create devices file

### DIFF
--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -48,11 +48,7 @@ def configure(vgs):
     # Always configure devices file. File maybe be empty or not up to date.
     # On the other hand configuring correct devices file doesn't cause any
     # harm.
-    try:
-        _create_system_devices(vgs)
-    except cmdutils.Error:
-        log.warning("Failed to create system devices file.")
-        raise
+    _create_system_devices(vgs)
 
     # Devices file was created, enable devices/use_devicesfile in lvm config.
     log.debug("Enabling lvm devices/use_devicesfile.")


### PR DESCRIPTION
Create empty devices file even if no lvm
volumes are found with
vdsm-tool config-lvm-filter.

Otherwise configuring LVM to use a devices
file without the file allows lvm commands
to see all volumes, with the associated risk.

Bug-Url: https://bugzilla.redhat.com/2125290
Signed-off-by: Albert Esteve [aesteve@redhat.com](mailto:aesteve@redhat.com)