### PR TITLE
virt: handle capacity=0 in getNextVolumeSize

### DIFF
--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -350,6 +350,8 @@ class Drive(core.Base):
         libvirt.virDomain.blockInfo() or qemuimg.info().
         """
         nextSize = utils.round(curSize + self.volExtensionChunk, MiB)
+        if capacity == 0:
+            return nextSize
         return min(nextSize, self.getMaxVolumeSize(capacity))
 
     def getMaxVolumeSize(self, capacity):


### PR DESCRIPTION
We saw a case where domstats returned capacity=0 just after taking a snapshot.
This causes a ImprobableAllocationError to be triggered and permanently keep the VM into a hanging paused state.

As writes can't be flushed to disk, the qcow2 image can become corrupted also when the VM is stopped.

So we add some fallback if capacity=0 so the disk is at least resized, so we don't end up with a broken VM.