### PR TITLE
volume: Extend raw sparse

### DIFF
--- a/lib/vdsm/storage/volume.py
+++ b/lib/vdsm/storage/volume.py
@@ -1380,9 +1380,10 @@ class Volume(object):
         if self.isShared():
             raise se.VolumeNonWritable(self.volUUID)
 
-        if self.getType() == sc.SPARSE_VOL:
-            self.log.debug("skipping sparse size extension for volume %s to "
-                           "capacity %s", self.volUUID, new_capacity)
+        if (self.getFormat() == sc.COW_FORMAT and
+                self.getType() == sc.SPARSE_VOL):
+            self.log.debug("skipping cow sparse size extension for volume %s "
+                           "to capacity %s", self.volUUID, new_capacity)
             return
 
         # Note: This function previously prohibited extending non-leaf volumes.

--- a/tests/storage/filevolume_test.py
+++ b/tests/storage/filevolume_test.py
@@ -157,7 +157,6 @@ def test_volume_size_unaligned(monkeypatch, tmpdir, tmp_repo, fake_access,
     assert vol.getCapacity() == expected_vol_capacity
 
 
-@pytest.mark.xfail(reason='Raw sparse volumes are not extended.')
 def test_extend_volume(tmp_repo, fake_access, fake_task):
     """
     Test added to verify fix for https://bugzilla.redhat.com/2210036.


### PR DESCRIPTION
Consider format also on the skip condition
for extending volumes. Only COW sparse volumes
shall be skipped.

Fixes: https://github.com/oVirt/vdsm/commit/c9d6da42bc43e863c3110d78769595785f35fc07
Bug-Url: https://bugzilla.redhat.com/2210036
Signed-off-by: Albert Esteve <aesteve@redhat.com>