### PR TITLE
Skip LVM filesystem check on LV reduction

### DIFF
--- a/lib/vdsm/osinfo.py
+++ b/lib/vdsm/osinfo.py
@@ -248,6 +248,7 @@ def package_versions():
             'qemu-kvm': ('qemu-kvm', 'qemu-kvm-rhev', 'qemu-kvm-ev'),
             'spice-server': ('spice-server',),
             'vdsm': ('vdsm',),
+            'lvm2': ('lvm2', 'lvm2-libs'),
         }
 
         if glusterEnabled:
@@ -281,6 +282,7 @@ def package_versions():
             'qemu-kvm': 'qemu-kvm',
             'spice-server': 'libspice-server1',
             'vdsm': 'vdsmd',
+            'lvm2': 'lvm2',
         }
 
         if glusterEnabled:

--- a/tests/lib/osinfo_test.py
+++ b/tests/lib/osinfo_test.py
@@ -36,6 +36,7 @@ def test_kernel_args(test_input, expected_result):
 def test_package_versions():
     pkgs = osinfo.package_versions()
     assert 'kernel' in pkgs
+    assert 'lvm2' in pkgs
 
 
 def test_get_boot_uuid(fake_findmnt):


### PR DESCRIPTION
Since LVM v2.03.17 (https://github.com/lvmteam/lvm2/commit/f6f2737015746b1b6c7fbd0d297a4596c584749b), reducing a logical volume (LV) requires the LV to be active due to the default 'checksize' option, which requires an active LV. This results in the following error when attempting to reduce a non-active LV:

`err=[\'  The LV must be active to safely reduce (see --fs options.)\']' ----`

To resolve this, we now check if the LVM version is newer than 2.03.17. If so, we bypass the 'checksize' by using the '--fs ignore' option. This approach is viable because oVirt already handles checksize, making lvreduce redundant.