### PR TITLE
ci: Mark the current git directory as safe

### DIFF
--- a/ci/rpm.sh
+++ b/ci/rpm.sh
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+git config --global --add safe.directory "$PWD"
+
 export EXPORT_DIR="${EXPORT_DIR:-exported-artifacts}"
 
 if [ "$GITHUB_EVENT_NAME" = "push" ]; then


### PR DESCRIPTION
This is necessary to prevent

  fatal: detected dubious ownership in repository at '/__w/vdsm/vdsm'

messages in the CentOS Stream 9 container and, more importantly, making wrong rpm release version there when building rpm’s.  Without this, the determined release version on CI is always ‘1’, which results in not installing the required set of rpm’s in OST and an OST failure.