### PR TITLE
Remove SPDX headers from sensitive files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,7 @@ check-unit:
 	$(MAKE) -C tests/ check NOSE_EVAL_ATTR="type=='unit'"
 
 .PHONY: lint
-lint: gitignore reuse execcmd black flake8 pylint
+lint: gitignore execcmd black flake8 pylint
 
 .PHONY: venv
 venv:

--- a/static/etc/sudoers.d/50_vdsm.in
+++ b/static/etc/sudoers.d/50_vdsm.in
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Red Hat, Inc.
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 Cmnd_Alias VDSM_STORAGE = \
     @FSCK_PATH@ -p *, \
     @TUNE2FS_PATH@ -j *, \

--- a/static/usr/share/vdsm/autounattend/Autounattend.xml.in
+++ b/static/usr/share/vdsm/autounattend/Autounattend.xml.in
@@ -1,8 +1,3 @@
-<!--                                                                                                                                                                                                                                                                                                                         
-SPDX-FileCopyrightText: Red Hat, Inc.                                                                                                                                                                                                                                                                                        
-SPDX-License-Identifier: GPL-2.0-or-later                                                                                                                                                                                                                                                                                    
--->  
-
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">

--- a/vdsm_hooks/extra_ipv4_addrs/sudoers
+++ b/vdsm_hooks/extra_ipv4_addrs/sudoers
@@ -1,4 +1,1 @@
-# SPDX-FileCopyrightText: Red Hat, Inc.
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 vdsm  ALL=(ALL) NOPASSWD: /usr/sbin/ip, /sbin/ip, /usr/bin/ip

--- a/vdsm_hooks/localdisk/sudoers.vdsm_hook_localdisk
+++ b/vdsm_hooks/localdisk/sudoers.vdsm_hook_localdisk
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Red Hat, Inc.
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 vdsm  ALL=(ALL) NOPASSWD: /usr/libexec/vdsm/localdisk-helper
 Defaults:vdsm !requiretty
 Defaults:vdsm !syslog

--- a/vdsm_hooks/openstacknet/sudoers.in
+++ b/vdsm_hooks/openstacknet/sudoers.in
@@ -1,5 +1,2 @@
-# SPDX-FileCopyrightText: Red Hat, Inc.
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 vdsm  ALL=(ALL) NOPASSWD: /usr/sbin/ip link set * nomaster
 vdsm  ALL=(ALL) NOPASSWD: /usr/bin/ovs-vsctl

--- a/vdsm_hooks/vhostmd/sudoers.vdsm_hook_vhostmd
+++ b/vdsm_hooks/vhostmd/sudoers.vdsm_hook_vhostmd
@@ -1,4 +1,1 @@
-# SPDX-FileCopyrightText: Red Hat, Inc.
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 vdsm  ALL=(ALL) NOPASSWD: /sbin/service vhostmd *


### PR DESCRIPTION
The recently added SPDX headers cause some problems with downstream builds:

- SPDX headers in sudoers files require security review.

- SPDX headers in autounattended files report linting failure because the files don’t start with an XML header at the very beginning.

Let’s remove SPDX headers from the given places to avoid false alerts. Let’s also disable ‘reuse’ check in ‘make lint’ to avoid linter failures due to missing SPDX headers.

This is 4.5.3-only change to avoid problems with downstream builds.