### PR TITLE
qemuimg: log warning on cmd error

### DIFF
--- a/lib/vdsm/storage/qemuimg.py
+++ b/lib/vdsm/storage/qemuimg.py
@@ -361,7 +361,7 @@ class ProgressCommand(object):
     REGEXPR = re.compile(br'\s*\(([\d.]+)/100%\)\s*')
 
     def __init__(self, cmd, cwd=None):
-        self._operation = operation.Command(cmd, cwd=cwd)
+        self._operation = operation.Command(cmd, cwd=cwd, warn_stderr=True)
         self._progress = 0.0
 
     def run(self):


### PR DESCRIPTION
Add flag warn_stderr to Command class to
log to WARNING level instead of DEBUG
level if the command execution has data
in the stderr output, even if the command
finished succesfully.

Also, the logged message changes if the
new warn_stderr flag is set, printing
the command that originated the error
output.

Legacy debug logging remains unchanged.

ProgressCommand in qemuimg will enable
the flag so that qemuimg commands show
warning on errors.

Example:
```
09:49:34,851 WARNING (MainThread) [storage.operation] Command
   ['/usr/bin/qemu-img', 'commit', '-p', '-t', 'none', '-b'...]
   succeeded with warnings: bytearray(b"qcow2_free_clusters failed: No space left on
   device\nqemu-img: Lost persistent bitmaps during inactivation of node \'#block365\':
   Failed to write bitmap \'stale-bitmap5\' to file: No space left on
   device\nqemu-img: Failed to flush the refcount block cache: No space
   left on device\n") (operation:159)']
```
Signed-off-by: Albert Esteve <aesteve@redhat.com>