### PR TITLE
tests/storage/virt: update threading event isSet calls

### DIFF
--- a/lib/vdsm/storage/resourceManager.py
+++ b/lib/vdsm/storage/resourceManager.py
@@ -186,7 +186,7 @@ class Request(object):
         with self._syncRoot:
             if self._isCanceled:
                 return "canceled"
-            if self._doneEvent.isSet():
+            if self._doneEvent.is_set():
                 return "granted"
             return "waiting"
 
@@ -217,7 +217,7 @@ class Request(object):
 
     def granted(self):
         with self._syncRoot:
-            return (not self._isCanceled) and self._doneEvent.isSet()
+            return (not self._isCanceled) and self._doneEvent.is_set()
 
     def __str__(self):
         return "Request for %s - %s: %s" % (self.full_name, self.lockType,

--- a/lib/vdsm/storage/sp.py
+++ b/lib/vdsm/storage/sp.py
@@ -105,7 +105,7 @@ class StoragePool(object):
 
     @unsecured
     def is_secure(self):
-        return self._secured.isSet()
+        return self._secured.is_set()
 
     @unsecured
     def _set_secure(self):

--- a/lib/vdsm/virt/migration.py
+++ b/lib/vdsm/virt/migration.py
@@ -853,7 +853,7 @@ class MonitorThread(object):
 
         self._execute_init(self._conv_schedule['init'])
 
-        while not self._stop.isSet():
+        while not self._stop.is_set():
             stopped = self._stop.wait(self._MIGRATION_MONITOR_INTERVAL)
             if stopped:
                 break
@@ -912,7 +912,7 @@ class MonitorThread(object):
                 self._vm.log.debug('new iteration: %i', current_iteration)
                 self._next_action(current_iteration)
 
-            if self._stop.isSet():
+            if self._stop.is_set():
                 break
 
             self.progress = progress

--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -5822,7 +5822,7 @@ class Vm(object):
         self.log.debug('migration destination: waiting %ss '
                        'for path preparation', prepare_timeout)
         self._incoming_migration_prepared.wait(prepare_timeout)
-        if not self._incoming_migration_prepared.isSet():
+        if not self._incoming_migration_prepared.is_set():
             self.log.debug('Timeout while waiting for path preparation')
             return False
         srcDomXML = self._src_domain_xml

--- a/lib/yajsonrpc/jsonrpcclient.py
+++ b/lib/yajsonrpc/jsonrpcclient.py
@@ -274,7 +274,4 @@ class JsonRpcCall(object):
 
     def wait(self, timeout=None):
         self._ev.wait(timeout)
-        return self.isSet()
-
-    def isSet(self):
         return self._ev.is_set()

--- a/tests/storage/misc_test.py
+++ b/tests/storage/misc_test.py
@@ -64,7 +64,7 @@ class TestEvent(VdsmTestCase):
         event.register(callback)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertTrue(ev.isSet())
+        self.assertTrue(ev.is_set())
 
     def testEmitStale(self):
         ev = threading.Event()
@@ -74,7 +74,7 @@ class TestEvent(VdsmTestCase):
         del callback
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertFalse(ev.isSet())
+        self.assertFalse(ev.is_set())
 
     def testUnregister(self):
         ev = threading.Event()
@@ -84,7 +84,7 @@ class TestEvent(VdsmTestCase):
         event.unregister(callback)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertFalse(ev.isSet())
+        self.assertFalse(ev.is_set())
 
     def testOneShot(self):
         ev = threading.Event()
@@ -97,11 +97,11 @@ class TestEvent(VdsmTestCase):
         event.register(callback, oneshot=True)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertTrue(ev.isSet())
+        self.assertTrue(ev.is_set())
         ev.clear()
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertFalse(ev.isSet())
+        self.assertFalse(ev.is_set())
 
     def testEmitCallbackException(self):
         ev = threading.Event()
@@ -117,7 +117,7 @@ class TestEvent(VdsmTestCase):
         event.register(callback2)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertTrue(ev.isSet())
+        self.assertTrue(ev.is_set())
 
     def testInstanceMethod(self):
         ev = threading.Event()
@@ -126,7 +126,7 @@ class TestEvent(VdsmTestCase):
         print(event._registrar)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertTrue(ev.isSet())
+        self.assertTrue(ev.is_set())
         receiver  # Makes pyflakes happy
 
     def testInstanceMethodDead(self):
@@ -138,7 +138,7 @@ class TestEvent(VdsmTestCase):
         print(event._registrar)
         event.emit()
         ev.wait(TIMEOUT)
-        self.assertFalse(ev.isSet())
+        self.assertFalse(ev.is_set())
 
 
 class Receiver(object):


### PR DESCRIPTION
the new is_set() snake case spelling has been available since Python2.7.
 https://docs.python.org/2/library/threading.html#threading.Event.is_set 
the old spelling raises a deprecation warning in Python3.10 (Centos10 & Alma10).
 https://docs.python.org/3.10/whatsnew/3.10.html#deprecated 
Simplified functionality in jsonrpcclient to remove confusion between is_set and isSet.