### PR TITLE
common: fix early stop of panic

### DIFF
--- a/lib/vdsm/common/panic.py
+++ b/lib/vdsm/common/panic.py
@@ -23,3 +23,4 @@ def panic(msg):
         logging.shutdown()
     finally:
         ready.set()
+    t.join()


### PR DESCRIPTION
Add a join() to the thread, otherwise it happens that the main process is already closed and the thread is still alive (because daemon = True).

This causes issues in tests, cause the returncode is 0 instead of -9, as there was not enough time to execute the os.killpg before the main thread ended.