### PR TITLE
fix_Flake8_Rules_E713

### DIFF
--- a/lib/vdsm/network/nmstate/ovs/network.py
+++ b/lib/vdsm/network/nmstate/ovs/network.py
@@ -205,7 +205,7 @@ class OvsBridge(object):
             persisted_ports_by_bridge[bridge] = [
                 port
                 for port in ports
-                if not port[OvsBridgeSchema.Port.NAME] in net_names
+                if port[OvsBridgeSchema.Port.NAME] not in net_names
             ]
         return persisted_ports_by_bridge
 

--- a/lib/vdsm/storage/formatconverter.py
+++ b/lib/vdsm/storage/formatconverter.py
@@ -96,7 +96,7 @@ def v3DomainConverter(repoPath, hostId, domain, isMsd):
         vol._setrw(True)
 
     def v3ReallocateMetadataSlot(domain, allVolumes):
-        if not domain.getStorageType() in sd.BLOCK_DOMAIN_TYPES:
+        if domain.getStorageType() not in sd.BLOCK_DOMAIN_TYPES:
             log.debug("The metadata reallocation check is not needed for "
                       "domain %s", domain.sdUUID)
             return

--- a/lib/vdsm/storage/sd.py
+++ b/lib/vdsm/storage/sd.py
@@ -214,13 +214,13 @@ def packLeaseParams(lockRenewalIntervalSec, leaseTimeSec,
 
 
 def validateSDDeprecatedStatus(status):
-    if not status.capitalize() in DEPRECATED_STATUSES:
+    if status.capitalize() not in DEPRECATED_STATUSES:
         raise se.StorageDomainStatusError(status)
     return DEPRECATED_STATUSES[status.capitalize()]
 
 
 def validateSDStatus(status):
-    if not status.capitalize() in DOMAIN_STATUSES:
+    if status.capitalize() not in DOMAIN_STATUSES:
         raise se.StorageDomainStatusError(status)
 
 

--- a/lib/vdsm/tool/configurators/libvirt.py
+++ b/lib/vdsm/tool/configurators/libvirt.py
@@ -97,7 +97,7 @@ def isconfigured():
     if not _is_hugetlbfs_1g_mounted():
         ret = NO
 
-    if not _socket_unit() in _unit_requirements(_LIBVIRT_SERVICE_UNIT):
+    if _socket_unit() not in _unit_requirements(_LIBVIRT_SERVICE_UNIT):
         ret = NO
 
     if ret == MAYBE:

--- a/tests/schemavalidation_test.py
+++ b/tests/schemavalidation_test.py
@@ -127,12 +127,12 @@ class SchemaValidation(TestCaseBase):
                     for marg in method_args:
                         # verify optional arg
                         if 'defaultvalue' in marg:
-                            if not marg.get('name') in default_args:
+                            if marg.get('name') not in default_args:
                                 raise AssertionError(
                                     self._prep_msg(rep, method_args, args))
                             continue
                         # verify args from schema in apiobj args
-                        if not marg.get('name') in args:
+                        if marg.get('name') not in args:
                             raise AssertionError(
                                 self._prep_msg(rep, method_args, args))
                     try:

--- a/tests/virt/vmoperations_test.py
+++ b/tests/virt/vmoperations_test.py
@@ -77,7 +77,7 @@ class TestVmOperations(XMLTestCase):
     def testTimeOffsetNotPresentByDefault(self, exitCode):
         with fake.VM() as testvm:
             testvm.setDownStatus(exitCode, vmexitreason.GENERIC_ERROR)
-            assert not ('timeOffset' in testvm.getStats())
+            assert 'timeOffset' not in testvm.getStats()
 
     @MonkeyPatch(libvirtconnection, 'get', lambda x: fake.Connection())
     @permutations([[define.NORMAL], [define.ERROR]])

--- a/vdsm_hooks/scratchpad/before_vm_start.py
+++ b/vdsm_hooks/scratchpad/before_vm_start.py
@@ -84,7 +84,7 @@ def add_disk(domxml, path):
         disks.append(d.getElementsByTagName('target')[0].getAttribute('dev'))
 
     for i in range(0, 27):
-        if not indexToDiskName(i) in disks:
+        if indexToDiskName(i) not in disks:
             target.setAttribute('dev', indexToDiskName(i))
             break
     disk.appendChild(target)


### PR DESCRIPTION
While the difference between X not in Y and not X in Y may be negligible from a performance standpoint, using a more direct form can in some cases make it easier for the code optimizer in the Python interpreter.