### PR TITLE
ci: only run CI on PR to master and Push on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 env:
   EXPORT_DIR: exported-artifacts
 jobs:


### PR DESCRIPTION
Only run the CI when it's a PR to master branch.
Or when something is pushed to master branch.