### PR TITLE
lvmdevices: create devices directory

### DIFF
--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -114,6 +114,7 @@ def _create_system_devices(vgs):
         data = (f"# Created by Vdsm pid {os.getpid()} at "
                 f"{now.strftime('%a %b %d %H:%M:%S %Y')}\n")
 
+        os.makedirs(os.path.dirname(devices_file), exist_ok=True)
         fileUtils.atomic_write(devices_file, data.encode("utf-8"))
     else:
         for vg in vgs:


### PR DESCRIPTION
Current implementation assumes /etc/lvm/devices folder exists, which may not be true with a fresh installation (only in an upgrade).

We need to make sure that we create the directory
before creating the empty devices file, with
exist_ok flag set to True. This will ensure
that it works in both scenarios.

Fixes: b8692e93f38abaed973c528fe457a767cc1245ea
Signed-off-by: Albert Esteve <aesteve@redhat.com>