### PR TITLE
Teardown replica when replication fails

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -4443,6 +4443,13 @@ class Vm(object):
                            "srcDisk: %r, job: %r)",
                            drive.name, srcDisk, blkJobInfo)
 
+            # best-effort attempt to tear down the replica
+            try:
+                self.cif.teardownVolumePath(drive.diskReplicate)
+            except Exception as e:
+                self.log.exception("Failed to teardown replica of %s: %s",
+                                   drive, e)
+
             # Making sure that we don't have any stale information
             self._delDiskReplica(drive)
             return response.error('replicaErr')


### PR DESCRIPTION
When disk replication fails during live storage migration, we detect it properly, fail the operation and remove the disk from the destination storage domain. However, we didn't tear down the replica on the host that executes the replication and therefore, if the removal of the destination disk was done on a different host, we had leftovers remaining on the host that executed the replication.

This patch changes the diskReplicateFinish function to tear down the replicate when the corresponding block job doesn't exist in order to prevent this scenario of having leftovers on the host that could lead to data corruption later on.

Bug-Url: https://bugzilla.redhat.com/2193392