### PR TITLE
Fix the cpu pinning parsing logic to parse the format appropriately and exclude cpu from pinning list

### DIFF
--- a/lib/vdsm/taskset.py
+++ b/lib/vdsm/taskset.py
@@ -91,10 +91,13 @@ def cpulist_parse(cpu_range):
     or the output of the 'taskset' and 'lscpu' tools.
     """
     cpus = []
+    excluded_cpus = []
     for item in cpu_range.split(','):
         if '-' in item:
             begin, end = item.split('-', 1)
             cpus.extend(range(int(begin), int(end) + 1))
+        elif item.startswith("^"):
+            excluded_cpus.append(int(item[1:]))
         else:
             cpus.append(int(item))
-    return frozenset(cpus)
+    return frozenset(cpus) - frozenset(excluded_cpus)

--- a/tests/virt/domaindescriptor_test.py
+++ b/tests/virt/domaindescriptor_test.py
@@ -112,6 +112,7 @@ PINNED_CPUS = """
     <cputune>
         <vcpupin vcpu="0" cpuset="1,2,5-7" />
         <vcpupin vcpu="1" cpuset="1,6,10" />
+        <vcpupin vcpu="2" cpuset="1-4,^3,6" />
     </cputune>
 </domain>
 """
@@ -261,9 +262,10 @@ class DomainDescriptorTests(XMLTestCase):
     def test_pinned_cpus(self):
         desc = DomainDescriptor(PINNED_CPUS)
         pinning = desc.pinned_cpus
-        assert len(pinning) == 2
+        assert len(pinning) == 3
         assert pinning[0] == frozenset([1, 2, 5, 6, 7])
         assert pinning[1] == frozenset([1, 6, 10])
+        assert pinning[2] == frozenset([1, 2, 4, 6])
 
     def test_no_pinned_cpus(self):
         desc = DomainDescriptor(NO_PINNED_CPUS)


### PR DESCRIPTION
Issue: The CPU pinning tool tip says that to exclude a cpu from pinning, it needs to provided in the following format.
0#10-13_1#25-27,^26

With this format CPU 26 will be excluded from pinning. However, vdsm code fails to parse the above string resulting in VM start failure.

Fix: Fix the cpu pinning parsing logic to parse the format appropriately and exclude cpu from pinning list.



Signed-off-by: ShubhaOracle <Shubha.kulkarni@oracle.com>
