### PR TITLE
 cold merge: prune stale bitmaps in base volume

### DIFF
--- a/lib/vdsm/storage/bitmaps.py
+++ b/lib/vdsm/storage/bitmaps.py
@@ -125,6 +125,27 @@ def remove_bitmap(vol_path, bitmap):
             vol_path=vol_path)
 
 
+def prune_bitmaps(base_path, top_path):
+    """
+    Prune all the stale bitmaps from the base volume path.
+    A bitmap is considered stale if it appears only in the base volume,
+    and is missing or invalid in the top volume.
+
+    Args:
+        base_path (str): Path to the base volume
+        top_path (str): Path to the top volume
+    """
+    base_bitmaps = _query_bitmaps(base_path)
+    valid_top_bitmaps = _query_bitmaps(top_path, filter=_valid)
+
+    stale_bitmaps = [
+        name for name in base_bitmaps if name not in valid_top_bitmaps]
+    if stale_bitmaps:
+        log.warning("Prune stale bitmaps %s from %r", stale_bitmaps, base_path)
+        for bitmap in stale_bitmaps:
+            remove_bitmap(base_path, bitmap)
+
+
 def clear_bitmaps(vol_path):
     """
     Remove all the bitmaps from the given volume path

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1258,7 +1258,6 @@ def test_create_volume_with_new_bitmap(
     11,  # required size = lv size
     15,  # required size > lv size
 ])
-@pytest.mark.xfail(reason='Stale bitmaps in base volume not considered')
 def test_merge_with_bitmap(
         tmp_storage, tmp_repo, fake_access, fake_rescan, tmp_db, fake_task,
         fake_sanlock, monkeypatch, stale_bitmaps, caplog):


### PR DESCRIPTION
Prune the stale base volume bitmaps during
the prepare step on a merge operation.

These stale bitmaps can cause the merge
operation to fail due to 'No space left on device'.
In this case, qemu does not end with error, so
the failure goes unnoticed.

As there is not a reliable way to measure
the size of these stale bitmaps, and they are
invalid and can never be used for incremental
backup, it is better to prune them to avoid
the error.

Related: https://github.com/oVirt/vdsm/issues/352
Signed-off-by: Albert Esteve <aesteve@redhat.com>