### PR TITLE
virt: Accept None returned by guest agent for vCPU count

### DIFF
--- a/lib/vdsm/virt/qemuguestagent.py
+++ b/lib/vdsm/virt/qemuguestagent.py
@@ -794,6 +794,9 @@ class QemuGuestAgentPoller(object):
                 'Not querying QEMU-GA for guest CPU info because domain'
                 'is not running for vm-id=%s', vm.id)
             return {}
+        if vcpus is None:
+            self.log.info('Guest CPU count was not returned for vm=%s', vm.id)
+            return {}
         if 'online' in vcpus:
             count = len(taskset.cpulist_parse(vcpus['online']))
         else:


### PR DESCRIPTION
If guest agent returns None for vCPU count, TypeError is raised. This patch adds correct handling of this situation.

Bug-Url: https://bugzilla.redhat.com/2120381
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>