### PR TITLE
docker: python system packages

### DIFF
--- a/docker/Dockerfile.alma-9
+++ b/docker/Dockerfile.alma-9
@@ -74,7 +74,7 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m venv /venv \
+    && python3 -m venv --system-site-packages /venv \
     && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -73,7 +73,7 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m venv /venv \
+    && python3 -m venv --system-site-packages /venv \
     && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.

--- a/docker/Dockerfile.centos-9
+++ b/docker/Dockerfile.centos-9
@@ -74,7 +74,7 @@ RUN debuginfo-install -y python3 \
 # Add development packages
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m venv /venv \
+    && python3 -m venv --system-site-packages /venv \
     && /venv/bin/python3 -m pip install --requirement requirements.txt
 
 # Add lvm configuration.


### PR DESCRIPTION
Create virtual environment for vdsm-test container with
system packages.

Otherwise, el9 containers have missing
dependencies.

Fixes: cd4425e
Signed-off-by: Albert Esteve <aesteve@redhat.com>