### PR TITLE
resourceManager: use f-strings in exceptions

### DIFF
--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -362,8 +362,7 @@ class _ResourceManager(object):
             resources = namespaceObj.resources
             with namespaceObj.lock:
                 if not namespaceObj.factory.resourceExists(name):
-                    raise KeyError("No such resource '%s.%s'" % (namespace,
-                                                                 name))
+                    raise KeyError(f"No such resource '{namespace}.{name}'")
 
                 if name not in resources:
                     return STATUS_FREE
@@ -469,7 +468,7 @@ class _ResourceManager(object):
                     resource = resources[name]
                 except KeyError:
                     if not namespaceObj.factory.resourceExists(name):
-                        raise KeyError("No such resource '%s'" % (full_name))
+                        raise KeyError(f"No such resource '{full_name}'")
                 else:
                     if len(resource.queue) == 0 and \
                             resource.currentLock == SHARED and \

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -333,7 +333,7 @@ class _ResourceManager(object):
 
     def registerNamespace(self, namespace, factory):
         if not self._namespaceValidator.match(namespace):
-            raise InvalidNamespace("Invalid namespace name %r" % namespace)
+            raise InvalidNamespace(f"Invalid namespace name {namespace!r}")
 
         if namespace in self._namespaces:
             raise NamespaceRegistered(

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -336,13 +336,13 @@ class _ResourceManager(object):
             raise InvalidNamespace("Invalid namespace name %r" % namespace)
 
         if namespace in self._namespaces:
-            raise NamespaceRegistered("Namespace '%s' already registered"
-                                      % namespace)
+            raise NamespaceRegistered(
+                f"Namespace '{namespace}' already registered")
 
         with self._syncRoot.exclusive:
             if namespace in self._namespaces:
-                raise NamespaceRegistered("Namespace '%s' already registered"
-                                          % namespace)
+                raise NamespaceRegistered(
+                    f"Namespace '{namespace}' already registered")
 
             log.debug("Registering namespace '%s'", namespace)
 

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -700,8 +700,8 @@ class Owner(object):
                     log.debug(
                         "%s: resource '%s' does not exist",
                         self, full_name)
-                    raise ResourceDoesNotExist("Resource %s does not exist"
-                                               % full_name)
+                    raise ResourceDoesNotExist(
+                        f"Resource {full_name} does not exist")
                 except Exception:
                     log.warning(
                         "Unexpected exception caught while owner '%s' tried "

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -676,8 +676,8 @@ class Owner(object):
             try:
                 if full_name in self.resources:
                     raise ResourceAlreadyAcquired(
-                        "%s is already acquired by %s",
-                        full_name, self.ownerobject.getID())
+                        f"{full_name} is already acquired "
+                        f"by {self.ownerobject.getID()}")
                 try:
                     resource = acquireResource(namespace, name, locktype,
                                                timeout)

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -356,8 +356,9 @@ class _ResourceManager(object):
             try:
                 namespaceObj = self._namespaces[namespace]
             except KeyError:
-                raise ValueError("Namespace '%s' is not registered with this "
-                                 "manager" % namespace)
+                raise ValueError(
+                    f"Namespace '{namespace}' is not registered "
+                    "with this manager")
             resources = namespaceObj.resources
             with namespaceObj.lock:
                 if not namespaceObj.factory.resourceExists(name):
@@ -458,8 +459,9 @@ class _ResourceManager(object):
             try:
                 namespaceObj = self._namespaces[namespace]
             except KeyError:
-                raise ValueError("Namespace '%s' is not registered with this "
-                                 "manager" % namespace)
+                raise ValueError(
+                    f"Namespace '{namespace}' is not registered "
+                    "with this manager")
 
             resources = namespaceObj.resources
             with namespaceObj.lock:
@@ -531,16 +533,18 @@ class _ResourceManager(object):
             try:
                 namespaceObj = self._namespaces[namespace]
             except KeyError:
-                raise ValueError("Namespace '%s' is not registered with this "
-                                 "manager", namespace)
+                raise ValueError(
+                    f"Namespace '{namespace}' is not registered "
+                    "with this manager")
             resources = namespaceObj.resources
 
             with namespaceObj.lock:
                 try:
                     resource = resources[name]
                 except KeyError:
-                    raise ValueError("Resource '%s.%s' is not currently "
-                                     "registered" % (namespace, name))
+                    raise ValueError(
+                        f"Resource '{namespace}.{name}' is not "
+                        "currently registered")
 
                 resource.activeUsers -= 1
                 log.debug("Released resource '%s' (%d active users)",
@@ -726,8 +730,7 @@ class Owner(object):
         full_name = "%s.%s" % (namespace, name)
         with self.lock:
             if full_name not in self.resources:
-                raise ValueError("resource %s not owned by %s" %
-                                 (full_name, self))
+                raise ValueError(f"resource {full_name} not owned by {self}")
 
             resource = self.resources[full_name]
 

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -74,7 +74,7 @@ def _statusFromType(locktype):
         return STATUS_SHARED
     if str(locktype) == EXCLUSIVE:
         return STATUS_LOCKED
-    raise InvalidLockType("Invalid locktype %r was used" % locktype)
+    raise InvalidLockType(f"Invalid locktype {locktype!r} was used")
 
 
 # TODO : Integrate all factory functionality to manager
@@ -449,7 +449,7 @@ class _ResourceManager(object):
             raise se.InvalidResourceName(name)
 
         if lockType not in (SHARED, EXCLUSIVE):
-            raise InvalidLockType("Invalid locktype %r was used" % lockType)
+            raise InvalidLockType(f"Invalid locktype {lockType!r} was used")
 
         request = Request(namespace, name, lockType, callback)
         log.debug("Trying to register resource '%s' for lock type '%s'",

--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -426,9 +426,9 @@ class _ResourceManager(object):
         if not request.granted():
             try:
                 request.cancel()
-                raise RequestTimedOutError("Request timed out. Could not "
-                                           "acquire resource '%s.%s'" %
-                                           (namespace, name))
+                raise RequestTimedOutError(
+                    "Request timed out. Could not "
+                    f"acquire resource '{namespace}.{name}'")
             except RequestAlreadyProcessedError:
                 # We might have acquired the resource between 'wait' and
                 # 'cancel'


### PR DESCRIPTION
Fix various exceptions in the resourceManager module, so that
it is constructed wiht f-string instead of %-format.
Fix `ResourceAlreadyAcquired` exception that is
using a comma to separate instead of `%`, resulting in
bogus printed message.

Before:
```
vdsm.storage.resourceManager.ResourceAlreadyAcquired: ('%s is already
acquired by %s', '00_storage.a2ad7a23-96c5-4c23-9007-c0d1892ea07d',
'fb7c6873-74b4-4895-876a-a52ab7bfa082')
```
After:
```
vdsm.storage.resourceManager.ResourceAlreadyAcquired:
'00_storage.a2ad7a23-96c5-4c23-9007-c0d1892ea07d is already
acquired by fb7c6873-74b4-4895-876a-a52ab7bfa082'
```
Signed-off-by: Albert Esteve <aesteve@redhat.com>