### PR TITLE
core: remove unused constant

### DIFF
--- a/lib/vdsm/supervdsm_api/udev.py
+++ b/lib/vdsm/supervdsm_api/udev.py
@@ -31,9 +31,6 @@ from . import expose
 _UDEV_RULE_FILE_DIR = "/etc/udev/rules.d/"
 _UDEV_RULE_FILE_PREFIX = "99-vdsm-"
 _UDEV_RULE_FILE_EXT = ".rules"
-_UDEV_RULE_FILE_NAME_VM = os.path.join(
-    _UDEV_RULE_FILE_DIR, _UDEV_RULE_FILE_PREFIX + '%s-%s' +
-    _UDEV_RULE_FILE_EXT)
 
 # TODO: remove this when managed devices no longer use appropriateDevice
 _UDEV_RULE_FILE_NAME = os.path.join(


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/vdsm/issues/165

## Changes introduced with this PR

* _UDEV_RULE_FILE_NAME_VM was no longer in use, can be removed.