### PR TITLE
network: fix route for own subnet

### DIFF
--- a/lib/vdsm/network/nmstate/route.py
+++ b/lib/vdsm/network/nmstate/route.py
@@ -225,7 +225,7 @@ class SourceRouteHelper(object):
             ),
             _create_route_state(
                 self._next_hop,
-                self._ipaddr,
+                "0.0.0.0",
                 self._network,
                 table_id=self._table_id,
             ),


### PR DESCRIPTION
Before the fix, the following routes were created for traffic to ovirtmgmt:
default via 10.0.10.1 dev ovirtmgmt proto static
10.0.10.0/24 via 10.0.10.5 dev ovirtmgmt proto static

Where 10.0.10.5 is the IP address of the server itself.

While this seems to work fine on CentOS 9, this breaks traffic from the own subnet on CentOS 10.
Therefor we replace it with the proper route:
10.0.10.0/24 dev ovirtmgmt proto kernel scope link src 10.0.10.5 metric 425

A question for this was also opened on the nmstate repository [1].

1: https://github.com/nmstate/nmstate/issues/3003