### PR TITLE
ci/container.yml: build also vdsm-test containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_REGISTRY: quay.io
   can_push: ${{ github.repository_owner == 'oVirt' }}
 jobs:
-  container:
+  container-network:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,6 +34,33 @@ jobs:
         with:
           image: ovirt/vdsm-network-tests-${{ matrix.container }}
           tags: alma-9 centos-8 centos-9
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME  }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        if: ${{ env.can_push == 'true' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  container-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [ centos-8, centos-9, alma-9 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Build container images
+        working-directory: docker
+        run: make ${{ matrix.distro }}
+      - name: Push to Quay.io
+        if: ${{ env.can_push == 'true' }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ovirt/vdsm-test
+          tags: ${{ matrix.distro }}
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}

--- a/docker/Dockerfile.alma-9
+++ b/docker/Dockerfile.alma-9
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Red Hat, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+FROM quay.io/almalinux/almalinux:9.0
+
+# Add runtime dependencies.
+RUN dnf install -y 'dnf-command(copr)' \
+    && dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
+    && dnf install -y ovirt-release-master \
+    && dnf update -y \
+    && dnf install -y \
+        autoconf \
+        automake \
+        createrepo_c \
+        dnf-utils \
+        dosfstools \
+        e2fsprogs \
+        gcc \
+        gdb \
+        genisoimage \
+        git \
+        glusterfs-api \
+        iproute-tc \
+        iscsi-initiator-utils \
+        lshw \
+        lsof \
+        lvm2 \
+        make \
+        mom \
+        NetworkManager \
+        nmstate \
+        nmstate-plugin-ovsdb \
+        openssl \
+        ovirt-imageio-client \
+        psmisc \
+        python3 \
+        python3-augeas \
+        python3-blivet \
+        python3-cryptography \
+        python3-dateutil \
+        python3-dbus \
+        python3-decorator \
+        python3-devel \
+        python3-dmidecode \
+        python3-ioprocess \
+        python3-libselinux \
+        python3-libvirt \
+        python3-magic \
+        python3-nose \
+        python3-pip \
+        python3-requests \
+        python3-rpm \
+        python3-sanlock \
+        python3-six \
+        python3-yaml \
+        qemu-img \
+        redhat-rpm-config \
+        rpm-build \
+        sanlock \
+        sudo \
+        systemd \
+        systemd-udev \
+        which \
+        xfsprogs \
+    && dnf clean all
+
+# Create vdsm user with groups kvm,qemu,sanlock
+RUN useradd --system -m -u 36 -N -G 36,107,179 vdsm
+
+# Add gdb python support.
+RUN debuginfo-install -y python3 \
+    && dnf clean all
+
+# Add development packages
+COPY requirements.txt requirements.txt
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --requirement requirements.txt
+
+# Add lvm configuration.
+COPY lvmlocal.conf /etc/lvm/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-targets := centos-8 centos-9
+targets := alma-9 centos-8 centos-9
 prefix := vdsm-test
 
 .PHONY: $(targets) push

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,9 +9,9 @@ prefix := vdsm-test
 all: $(targets)
 
 $(targets):
-	podman build -t $(prefix)-$@ -f Dockerfile.$@ .
+	podman build -t $(prefix):$@ -f Dockerfile.$@ .
 
 push:
 	for name in $(targets); do \
-		podman push $(prefix)-$$name quay.io/ovirt/$(prefix)-$$name; \
+		podman push $(prefix):$$name quay.io/ovirt/$(prefix):$$name; \
 	done


### PR DESCRIPTION
Build also vdsm test containers in the weekly
build workflow.

Add another job to the containers workflow
to build and upload test containers
in `docker` directory.

For test containers, build each distro
separately and push it to the same
repository with a different tag.

Final tree of Vdsm repositories:
```
.
└── ovirt/
    ├── ovirt-vdsm-network-tests-functional:
    │   ├── centos-8
    │   ├── centos-9
    │   └── alma-9
    ├── ovirt-vdsm-network-tests-integration:
    │   ├── centos-8
    │   ├── centos-9
    │   └── alma-9
    ├── ovirt-vdsm-network-tests-unit:
    │   ├── centos-8
    │   ├── centos-9
    │   └── alma-9
    └── ovirt-test:
        ├── centos-8
        ├── centos-9
        └── alma-9
```

Signed-off-by: Albert Esteve <aesteve@redhat.com>