### PR TITLE
livemerge: prune bitmaps before measuring

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -6106,6 +6106,22 @@ class Vm(object):
 
     # Accessing storage
 
+    def prune_bitmaps(self, domainID, imageID, topID, baseID):
+        """
+        Prune stale bitmaps from the base volume.
+        """
+        res = self.cif.irs.prune_bitmaps(
+            sdUUID=domainID,
+            imgUUID=imageID,
+            volUUID=topID,
+            baseUUID=baseID)
+
+        if res['status']['code'] != 0:
+            message = res['status']['message']
+            raise errors.StorageUnavailableError(
+                f"Unable to prune bitmaps in domain {domainID} "
+                f"image {imageID} top {topID} base {baseID}: {message}")
+
     def measure(self, domainID, imageID, topID, dest_format, backing=True,
                 baseID=None):
         """

--- a/tests/virt/livemerge_test.py
+++ b/tests/virt/livemerge_test.py
@@ -856,9 +856,20 @@ def test_internal_merge():
     # Check current chain matches expected chain - current chain is unordered.
     assert set(vdsm_chain) == set(new_chain)
 
-    # Check imageSyncVolumeChain was called with correct arguments.
-    assert len(vm.cif.irs.__calls__) == 1
+    assert len(vm.cif.irs.__calls__) == 2
+    # First call to prune_bitmaps, as it is supported and may be required.
+    # This is an internal merge with cow volumes.
     meth, arg, kwarg = vm.cif.irs.__calls__[0]
+    assert meth == "prune_bitmaps"
+    assert kwarg == {
+        "sdUUID": sd_id,
+        "imgUUID": img_id,
+        "volUUID": top_id,
+        "baseUUID": base_id
+    }
+
+    # Check imageSyncVolumeChain was called with correct arguments.
+    meth, arg, kwarg = vm.cif.irs.__calls__[1]
     assert meth == "imageSyncVolumeChain"
     assert arg[:3] == (sd_id, img_id, drive.volumeID)
     assert set(arg[3]) == set(new_chain)

--- a/tests/virt/vmfakelib.py
+++ b/tests/virt/vmfakelib.py
@@ -41,6 +41,7 @@ class IRS(object):
         self.extend_requests = []
         self.sd_types = {}
         self.measure_info = {}
+        self.errors = {}
 
     def getDeviceVisibility(self, guid):
         pass
@@ -53,6 +54,9 @@ class IRS(object):
 
     @recorded
     def prune_bitmaps(self, sdUUID, imgUUID, volUUID, baseUUID):
+        error = self.errors.get("prune_bitmaps")
+        if error:
+            return response.error_raw(error.code, error.msg)
         return response.success(result=None)
 
     def measure(self, sdUUID, imgUUID, volUUID, dest_format, backing=True,

--- a/tests/virt/vmfakelib.py
+++ b/tests/virt/vmfakelib.py
@@ -51,6 +51,7 @@ class IRS(object):
     def inappropriateDevices(self, ident):
         pass
 
+    @recorded
     def prune_bitmaps(self, sdUUID, imgUUID, volUUID, baseUUID):
         return response.success(result=None)
 

--- a/tests/virt/vmfakelib.py
+++ b/tests/virt/vmfakelib.py
@@ -51,6 +51,9 @@ class IRS(object):
     def inappropriateDevices(self, ident):
         pass
 
+    def prune_bitmaps(self, sdUUID, imgUUID, volUUID, baseUUID):
+        return response.success(result=None)
+
     def measure(self, sdUUID, imgUUID, volUUID, dest_format, backing=True,
                 baseUUID=None):
         # Return fake measure set up by the test. Not setting up anyting will


### PR DESCRIPTION
Prune stale bitmaps before a live merge to avoid
failing with ENOSPC.

Fixes: #352
Signed-off-by: Albert Esteve <aesteve@redhat.com>