### PR TITLE
managedvolume: add support for local device

### DIFF
--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -49,6 +49,9 @@ SUPPORTED_DRIVERS = (
 
     # Tested by Muli Ben-Yehuda <info (at) lightbitslabs.com>
     "lightos",
+
+    # Tested by Moritz Wanzenböck <technik+ovirt (at) linbit.com>
+    "local",
 )
 
 log = logging.getLogger("storage.managedvolume")


### PR DESCRIPTION
"local" connections are used by storage systems that directly set up devices on vdsm nodes, such as linstor[1]

[1]: https://docs.openstack.org/cinder/latest/configuration/block-storage/drivers/linstor-driver.html