### PR TITLE
Fix missing informations on geo replication tab of GlusterFS volumes.

### DIFF
--- a/tests/glusterGeoRepStatus.xml
+++ b/tests/glusterGeoRepStatus.xml
@@ -8,14 +8,14 @@
       <name>vol1</name>
       <sessions>
         <session>
-          <session_slave>6a2f7584-05a8-4651-8786-1cd6ae87b896:ssh://192.168.122.145::vol2</session_slave>
+          <session_secondary>6a2f7584-05a8-4651-8786-1cd6ae87b896:ssh://192.168.122.145::vol2:3e8382d6-f509-49db-b64f-59a8dfb5ee3b</session_secondary>
           <pair>
-            <master_node>localhost.localdomain</master_node>
-            <master_node_uuid>6a2f7584-05a8-4651-8786-1cd6ae87b896</master_node_uuid>
-            <master_brick>/root/b1_vol1</master_brick>
-	    <slave_user>root</slave_user>
-            <slave>192.168.122.145::vol2</slave>
-	    <slave_node>192.168.122.145</slave_node>
+            <primary_node>localhost.localdomain</primary_node>
+            <primary_node_uuid>6a2f7584-05a8-4651-8786-1cd6ae87b896</primary_node_uuid>
+            <primary_brick>/root/b1_vol1</primary_brick>
+	    	<secondary_user>root</secondary_user>
+            <secondary>192.168.122.145::vol2</secondary>
+	    	<secondary_node/>
             <status>Stopped</status>
             <crawl_status>N/A</crawl_status>
             <last_synced>2014-12-12 05:18:23</last_synced>
@@ -23,9 +23,9 @@
             <data>0</data>
             <meta>0</meta>
             <failures>0</failures>
-	    <checkpoint_time>2014-12-12 05:17:23</checkpoint_time>
-	    <checkpoint_completion_time>2014-12-12 05:18:20</checkpoint_completion_time>
-	    <checkpoint_completed>Yes</checkpoint_completed>
+	    	<checkpoint_time>2014-12-12 05:17:23</checkpoint_time>
+	    	<checkpoint_completion_time>2014-12-12 05:18:20</checkpoint_completion_time>
+	    	<checkpoint_completed>Yes</checkpoint_completed>
           </pair>
         </session>
       </sessions>

--- a/tests/glusterGeoRepStatusOld.xml
+++ b/tests/glusterGeoRepStatusOld.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cliOutput>
+  <opRet>0</opRet>
+  <opErrno>0</opErrno>
+  <opErrstr/>
+  <geoRep>
+    <volume>
+      <name>vol1</name>
+      <sessions>
+        <session>
+          <session_slave>6a2f7584-05a8-4651-8786-1cd6ae87b896:ssh://192.168.122.145::vol2</session_slave>
+          <pair>
+            <master_node>localhost.localdomain</master_node>
+            <master_node_uuid>6a2f7584-05a8-4651-8786-1cd6ae87b896</master_node_uuid>
+            <master_brick>/root/b1_vol1</master_brick>
+	    <slave_user>root</slave_user>
+            <slave>192.168.122.145::vol2</slave>
+	    <slave_node>192.168.122.145</slave_node>
+            <status>Stopped</status>
+            <crawl_status>N/A</crawl_status>
+            <last_synced>2014-12-12 05:18:23</last_synced>
+            <entry>0</entry>
+            <data>0</data>
+            <meta>0</meta>
+            <failures>0</failures>
+	    <checkpoint_time>2014-12-12 05:17:23</checkpoint_time>
+	    <checkpoint_completion_time>2014-12-12 05:18:20</checkpoint_completion_time>
+	    <checkpoint_completed>Yes</checkpoint_completed>
+          </pair>
+        </session>
+      </sessions>
+    </volume>
+  </geoRep>
+</cliOutput>

--- a/tests/glusterGeoRepStatusOld.xml.license
+++ b/tests/glusterGeoRepStatusOld.xml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/glusterTestData.py
+++ b/tests/glusterTestData.py
@@ -1072,6 +1072,33 @@ GLUSTER_GEOREP_STATUS = {
                  'data': '0'}],
              'remoteVolumeName': 'vol2',
              'sessionKey': '6a2f7584-05a8-4651-8786-1cd6ae87b896:ssh:'
+             '//192.168.122.145::vol2:3e8382d6-f509-49db-b64f-59a8dfb5ee3b'}
+        ]
+    }
+}
+
+GLUSTER_GEOREP_STATUS_OLD = {
+    'vol1': {
+        'sessions': [
+            {'bricks': [
+                {'status': 'Stopped',
+                 'brickName': '/root/b1_vol1',
+                 'crawlStatus': 'N/A',
+                 'hostUuid': '6a2f7584-05a8-4651-8786-1cd6ae87b896',
+                 'remoteHost': '192.168.122.145',
+                 'checkpointCompletionTime': 1418361500,
+                 'meta': '0',
+                 'checkpointCompleted': 'Yes',
+                 'host': 'localhost.localdomain',
+                 'checkpointTime': 1418361443,
+                 'lastSynced': 1418361503,
+                 'failures': '0',
+                 'entry': '0',
+                 'remoteUserName': 'root',
+                 'timeZone': 'IST',
+                 'data': '0'}],
+             'remoteVolumeName': 'vol2',
+             'sessionKey': '6a2f7584-05a8-4651-8786-1cd6ae87b896:ssh:'
              '//192.168.122.145::vol2'}
         ]
     }

--- a/tests/gluster_cli_test.py
+++ b/tests/gluster_cli_test.py
@@ -1287,6 +1287,14 @@ class GlusterCliTests(TestCaseBase):
         status = gcli._parseGeoRepStatus(tree)
         self.assertEqual(status, glusterTestData.GLUSTER_GEOREP_STATUS)
 
+    def test_parseGeoRepStatusOld(self):
+        with open("glusterGeoRepStatusOld.xml") as f:
+            out = f.read()
+        tree = etree.fromstring(out)
+        gcli._TIME_ZONE = 'IST'
+        status = gcli._parseGeoRepStatus(tree)
+        self.assertEqual(status, glusterTestData.GLUSTER_GEOREP_STATUS_OLD)
+
     def test_parseVolumeGeoRepConfig(self):
         with open("glusterVolumeGeoRepConfigList.xml") as f:
             out = f.read()


### PR DESCRIPTION
Since the upgrade to oVirt 4.5 and GlusterFS 10, information about snapshots and geo replication are no more visible on the engine Webui. After digging VDSM logs, I found that it's caused by the change of some XML elements name introduced in a new Gluster release (https://github.com/gluster/glusterfs/pull/1568) and by the addition of the timezone in output of status command.

This commit fix the parsing process of the output returned by gluster command, so that data sent to ovirt engine are as expected.

Bug-URL: https://bugzilla.redhat.com/show_bug.cgi?id=2104278