### PR TITLE
Bump OvS to 2.17 and OVN to 2.19 on EL9

### DIFF
--- a/vdsm.spec.in
+++ b/vdsm.spec.in
@@ -370,9 +370,15 @@ Requires:       NetworkManager-ovs
 Requires:       ethtool
 Requires:       iproute
 Requires:       iproute-tc
+%if 0%{?rhel} >= 9
+Requires:       ovirt-openvswitch >= 2.17
+# Workaround for BZ#1966143
+Requires:       ovirt-python-openvswitch >= 2.17
+%else
 Requires:       ovirt-openvswitch >= 2.15
 # Workaround for BZ#1966143
 Requires:       ovirt-python-openvswitch >= 2.15
+%endif
 Requires:       nmstate >= 1.2.1-3
 %if 0%{?rhel} < 9
 Requires:       nmstate-plugin-ovsdb


### PR DESCRIPTION
OvS 2.17 and OVN 2.19 are the lowest supported versions on EL9, so we
need to bump the requirements. But OvS 2.15 and OVN 2021 are the
supported versions on EL8, no changes there.

Signed-off-by: Martin Perina <mperina@redhat.com>
