### PR TITLE
tests: add dep on packaging in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     pytest
     pytest-cov
     pytest-timeout
+    packaging
 changedir = {toxinidir}/tests
 markers = "not (integration or slow or stress)"
 


### PR DESCRIPTION
There is an incompatibility between packaging version from CentOS and setuptools from pip. Which causes a failure running the tests: TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'

See also https://github.com/pypa/setuptools/issues/4483

Fix this by using a the current packaging version instead of the CentOS packaged one.