### PR TITLE
Fix flapping disk info due to timing differences

### DIFF
--- a/tests/virt/qemuguestagent_test.py
+++ b/tests/virt/qemuguestagent_test.py
@@ -194,6 +194,7 @@ class QemuGuestAgentTests(TestCaseBase):
                     qemuguestagent._QEMU_DEVICES_COMMAND,
                     qemuguestagent._QEMU_GUEST_INFO_COMMAND,
                     qemuguestagent._QEMU_FSINFO_COMMAND,
+                    qemuguestagent._QEMU_DISKS_COMMAND,
                     qemuguestagent._QEMU_HOST_NAME_COMMAND,
                     qemuguestagent._QEMU_NETWORK_INTERFACES_COMMAND,
                     qemuguestagent._QEMU_OSINFO_COMMAND,


### PR DESCRIPTION
In commit 45903d01e142047093bf844628b5d90df12b6ffb there was code added to refresh the fs info earlier when a hotplug disk was added. Now this caused some side effect that when only that command was triggered, the info dict never contained 'disk.count', which caused us to change the diskMapping to the parsed data from fsinfo.

Some minutes later when the disk command needed to be refreshed, it changed the diskMapping again, because (sometimes) the disks call returns more disks in comparision to the fsinfo call (for ex unmounted disks).

Again a bit later, the fsinfo had to be refreshed, and the diskMapping was modified again.

This occurs continiously, causing the device hash to change every time, and causing an excessive amount of dumpxml's also due to that.

Fixed this by not setting the diskMapping when we have the _QEMU_DISKS_COMMAND in our caps. As this means somewhere else in time this command will refresh the disk info.
Also refresh the disk info and not only fs info after a disk hotplug.

Signed-off-by: Jean-Louis Dupond <jean-louis@dupond.be>
Change-Id: I27a30e020a5221237d9d4ae7835a1cc4e69c0c59