### PR TITLE
copr: build with timestamp version

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,7 +4,7 @@
 .PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
-	dnf -y install autoconf automake gcc gettext-devel git libtool make openssl python3-dateutil python3-devel python3-libvirt python3-pyyaml python3-six systemd-units util-linux
+	dnf -y install autoconf automake gcc gettext-devel git libtool make openssl python3-dateutil python3-devel python3-libvirt python3-pyyaml systemd-units util-linux
 
 git_cfg_safe:
 	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
@@ -12,15 +12,14 @@ git_cfg_safe:
 	git config --global --add safe.directory "$(shell pwd)"
 	
 srpm: installdeps git_cfg_safe
-	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	mkdir -p tmp.repos
 	./autogen.sh \
             --system \
             --enable-hooks \
-            --enable-vhostmd
+            --enable-vhostmd \
+            --enable-timestamp
 	make dist
 	rpmbuild \
 		-D "_topdir tmp.repos" \
-		-D "release_suffix ${SUFFIX}" \
 		-ts ./*.tar.gz
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
- Add timestamp in copr versions.
- Drop python3-six from copr deps, as we have removed six dependency
- Don't pass release_suffix as this is not used in the spec