### PR TITLE
reuse: Cleanup of SPDX handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,7 @@ check-unit:
 	$(MAKE) -C tests/ check NOSE_EVAL_ATTR="type=='unit'"
 
 .PHONY: lint
-lint: gitignore execcmd black flake8 pylint
+lint: gitignore reuse execcmd black flake8 pylint
 
 .PHONY: venv
 venv:

--- a/static/etc/sudoers.d/50_vdsm.in.license
+++ b/static/etc/sudoers.d/50_vdsm.in.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/static/usr/share/vdsm/autounattend/Autounattend.xml.in
+++ b/static/usr/share/vdsm/autounattend/Autounattend.xml.in
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/vdsm_hooks/extra_ipv4_addrs/sudoers.license
+++ b/vdsm_hooks/extra_ipv4_addrs/sudoers.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/vdsm_hooks/localdisk/sudoers.vdsm_hook_localdisk.license
+++ b/vdsm_hooks/localdisk/sudoers.vdsm_hook_localdisk.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/vdsm_hooks/openstacknet/sudoers.in.license
+++ b/vdsm_hooks/openstacknet/sudoers.in.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/vdsm_hooks/vhostmd/sudoers.vdsm_hook_vhostmd.license
+++ b/vdsm_hooks/vhostmd/sudoers.vdsm_hook_vhostmd.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Red Hat, Inc.
+SPDX-License-Identifier: GPL-2.0-or-later


### PR DESCRIPTION
Let’s improve the recent SPDX workarounds:

- Put back SPDX to Autounattend.xml.in, just at the right place.
- Add *.license files to sudoers files to avoid modifying the files directly.
- Re-enable running ‘reuse’ linter check by default.