### PR TITLE
reuse: Put SPDX after XML declaration

### DIFF
--- a/static/usr/share/vdsm/autounattend/Autounattend.xml.in
+++ b/static/usr/share/vdsm/autounattend/Autounattend.xml.in
@@ -1,9 +1,8 @@
-<!--                                                                                                                                                                                                                                                                                                                         
-SPDX-FileCopyrightText: Red Hat, Inc.                                                                                                                                                                                                                                                                                        
-SPDX-License-Identifier: GPL-2.0-or-later                                                                                                                                                                                                                                                                                    
--->  
-
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
A valid XML should start with the declaration and only then comments are allowed.