### PR TITLE
ci: use new vdsm-test container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         distro: [centos-8, centos-9]
-    container: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
+    container: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
     steps:
     - uses: ovirt/checkout-action@main
     - name: Run linters
@@ -26,7 +26,7 @@ jobs:
       matrix:
         distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
+      image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Required to create loop devices.
       options: --privileged
     steps:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
+      image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Required to create loop devices.
       options: --privileged
     steps:
@@ -58,7 +58,7 @@ jobs:
       matrix:
         distro: [centos-8, centos-9]
     container:
-      image: quay.io/ovirt/vdsm-test-${{ matrix.distro }}
+      image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Needed for many operations, i.e. creating bridges
       options: --privileged
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos-8, centos-9]
+        distro: [centos-8, centos-9, alma-9]
     container: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
     steps:
     - uses: ovirt/checkout-action@main
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos-8, centos-9]
+        distro: [centos-8, centos-9, alma-9]
     container:
       image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Required to create loop devices.
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos-8, centos-9]
+        distro: [centos-8, centos-9, alma-9]
     container:
       image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Required to create loop devices.
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos-8, centos-9]
+        distro: [centos-8, centos-9, alma-9]
     container:
       image: quay.io/ovirt/vdsm-test:${{ matrix.distro }}
       # Needed for many operations, i.e. creating bridges

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,7 +72,7 @@ gitignore:
 
 .PHONY: pylint
 pylint: tox
-	tox -e pylint \
+	tox -e pylint -- \
 		$(PYLINT_TARGETS)
 
 execcmd:

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -3,6 +3,9 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+# Activate the tests venv (for containers only)
+[ -d /venv ] && source /venv/bin/activate
+
 ./autogen.sh --system
 make
 make lint

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -3,8 +3,15 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Activate the tests venv (for containers only)
-[ -d /venv ] && source /venv/bin/activate
+# Only when running in a container
+[ -d /venv ] && {
+    # Workaround to avoid this warning:
+    #   fatal: detected dubious ownership in repository at '/dir'
+    git config --global --add safe.directory "$(pwd)"
+
+    # Activate the tests venv (for containers only)
+    source /venv/bin/activate
+}
 
 ./autogen.sh --system
 make

--- a/ci/tests-storage.sh
+++ b/ci/tests-storage.sh
@@ -56,6 +56,9 @@ if [ -z "$user" ]; then
     exit 1
 fi
 
+# Activate the tests venv (for containers only)
+[ -d /venv ] && source /venv/bin/activate
+
 echo "Running tests as user $user"
 
 setup_storage

--- a/ci/tests-storage.sh
+++ b/ci/tests-storage.sh
@@ -56,8 +56,15 @@ if [ -z "$user" ]; then
     exit 1
 fi
 
-# Activate the tests venv (for containers only)
-[ -d /venv ] && source /venv/bin/activate
+# Only when running in a container
+[ -d /venv ] && {
+    # Workaround to avoid this warning:
+    #   fatal: detected dubious ownership in repository at '/dir'
+    git config --global --add safe.directory "$(pwd)"
+
+    # Activate the tests venv (for containers only)
+    source /venv/bin/activate
+}
 
 echo "Running tests as user $user"
 

--- a/ci/tests.sh
+++ b/ci/tests.sh
@@ -9,6 +9,9 @@ echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
 SUFFIX=$RANDOM
 ip link add mod_bond$SUFFIX type bond && ip link del mod_bond$SUFFIX
 
+# Activate the tests venv (for containers only)
+[ -d /venv ] && source /venv/bin/activate
+
 ./autogen.sh --system
 make
 make tests

--- a/ci/tests.sh
+++ b/ci/tests.sh
@@ -9,8 +9,15 @@ echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
 SUFFIX=$RANDOM
 ip link add mod_bond$SUFFIX type bond && ip link del mod_bond$SUFFIX
 
-# Activate the tests venv (for containers only)
-[ -d /venv ] && source /venv/bin/activate
+# Only when running in a container
+[ -d /venv ] && {
+    # Workaround to avoid this warning:
+    #   fatal: detected dubious ownership in repository at '/dir'
+    git config --global --add safe.directory "$(pwd)"
+
+    # Activate the tests venv (for containers only)
+    source /venv/bin/activate
+}
 
 ./autogen.sh --system
 make

--- a/tests/pywatch_test.py
+++ b/tests/pywatch_test.py
@@ -43,13 +43,14 @@ def has_py_gdb_support():
     pkg_name = "python{}".format(sys.version_info.major)
     pkg_ver = package_version(pkg_name)
 
-    # On CentOS we we don't have "python2" package and we must query "python"
-    # and "python-debuginfo".
-    if pkg_name == "python2" and not pkg_ver:
-        pkg_name = "python"
-        pkg_ver = package_version(pkg_name)
-
     pkg_dbg_ver = package_version("{}-debuginfo".format(pkg_name))
+
+    # On CentOS Stream 9 debuginfo packages now include the minor version in
+    # the name, i.e. python3.9-debuginfo-...
+    if pkg_dbg_ver == "":
+        pkg_name2 = "python{}.{}".format(sys.version_info.major,
+                                         sys.version_info.minor)
+        pkg_dbg_ver = package_version("{}-debuginfo".format(pkg_name2))
 
     return pkg_dbg_ver != "" and pkg_dbg_ver == pkg_ver
 

--- a/tox.ini
+++ b/tox.ini
@@ -200,7 +200,7 @@ commands =
         ./lib/vdsm/network/ \
         ./tests/network
 
-[testenv:reuse]
+[reuse]
 deps =
     reuse
 commands =


### PR DESCRIPTION
Update the cis workflow to use the new vdsm-test
container at quay.io/ovirt/vdsm-test:<distro>.

Modify the test scripts to activate the venv
before running the tests, otherwise the tests
will have missing dependencies that are only
installed in the venv in the new containers.

Signed-off-by: Albert Esteve <aesteve@redhat.com>