### PR TITLE
volume: allow extend cow preallocated

### DIFF
--- a/lib/vdsm/storage/blockVolume.py
+++ b/lib/vdsm/storage/blockVolume.py
@@ -718,7 +718,7 @@ class BlockVolume(volume.Volume):
     def getMetaSlot(self):
         return self._manifest.getMetaSlot()
 
-    def _extendSizeRaw(self, new_capacity):
+    def _extendSize(self, new_capacity):
         # Since this method relies on lvm.extendLV (lvextend) when the
         # requested size is equal or smaller than the current size, the
         # request is siliently ignored.

--- a/lib/vdsm/storage/fileVolume.py
+++ b/lib/vdsm/storage/fileVolume.py
@@ -734,7 +734,7 @@ class FileVolume(volume.Volume):
         # pylint: disable=no-member
         return self._manifest.getLeaseVolumePath(vol_path)
 
-    def _extendSizeRaw(self, new_capacity):
+    def _extendSize(self, new_capacity):
         volPath = self.getVolumePath()
         cur_capacity = self.oop.os.stat(volPath).st_size
 

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -1381,11 +1381,11 @@ class Volume(object):
             raise se.VolumeNonWritable(self.volUUID)
 
         volFormat = self.getFormat()
-        if volFormat == sc.COW_FORMAT:
+        if volFormat == sc.COW_FORMAT and self.getType() == sc.SPARSE_VOL:
             self.log.debug("skipping cow size extension for volume %s to "
                            "capacity %s", self.volUUID, new_capacity)
             return
-        elif volFormat != sc.RAW_FORMAT:
+        if volFormat not in [sc.RAW_FORMAT, sc.COW_FORMAT]:
             raise se.IncorrectFormat(self.volUUID)
 
         # Note: This function previously prohibited extending non-leaf volumes.

--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -1416,7 +1416,7 @@ class Volume(object):
                 "Extend size for volume: " + self.volUUID, "volume",
                 "Volume", "extendSizeFinalize",
                 [self.sdUUID, self.imgUUID, self.volUUID]))
-            self._extendSizeRaw(new_capacity)
+            self._extendSize(new_capacity)
 
         self.syncMetadata()  # update the metadata
 
@@ -1594,7 +1594,7 @@ class Volume(object):
     def getImageVolumes(cls, sdUUID, imgUUID):
         return cls.manifestClass.getImageVolumes(sdUUID, imgUUID)
 
-    def _extendSizeRaw(self, newSize):
+    def _extendSize(self, newSize):
         raise NotImplementedError
 
     # Used only for block volume

--- a/tests/storage/blocksd_test.py
+++ b/tests/storage/blocksd_test.py
@@ -1859,7 +1859,6 @@ def test_reduce_volume_skipped(domain_factory, fake_task, fake_sanlock):
 
 @requires_root
 @pytest.mark.root
-@pytest.mark.xfail(reason='Cow volumes are not extended.')
 def test_extend_volume(domain_factory, fake_task, fake_sanlock):
     """
     Test added to verify fix for https://bugzilla.redhat.com/2170689.


### PR DESCRIPTION
Currently we assume in the code that cow
volumes do not need to be extended in any case.
However, all preallocated volumes, both
cow and raw, should be extended when requested.
Otherwise, cow preallocated volumes have bigger
capacity than their truesize. Thus, when the size
of the disk reaches the truesize, the VM will
pause, which is an undesired effect.

To avoid this, we relax this assumption so that
only cow sparse volumes are skipped on extend calls.

Bug-Url: https://bugzilla.redhat.com/2170689
Signed-off-by: Albert Esteve <aesteve@redhat.com>