### PR TITLE
containers: test and network name consistency

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -59,7 +59,7 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: vdsm-test
+          image: ovirt/vdsm-test
           tags: ${{ matrix.distro }}
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 targets := alma-9 centos-8 centos-9
-prefix := vdsm-test
+prefix := ovirt/vdsm-test
 
 .PHONY: $(targets) push
 
@@ -13,5 +13,5 @@ $(targets):
 
 push:
 	for name in $(targets); do \
-		podman push $(prefix):$$name quay.io/ovirt/$(prefix):$$name; \
+		podman push $(prefix):$$name quay.io/$(prefix):$$name; \
 	done


### PR DESCRIPTION
Make vdsm-network and vdsm-test container
local tag consistent. This will make it easier
to handle in the containers github workflow.

Before:
ovirt/vdsm-network-tests
vdsm-test

After:
ovirt/vdsm-network-tests
ovirt/vdsm-test

Fixes: 533322126010366da334d11980df4e1a525cf797
Signed-off-by: Albert Esteve <aesteve@redhat.com>