### PR TITLE
API: added method for deleting unused links

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -903,11 +903,19 @@ class Image(APIBase):
         APIBase.__init__(self)
         self._UUID = UUID
         self._spUUID = spUUID
+        self._log = logging.getLogger("{}.Image".format(__name__))
         self._sdUUID = sdUUID
 
     def delete(self, postZero, force, discard=False):
         return self._irs.deleteImage(self._sdUUID, self._spUUID, self._UUID,
                                      postZero, force, discard)
+
+    def deleteUnusedLinks(self, postZero=False, force=False, discard=False):
+        """
+        Delete unused links for volumes after delete image from SP
+        """
+        return self._irs.deleteUnusedLinks(self._sdUUID, self._spUUID, self._UUID,
+                                    postZero, force, discard)
 
     def deleteVolumes(self, volumeList, postZero=False, force=False,
                       discard=False):

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -9928,6 +9928,35 @@ Image.delete:
         description: A task UUID
         type: *UUID
 
+Image.deleteUnusedLinks:
+    added: '4.2'
+    description: Delete unused links for volumes after delete disk.
+    params:
+    -   description: The UUID of the Image
+        name: imageID
+        type: *UUID
+
+    -   description: The UUID of the Storage Pool associated with the Image
+        name: storagepoolID
+        type: *UUID
+
+    -   description: The UUID of the Storage Domain associated with the Image
+        name: storagedomainID
+        type: *UUID
+
+    -   description: If True, overwrite Volume data with zeroes after deletion
+        name: postZero
+        type: boolean
+
+    -   description: Force the operation and do not perform any validation
+        name: force
+        type: boolean
+
+    -   defaultvalue: false
+        description: If true, discard the image and its volumes before deletion
+        name: discard
+        type: boolean
+
 Image.deleteVolumes:
     added: '3.1'
     description: Delete one or more Volumes associated with this image.

--- a/lib/vdsm/rpc/Bridge.py
+++ b/lib/vdsm/rpc/Bridge.py
@@ -345,6 +345,7 @@ command_info = {
     'Host_echo': {'ret': 'logged'},
     'Image_cloneStructure': {'ret': 'uuid'},
     'Image_delete': {'ret': 'uuid'},
+    'Image_deleteUnusedLinks': {'ret': 'status'},
     'Image_deleteVolumes': {'ret': 'uuid'},
     'Image_getVolumes': {'ret': 'uuidlist'},
     'Image_download': {'ret': 'uuid'},

--- a/lib/vdsm/storage/exception.py
+++ b/lib/vdsm/storage/exception.py
@@ -351,6 +351,11 @@ class InvalidVolumeUpdate(StorageException):
         self.value = "vol_id=%s, reason=%s" % (vol_id, reason)
 
 
+class CannotDeleteLinks(StorageException):
+    code = 236      # change code
+    msg = "Links deletion error"
+
+
 #################################################
 #  Images Exceptions
 #################################################

--- a/lib/vdsm/storage/hsm.py
+++ b/lib/vdsm/storage/hsm.py
@@ -29,6 +29,7 @@ from vdsm.common import concurrent
 from vdsm.common import exception
 from vdsm.common import function
 from vdsm.common import supervdsm
+from vdsm.common import response
 from vdsm.common.marks import deprecated
 from vdsm.common.threadlocal import vars
 from vdsm.common.time import monotonic_time
@@ -1282,6 +1283,7 @@ class HSM(object):
                           volUUID, desc, srcImgUUID, srcVolUUID, initial_size,
                           addBitmaps, legal, sequence, bitmap)
 
+
     @public
     def deleteVolume(self, sdUUID, spUUID, imgUUID, volumes, postZero=False,
                      force=False, discard=False):
@@ -1355,6 +1357,36 @@ class HSM(object):
             self._spmSchedule(spUUID, "purgeImage_%s" % imgUUID,
                               pool.purgeImage, sdUUID, imgUUID, volsByImg,
                               discard)
+
+    @public
+    def deleteUnusedLinks(self, sdUUID, spUUID, imgUUID, postZero=False,
+                     force=False, discard=False):
+        """
+        Delete Unused links
+        """
+        argsStr = "sdUUID=%s, spUUID=%s, imgUUID=%s, " \
+                  "postZero=%s, force=%s, discard=%s" % \
+                  (sdUUID, spUUID, imgUUID, postZero, force, discard)
+        # fileVolume path has pattern:/rhev/data-center/mnt/blockSD/sdUUID/images/imgUUID/volUUID
+        mountpoint = os.path.dirname("/rhev/data-center/mnt/blockSD/")
+        sdPath = os.path.join(mountpoint, sdUUID)
+        domainImages = 'images'
+        imagePath = os.path.join(sdPath, domainImages, imgUUID)
+        if os.path.exists(imagePath):
+            try:
+                for file in os.listdir(imagePath):
+                    self.log.info("Unlinking volume: %s", file)
+                    os.unlink(os.path.join(imagePath, file))
+                self.log.info("Deleting unused imagePath: %s" % imagePath)
+                os.rmdir(imagePath)
+                return response.success()
+            except Exception as e:
+                self.log.error("Cannot delete image's %s/%s link path: %s",
+                               sdUUID, imgUUID, imagePath, exc_info=True)
+                raise se.CannotDeleteLinks()
+        else:
+            self.log.info("Unused links for image %s doesn't exists", imgUUID)
+            return response.success()
 
     @public
     def verify_untrusted_volume(self, spUUID, sdUUID, imgUUID, volUUID):


### PR DESCRIPTION
**Problem:**
When creating a disk on a block storage domain (for example, FibreChannel), links to the disk are created on all active hosts that belong to the StoragePool of the disk being created. Further, when deleting a created disk, links to the disk are deleted only on the host with the SPM role, while incorrect links to the deleted disk remain on the other hosts.

**Playback:**
Environment: SA oVirt Engine, 2 hosts (Host 1 with the SPM role), a FibreChannel storage domain.
**Actions:**

1. Create two disks in the FibreChannel storage domain.
2. Links to these two disks are immediately created on Host 1 (SPM)
```shell
[root@host1 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
…
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:50 7c451669-9d44-4994-9711-389d5026ff36
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:50 e394da48-7cf3-413a-b22c-7a9fc56d8985
``` 
3. After some time, links to the created disks are created on Host 2.
```shell
[root@host2 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
…
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:51 7c451669-9d44-4994-9711-389d5026ff36
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:51 e394da48-7cf3-413a-b22c-7a9fc56d8985
``` 
4. Delete both created disks.
5. Disk links have been deleted on Host 1 (SPM).
```shell
[root@host1 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
drwxr-xr-x. 4 vdsm kvm 94 Apr 11 08:52 .
drwxr-xr-x. 5 vdsm kvm 48 Apr 10 13:30 ..
```
6. There are still links to deleted disks on the Host 2, but they are now incorrect:
```shell
[root@host2 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
…
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:51 7c451669-9d44-4994-9711-389d5026ff36
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:51 e394da48-7cf3-413a-b22c-7a9fc56d8985
``` 
**Solution:**
Added an API method on VDSM to remove unused links. When deleting a disk, the command to delete unused links is invoked for all active hosts that are associated with the StoragePool of the disk being deleted.

**Playback (after solved issue):**
Environment: SA oVirt Engine, 2 hosts (Host 1 with the SPM role), a FibreChannel storage domain.
 _Actions:_
1. Create two disks in the FibreChannel storage domain.
2. Links to these two disks are immediately created on Host 1 (SPM)
```shell
[root@host1 ~]#  ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
…
drwxr-xr-x. 2 vdsm kvm  50 Apr 15 07:18 2a1bff81-1474-44a1-8cd2-ca39b0b498e7
drwxr-xr-x. 2 vdsm kvm  50 Apr 15 07:18 311450d6-854c-4a56-84fe-4ce7bb432b86
``` 
3. After some time, links to the created disks are created on Host 2
```shell
 [root@host2 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
…
drwxr-xr-x. 2 vdsm kvm  50 Apr 15 07:18 311450d6-854c-4a56-84fe-4ce7bb432b86
drwxr-xr-x. 2 vdsm kvm  50 Apr 15 07:18 2a1bff81-1474-44a1-8cd2-ca39b0b498e7
```
4. Delete both created disks.
5. Disk links have been deleted on Host 1 (SPM).
```shell
[root@host1 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
drwxr-xr-x. 4 vdsm kvm 94 Apr 11 08:52 .
drwxr-xr-x. 5 vdsm kvm 48 Apr 10 13:30 ..
``` 
6. Disk links have been deleted on Host 2.
```shell
 [root@host2 ~]# ls -la /rhev/data-center/77b48f64-1484-11f0-9d8c-566fd2810d4a/ab643bd9-8753-4375-8c6c-eb1fbedcf6b4/images/
total 0
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 08:52 .
drwxr-xr-x. 2 vdsm kvm  50 Apr 11 13:30 ..
```
**Attention!**
This PR should be applied only after applying PR on the VDSM:
https://github.com/oVirt/ovirt-engine/pull/1009

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes