### PR TITLE
virt: remove bandwidth limit on nic update

### DIFF
--- a/lib/vdsm/virt/vmdevices/network.py
+++ b/lib/vdsm/virt/vmdevices/network.py
@@ -482,12 +482,12 @@ def update_port_xml(vnicXML, port_isolated):
 
 
 def update_bandwidth_xml(iface, vnicXML, specParams=None):
+    oldBandwidth = vmxml.find_first(vnicXML, 'bandwidth', None)
+    if oldBandwidth is not None:
+        vmxml.remove_child(vnicXML, oldBandwidth)
     if (specParams and
             ('inbound' in specParams or 'outbound' in specParams)):
-        oldBandwidth = vmxml.find_first(vnicXML, 'bandwidth', None)
         newBandwidth = iface.get_bandwidth_xml(specParams, oldBandwidth)
-        if oldBandwidth is not None:
-            vmxml.remove_child(vnicXML, oldBandwidth)
         vmxml.append_child(vnicXML, newBandwidth)
 
 

--- a/tests/virt/devicexml_test.py
+++ b/tests/virt/devicexml_test.py
@@ -162,6 +162,17 @@ class DeviceToXMLTests(XMLTestCase):
         vmdevices.network.update_bandwidth_xml(dev, vnic_xml, specParams)
         self.assertXMLEqual(xmlutils.tostring(vnic_xml), XML)
 
+        specParams = {}
+        XML = u"""
+        <interface type='network'>
+          <mac address="fake" />
+          <source bridge='default'/>
+          <link state="up"/>
+        </interface>
+        """
+        vmdevices.network.update_bandwidth_xml(dev, vnic_xml, specParams)
+        self.assertXMLEqual(xmlutils.tostring(vnic_xml), XML)
+
 
 @expandPermutations
 class ParsingHelperTests(XMLTestCase):


### PR DESCRIPTION
There was some logic error in the update_bandwidth_xml function. If you have a running VM with a NIC that has a QoS, it will contain a bandwidth setting in the XML.
Now if you change the NIC to a vNIC Profile without QoS, it will not contain the 'inbound' and 'outbound' specParams, and the old QoS will never get removed (only after stop/start).

So we take the removal of the bandwidth out of the if so the limit gets cleared correctly.