### PR TITLE
Add support for cluster level 4.8

### DIFF
--- a/lib/vdsm/common/dsaversion.py.in
+++ b/lib/vdsm/common/dsaversion.py.in
@@ -27,13 +27,25 @@ def _get_libvirt_version():
     return libvirt_version[:2]
 
 
+def _get_qemukvm_version():
+    packages = osinfo.package_versions()
+    qemukvm_version = tuple(
+        int(v)
+        for v in packages['qemu-kvm']['version'].split('.')
+    )
+    return qemukvm_version[:2]
+
+
 @cache.memoized
 def version_info():
     cluster_levels = ['4.2', '4.3', '4.4', '4.5', '4.6']
     libvirt_version = _get_libvirt_version()
+    qemukvm_version = _get_qemukvm_version()
 
     if libvirt_version >= (8, 0):
         cluster_levels.append('4.7')
+    if libvirt_version >= (9, 5) and qemukvm_version >= (8, 1):
+        cluster_levels.append('4.8')
 
     return {
         'version_name': version_name,


### PR DESCRIPTION
This patch adds support for cluster compatibility level 4.8. Support for cluster compatibility level 4.8 is reported when the libvirt version >= 9.5.0 and qemu-kvm version >= 8.1.0. This version of libvirt adds support for the discard-no-unref option in qemu (https://patchew.org/QEMU/20230602124747.1544077-1-jean-louis@dupond.be/)

Corresponding PR: https://github.com/oVirt/ovirt-engine/pull/938