### PR TITLE
containers: fix local image name

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -59,7 +59,7 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ovirt/vdsm-test
+          image: vdsm-test
           tags: ${{ matrix.distro }}
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}


### PR DESCRIPTION
Local image name of the vdsm-test containers
is `vdsm-test:tag`. However, the containers test job, mimicking the network job, has `ovirt/vdsm-test` as the image name. As a result, when the job tries to upload the image, it fails to find it locally.

It should be just `vdsm-test`. The upload job will store the image for the oVirt user under
`ovirt/vdsm-test:tag` repository, as expected.

Fixes: 533322126010366da334d11980df4e1a525cf797
Signed-off-by: Albert Esteve <aesteve@redhat.com>