### PR TITLE
storage: add logic for discard_no_unref

### DIFF
--- a/lib/vdsm/virt/vmdevices/storage.py
+++ b/lib/vdsm/virt/vmdevices/storage.py
@@ -113,7 +113,7 @@ class Drive(core.Base):
                  'vm_custom', '_block_info', '_threshold_state', '_lock',
                  '_monitor_lock', '_monitorable', 'guestName', '_iotune',
                  'RBD', 'managed', 'scratch_disk', 'exceeded_time',
-                 'extend_time', 'managed_reservation')
+                 'extend_time', 'managed_reservation', 'discard_no_unref')
     # pylint: disable=used-before-assignment
     VOLWM_CHUNK_SIZE = (
         config.getint('irs', 'volume_utilization_chunk_mb') * MiB)
@@ -1125,6 +1125,8 @@ def _getDriverXML(drive):
 
     if 'discard' in drive and drive['discard']:
         driverAttrs['discard'] = 'unmap'
+        if 'discard_no_unref' in drive:
+            driverAttrs['discard_no_unref'] = drive['discard_no_unref']
 
     try:
         driverAttrs['iothread'] = str(drive['specParams']['pinToIoThread'])

--- a/lib/vdsm/virt/vmdevices/storagexml.py
+++ b/lib/vdsm/virt/vmdevices/storagexml.py
@@ -221,6 +221,10 @@ def _get_driver_params(driver):
         'format': 'cow' if driver.attrib.get('type') == 'qcow2' else 'raw',
     }
 
+    discard_no_unref = driver.attrib.get('discard_no_unref', None)
+    if discard_no_unref:
+        params['discard_no_unref'] = discard_no_unref
+
     error_policy = driver.attrib.get('error_policy', 'stop')
     if error_policy == 'report':
         params['propagateErrors'] = 'report'


### PR DESCRIPTION
discard-no-unref support was added in ovirt-engine: https://github.com/oVirt/ovirt-engine/commit/142d791d0a1a6f75e307454d3b22a317a3824b21. Update vdsm to recognize and remember this parameter.