### PR TITLE
github actions: upgrade to checkout version 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: ovirt/checkout-action@main
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         container: [ functional, integration, unit ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update
@@ -46,7 +46,7 @@ jobs:
       matrix:
         distro: [ centos-8, centos-9, alma-9 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         container: [ functional, integration, unit ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: ovirt/checkout-action@main
       - name: Install dependencies
         run: |
           sudo apt update
@@ -46,7 +46,7 @@ jobs:
       matrix:
         distro: [ centos-8, centos-9, alma-9 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: ovirt/checkout-action@main
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -37,7 +37,7 @@ jobs:
           - type: integration
             tag: centos-9
     steps:
-      - uses: actions/checkout@v3
+      - uses: ovirt/checkout-action@main
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -27,6 +27,7 @@ jobs:
       IMAGE_TAG: ${{ matrix.tag }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         type: [ unit, integration, functional ]
         tag: [ alma-9, centos-8 ]
@@ -36,7 +37,7 @@ jobs:
           - type: integration
             tag: centos-9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
Version 2 of the checkout action produces a warning and cancels the action. Upgrading to version 3.

Change-Id: I6f80aeae400104a188615444ca3bdbbcc8817898
Signed-off-by: Eitan Raviv <eraviv@redhat.com>