### PR TITLE
aarch64: add default image

### DIFF
--- a/lib/vdsm/virt/libvirtxml.py
+++ b/lib/vdsm/virt/libvirtxml.py
@@ -16,6 +16,7 @@ _DEFAULT_MACHINES = {
     cpuarch.PPC64: 'pseries',
     cpuarch.PPC64LE: 'pseries',
     cpuarch.S390X: 's390-ccw-virtio',
+    cpuarch.AARCH64: 'virt',
 }
 
 


### PR DESCRIPTION
Add the 'generic virtual board model' for aarch64 support.

Currently there is no aarch64 board supported in vdsm/_DEFAULT_MACHINES and according to the qemu documentation
https://qemu-project.gitlab.io/qemu/system/arm/virt.html
'virt' seems to be the recommended generic board model for this platform.

