### PR TITLE
docker: create venv for tests

### DIFF
--- a/docker/Dockerfile.alma-9
+++ b/docker/Dockerfile.alma-9
@@ -74,7 +74,8 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.
 COPY lvmlocal.conf /etc/lvm/

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -73,7 +73,8 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.
 COPY lvmlocal.conf /etc/lvm/

--- a/docker/Dockerfile.centos-9
+++ b/docker/Dockerfile.centos-9
@@ -74,7 +74,8 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.
 COPY lvmlocal.conf /etc/lvm/


### PR DESCRIPTION
In vdsm-test containers, create a
new venv [1] at /venv instead of installing
the required packages directly in the
root environment. Installing packages in
the root environment is strongly discouraged,
as it can run into conflicts with the system
package manager.

[1] - https://pip.pypa.io/warnings/venv

Signed-off-by: Albert Esteve <aesteve@redhat.com>