### PR TITLE
network: tests - use make to build nmstate

### DIFF
--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -30,12 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         type: [ unit, integration, functional ]
-        tag: [ alma-9, centos-8 ]
-        include:
-          - type: unit
-            tag: centos-9
-          - type: integration
-            tag: centos-9
+        tag: [ centos-8, centos-9 ]
     steps:
       - uses: ovirt/checkout-action@main
       - name: Install dependencies

--- a/tests/network/functional/run-tests.sh
+++ b/tests/network/functional/run-tests.sh
@@ -35,6 +35,10 @@ function replace_resolvconf {
 }
 
 function install_nmstate_from_source {
+    BUILD_NMSTATE = "make rpm"
+    if grep -q "8" <<< $IMAGE_TAG ; then
+      BUILD_NMSTATE = "pip3 install --no-deps -U ."
+    fi
     container_exec "
         mkdir $NMSTATE_TMP \
         && \
@@ -42,7 +46,7 @@ function install_nmstate_from_source {
         && \
         cd $NMSTATE_TMP/nmstate \
         && \
-        pip3 install --no-deps -U . \
+        $BUILD_NMSTATE \
         && \
         cd -
     "


### PR DESCRIPTION
Building nmstate from source for the tests now requires using `make rpm` instead of pip install.

Change-Id: I46bf7fa6acf29da41ed313252aa54a64c6b24ab1