### PR TITLE
conf: upgrade 4.8 version check

### DIFF
--- a/lib/vdsm/common/dsaversion.py.in
+++ b/lib/vdsm/common/dsaversion.py.in
@@ -44,7 +44,7 @@ def version_info():
 
     if libvirt_version >= (8, 0):
         cluster_levels.append('4.7')
-    if libvirt_version >= (9, 5) and qemukvm_version >= (8, 1):
+    if libvirt_version >= (10, 10) and qemukvm_version >= (9, 1):
         cluster_levels.append('4.8')
 
     return {


### PR DESCRIPTION
Update the versions of libvirt and qemu that are required for cluster version 4.8.