### PR TITLE
doc: remove deprecated utf header

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# -*- coding: utf-8 -*-
 #
 # VDSM documentation build configuration file, created by
 # sphinx-quickstart on Thu Dec 24 14:07:47 2009.


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/vdsm/issues/326

## Changes introduced with this PR

* python 3+ has no need anymore for the utf-8 coding header.