### PR TITLE
Added option to upload disk to Managed Block domains

### DIFF
--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -1807,5 +1807,12 @@ class ManagedVolume(APIBase):
 
     @api.logged(on="api.storage")
     @api.method
+    def convert_volume(self, sd_id, src_vol_id, dst_vol_id, src_format,
+                       dst_format):
+        return managedvolume.convert_volume(
+            sd_id, src_vol_id, dst_vol_id, src_format, dst_format)
+
+    @api.logged(on="api.storage")
+    @api.method
     def volumes_info(self, vol_ids=()):
         return managedvolume.volumes_info(vol_ids)

--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -2100,5 +2100,12 @@ class ManagedVolume(APIBase):
 
     @api.logged(on="api.storage")
     @api.method
+    def convert_volume(self, sd_id, src_vol_id, dst_vol_id, src_format,
+                       dst_format):
+        return managedvolume.convert_volume(
+            sd_id, src_vol_id, dst_vol_id, src_format, dst_format)
+
+    @api.logged(on="api.storage")
+    @api.method
     def volumes_info(self, vol_ids=()):
         return managedvolume.volumes_info(vol_ids)

--- a/lib/vdsm/API.py
+++ b/lib/vdsm/API.py
@@ -2100,10 +2100,12 @@ class ManagedVolume(APIBase):
 
     @api.logged(on="api.storage")
     @api.method
-    def convert_volume(self, sd_id, src_vol_id, dst_vol_id, src_format,
-                       dst_format):
+    def convert_volume(
+        self, sd_id, src_vol_id, dst_vol_id, src_format, dst_format
+    ):
         return managedvolume.convert_volume(
-            sd_id, src_vol_id, dst_vol_id, src_format, dst_format)
+            sd_id, src_vol_id, dst_vol_id, src_format, dst_format
+        )
 
     @api.logged(on="api.storage")
     @api.method

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -9847,6 +9847,28 @@ ManagedVolume.detach_volume:
         name: sd_id
         type: *UUID
 
+ManagedVolume.convert_volume:
+    added: '4.6'
+    description: Run qemu-img convert from source volume to destination volume.
+        Both volumes must be attached and managed via ManagedVolume. Used for
+        format conversion after upload on Managed Block Storage.
+    params:
+    -   description: The storage domain ID
+        name: sd_id
+        type: *UUID
+    -   description: The source volume ID
+        name: src_vol_id
+        type: *UUID
+    -   description: The destination volume ID
+        name: dst_vol_id
+        type: *UUID
+    -   description: Source volume format (e.g. qcow2, raw)
+        name: src_format
+        type: string
+    -   description: Destination volume format (e.g. qcow2, raw)
+        name: dst_format
+        type: string
+
 ManagedVolume.volumes_info:
     added: '4.3'
     description: Get information about list of volumes

--- a/lib/vdsm/api/vdsm-api.yml
+++ b/lib/vdsm/api/vdsm-api.yml
@@ -9852,6 +9852,28 @@ ManagedVolume.detach_volume:
         name: sd_id
         type: *UUID
 
+ManagedVolume.convert_volume:
+    added: '4.6'
+    description: Run qemu-img convert from source volume to destination volume.
+        Both volumes must be attached and managed via ManagedVolume. Used for
+        format conversion after upload on Managed Block Storage.
+    params:
+    -   description: The storage domain ID
+        name: sd_id
+        type: *UUID
+    -   description: The source volume ID
+        name: src_vol_id
+        type: *UUID
+    -   description: The destination volume ID
+        name: dst_vol_id
+        type: *UUID
+    -   description: Source volume format (e.g. qcow2, raw)
+        name: src_format
+        type: string
+    -   description: Destination volume format (e.g. qcow2, raw)
+        name: dst_format
+        type: string
+
 ManagedVolume.volumes_info:
     added: '4.3'
     description: Get information about list of volumes

--- a/lib/vdsm/rpc/Bridge.py
+++ b/lib/vdsm/rpc/Bridge.py
@@ -428,6 +428,8 @@ command_info = {
     'Lease_status': {'ret': 'result'},
     'NBD_start_server': {'ret': 'result'},
     'ManagedVolume_attach_volume': {'ret': 'result'},
+    'ManagedVolume_detach_volume': {},   # Returns status only, no result payload
+    'ManagedVolume_convert_volume': {},   # Returns status only, no result payload
     'ManagedVolume_volumes_info': {'ret': 'result'},
     'VM_start_backup': {'ret': 'result'},
     'VM_stop_backup': {'ret': 'status'},

--- a/lib/vdsm/rpc/Bridge.py
+++ b/lib/vdsm/rpc/Bridge.py
@@ -436,6 +436,8 @@ command_info = {
     'Lease_status': {'ret': 'result'},
     'NBD_start_server': {'ret': 'result'},
     'ManagedVolume_attach_volume': {'ret': 'result'},
+    'ManagedVolume_detach_volume': {},
+    'ManagedVolume_convert_volume': {},
     'ManagedVolume_volumes_info': {'ret': 'result'},
     'VM_start_backup': {'ret': 'result'},
     'VM_stop_backup': {'ret': 'status'},

--- a/lib/vdsm/storage/managedvolume-helper
+++ b/lib/vdsm/storage/managedvolume-helper
@@ -116,8 +116,10 @@ def get_connector(conn_info):
 
 
 def attach(args):
-    conn_info = read_input()
-    log.debug("Connection info: %s", conn_info)
+    vol_info = read_input()
+    log.debug("Volume info: %s", vol_info)
+    # VDSM sends vol_info = {"connection_info": {"driver_volume_type": ..., "data": ...}}
+    conn_info = vol_info.get("connection_info", vol_info)
     conn = get_connector(conn_info)
     attachment = conn.connect_volume(conn_info['data'])
     log.debug("Attachment %s", attachment)

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -35,6 +35,7 @@ from vdsm.common import supervdsm
 from vdsm.storage import exception as se
 from vdsm.storage import lvm
 from vdsm.storage import managedvolumedb
+from vdsm.storage import qemuimg
 
 HELPER = '/usr/libexec/vdsm/managedvolume-helper'
 DEV_MAPPER = "/dev/mapper"
@@ -97,6 +98,8 @@ def attach_volume(sd_id, vol_id, connection_info):
                   vol_id, connection_info)
 
         try:
+            # Pass connection_info directly so the helper receives it as stdin;
+            # it expects a dict with driver_volume_type and data (same for all MBS backends).
             attachment = run_helper("attach", connection_info)
             try:
                 path = _resolve_path(vol_id, connection_info, attachment)
@@ -179,6 +182,36 @@ def volumes_info(vol_ids=()):
             result.append(vol_info)
 
     return {"result": result}
+
+
+def convert_volume(sd_id, src_vol_id, dst_vol_id, src_format, dst_format):
+    """
+    Run qemu-img convert from source volume to destination volume.
+    Both volumes must be attached (managed via attach_volume).
+    Paths are /run/vdsm/managedvolumes/{sd_id}_{vol_id}.
+    """
+    src_path = _run_link(sd_id, src_vol_id)
+    dst_path = _run_link(sd_id, dst_vol_id)
+    if not os.path.exists(src_path):
+        raise se.ManagedVolumeHelperFailed(
+            "Source volume %s not attached at %s" % (src_vol_id, src_path))
+    if not os.path.exists(dst_path):
+        raise se.ManagedVolumeHelperFailed(
+            "Destination volume %s not attached at %s" % (dst_vol_id, dst_path))
+
+    log.info("Converting managed volume %s -> %s (src_fmt=%s dst_fmt=%s)",
+             src_vol_id, dst_vol_id, src_format, dst_format)
+    operation = qemuimg.convert(
+        src_path,
+        dst_path,
+        srcFormat=src_format,
+        dstFormat=dst_format,
+        create=False,
+        target_is_zero=True,
+    )
+    operation.run()
+    log.info("Convert completed for managed volume %s -> %s",
+             src_vol_id, dst_vol_id)
 
 
 # supervdsm interface
@@ -310,14 +343,20 @@ def _remove_udev_rule(sd_id, vol_id):
 def _add_run_link(sd_id, vol_id, path):
     _create_run_dir()
     run_path = _run_link(sd_id, vol_id)
+    if os.path.islink(run_path):
+        if os.path.realpath(run_path) == os.path.realpath(path):
+            return run_path
+        os.remove(run_path)
     os.symlink(path, run_path)
     return run_path
 
 
 def _remove_run_link(sd_id, vol_id):
     try:
-        os.remove(_run_link(sd_id, vol_id))
-    except Exception:
+        run_path = _run_link(sd_id, vol_id)
+        if os.path.exists(run_path):
+            os.remove(run_path)
+    except OSError:
         log.exception("Failed to remove run link for volume %s", vol_id)
 
 

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -31,6 +31,7 @@ from vdsm.common import supervdsm
 from vdsm.storage import exception as se
 from vdsm.storage import lvm
 from vdsm.storage import managedvolumedb
+from vdsm.storage import qemuimg
 
 HELPER = '/usr/libexec/vdsm/managedvolume-helper'
 DEV_MAPPER = "/dev/mapper"
@@ -186,6 +187,36 @@ def volumes_info(vol_ids=()):
     return {"result": result}
 
 
+def convert_volume(sd_id, src_vol_id, dst_vol_id, src_format, dst_format):
+    """
+    Run qemu-img convert from source volume to destination volume.
+    Both volumes must be attached (managed via attach_volume).
+    Paths are /run/vdsm/managedvolumes/{sd_id}_{vol_id}.
+    """
+    src_path = _run_link(sd_id, src_vol_id)
+    dst_path = _run_link(sd_id, dst_vol_id)
+    if not os.path.exists(src_path):
+        raise se.ManagedVolumeHelperFailed(
+            "Source volume %s not attached at %s" % (src_vol_id, src_path))
+    if not os.path.exists(dst_path):
+        raise se.ManagedVolumeHelperFailed(
+            "Destination volume %s not attached at %s" % (dst_vol_id, dst_path))
+
+    log.info("Converting managed volume %s -> %s (src_fmt=%s dst_fmt=%s)",
+             src_vol_id, dst_vol_id, src_format, dst_format)
+    operation = qemuimg.convert(
+        src_path,
+        dst_path,
+        srcFormat=src_format,
+        dstFormat=dst_format,
+        create=False,
+        target_is_zero=True,
+    )
+    operation.run()
+    log.info("Convert completed for managed volume %s -> %s",
+             src_vol_id, dst_vol_id)
+
+
 # supervdsm interface
 
 
@@ -323,14 +354,20 @@ def _remove_udev_rule(sd_id, vol_id):
 def _add_run_link(sd_id, vol_id, path):
     _create_run_dir()
     run_path = _run_link(sd_id, vol_id)
+    if os.path.islink(run_path):
+        if os.path.realpath(run_path) == os.path.realpath(path):
+            return run_path
+        os.remove(run_path)
     os.symlink(path, run_path)
     return run_path
 
 
 def _remove_run_link(sd_id, vol_id):
     try:
-        os.remove(_run_link(sd_id, vol_id))
-    except Exception:
+        run_path = _run_link(sd_id, vol_id)
+        if os.path.exists(run_path):
+            os.remove(run_path)
+    except OSError:
         log.exception("Failed to remove run link for volume %s", vol_id)
 
 

--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -197,13 +197,20 @@ def convert_volume(sd_id, src_vol_id, dst_vol_id, src_format, dst_format):
     dst_path = _run_link(sd_id, dst_vol_id)
     if not os.path.exists(src_path):
         raise se.ManagedVolumeHelperFailed(
-            "Source volume %s not attached at %s" % (src_vol_id, src_path))
+            "Source volume %s not attached at %s" % (src_vol_id, src_path)
+        )
     if not os.path.exists(dst_path):
         raise se.ManagedVolumeHelperFailed(
-            "Destination volume %s not attached at %s" % (dst_vol_id, dst_path))
+            "Destination volume %s not attached at %s" % (dst_vol_id, dst_path)
+        )
 
-    log.info("Converting managed volume %s -> %s (src_fmt=%s dst_fmt=%s)",
-             src_vol_id, dst_vol_id, src_format, dst_format)
+    log.info(
+        "Converting managed volume %s -> %s (src_fmt=%s dst_fmt=%s)",
+        src_vol_id,
+        dst_vol_id,
+        src_format,
+        dst_format,
+    )
     operation = qemuimg.convert(
         src_path,
         dst_path,
@@ -213,8 +220,9 @@ def convert_volume(sd_id, src_vol_id, dst_vol_id, src_format, dst_format):
         target_is_zero=True,
     )
     operation.run()
-    log.info("Convert completed for managed volume %s -> %s",
-             src_vol_id, dst_vol_id)
+    log.info(
+        "Convert completed for managed volume %s -> %s", src_vol_id, dst_vol_id
+    )
 
 
 # supervdsm interface

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import time
+from contextlib import closing
 
 from vdsm.common import cmdutils
 from vdsm.common import constants
@@ -96,40 +97,26 @@ QemuNBDConfig = collections.namedtuple(
 
 def start_server(server_id, config):
     cfg = ServerConfig(config)
-    dom = sdCache.produce_manifest(cfg.sd_id)
-    vol = dom.produceVolume(cfg.img_id, cfg.vol_id)
 
-    if vol.isShared() and not cfg.readonly:
-        raise se.SharedVolumeNonWritable(vol)
+    try:
+        dom = sdCache.produce_manifest(cfg.sd_id)
+        vol = dom.produceVolume(cfg.img_id, cfg.vol_id)
+        path, format, is_block, using_overlay, bitmap_chain = (
+            _volume_export_config(cfg, vol))
+    except se.StorageDomainDoesNotExist:
 
-    if cfg.bitmap:
-        if vol.getFormat() != sc.COW_FORMAT:
-            raise se.UnsupportedOperation(
-                "Cannot export bitmap from RAW volume")
-
-        # The bitmap must exist in the volume, and may exist in the
-        # backing chain.
-        bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
-        if not bitmap_chain:
-            raise se.BitmapDoesNotExist(
-                reason=f"Bitmap does not exist in {vol.volumePath}",
-                bitmap=cfg.bitmap)
+        log.info("Domain %s not in sdCache, trying managed volume DB for vol %s",
+                 cfg.sd_id, cfg.vol_id)
+        path, format, is_block, using_overlay, bitmap_chain = (
+            _managed_volume_export_config(cfg))
 
     _create_rundir()
 
-    # If the bitmap exists in the volume backing chain, we need to
-    # create an overlay exporting the bitmap from the entire chain.
-    using_overlay = cfg.bitmap and len(bitmap_chain) > 1
-
     if using_overlay:
         path = _create_overlay(
-            server_id, vol.volumePath, cfg.bitmap, bitmap_chain)
+            server_id, path, cfg.bitmap, bitmap_chain)
         format = "qcow2"
         is_block = False
-    else:
-        path = vol.volumePath
-        format = sc.fmt2str(vol.getFormat())
-        is_block = vol.is_block()
     try:
         sock = _socket_path(server_id)
 
@@ -162,6 +149,58 @@ def start_server(server_id, config):
     os.chmod(sock, DEFAULT_SOCKET_MODE)
     unix_address = nbdutils.UnixAddress(sock)
     return unix_address.url()
+
+
+def _volume_export_config(cfg, vol):
+    """Resolve path, format, and flags for a volume from sdCache."""
+    if vol.isShared() and not cfg.readonly:
+        raise se.SharedVolumeNonWritable(vol)
+
+    if cfg.bitmap:
+        if vol.getFormat() != sc.COW_FORMAT:
+            raise se.UnsupportedOperation(
+                "Cannot export bitmap from RAW volume")
+        bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
+        if not bitmap_chain:
+            raise se.BitmapDoesNotExist(
+                reason=f"Bitmap does not exist in {vol.volumePath}",
+                bitmap=cfg.bitmap)
+        using_overlay = len(bitmap_chain) > 1
+    else:
+        bitmap_chain = None
+        using_overlay = False
+
+    path = vol.volumePath
+    format = sc.fmt2str(vol.getFormat())
+    is_block = vol.is_block()
+    return (path, format, is_block, using_overlay, bitmap_chain)
+
+
+def _managed_volume_export_config(cfg):
+    """
+    Resolve path for an attached Managed Block Storage volume (not in sdCache).
+    Volume must have been attached via ManagedVolume.attach_volume first.
+    """
+    if cfg.bitmap:
+        raise se.UnsupportedOperation(
+            "Cannot export bitmap from Managed Block Storage volume")
+    from vdsm.storage import managedvolumedb
+    try:
+        db = managedvolumedb.open()
+        with closing(db):
+            vol_info = db.get_volume(cfg.vol_id)
+    except managedvolumedb.NotFound:
+        log.warning("Managed volume %s not in DB (attach may have failed or "
+                    "not run yet)", cfg.vol_id)
+        raise se.StorageDomainDoesNotExist(cfg.sd_id)
+    path = vol_info.get("path")
+    if not path or not os.path.exists(path):
+        log.warning("Managed volume %s has no path or path missing: path=%s",
+                    cfg.vol_id, path)
+        raise se.StorageDomainDoesNotExist(cfg.sd_id)
+    log.info("Using managed volume path for vol %s: %s", cfg.vol_id, path)
+    # MBS volumes are block devices (e.g. iscsi, rbd), raw format, no chain
+    return (path, "raw", True, False, None)
 
 
 def stop_server(server_id):
@@ -490,18 +529,35 @@ def json_uri(config):
     return "json:" + json.dumps(image)
 
 
+# Path prefixes allowed for attached Managed Block Storage volumes
+_MANAGED_VOLUME_PATH_PREFIXES = (
+    "/dev/mapper/",
+    "/dev/rbd/",
+    "/dev/storpool-byid/",
+    "/run/vdsm/managedvolumes/",
+)
+
+
 def _verify_path(path):
     """
     Anyone running as vdsm can invoke nbd_start_transient_service() with
     arbitrary path. Verify the path is in the storage repository, or path is a
-    transient disk with a backing file in the storage repository.
+    transient disk with a backing file in the storage repository, or path is an
+    attached Managed Block Storage volume.
     """
     path = os.path.normpath(path)
+    log.info("_verify_path checking path=%r", path)
 
     if path.startswith(transientdisk.P_TRANSIENT_DISKS):
         path = qemuimg.info(path, format="qcow2")["backing-filename"]
+        log.info("_verify_path resolved transient backing to path=%r", path)
+
+    if any(path.startswith(prefix) for prefix in _MANAGED_VOLUME_PATH_PREFIXES):
+        log.info("_verify_path path %r allowed (managed volume prefix)", path)
+        return
 
     if not path.startswith(sc.REPO_MOUNT_DIR):
+        log.warning("_verify_path rejecting path=%r (repo=%r)", path, sc.REPO_MOUNT_DIR)
         raise InvalidPath(
             "Path {!r} is outside storage repository {!r}"
             .format(path, sc.REPO_MOUNT_DIR))

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import time
+from contextlib import closing
 
 from vdsm.common import cmdutils
 from vdsm.common import constants
@@ -95,43 +96,25 @@ QemuNBDConfig = collections.namedtuple(
 
 def start_server(server_id, config):
     cfg = ServerConfig(config)
-    dom = sdCache.produce_manifest(cfg.sd_id)
-    vol = dom.produceVolume(cfg.img_id, cfg.vol_id)
 
-    if vol.isShared() and not cfg.readonly:
-        raise se.SharedVolumeNonWritable(vol)
-
-    if cfg.bitmap:
-        if vol.getFormat() != sc.COW_FORMAT:
-            raise se.UnsupportedOperation(
-                "Cannot export bitmap from RAW volume"
-            )
-
-        # The bitmap must exist in the volume, and may exist in the
-        # backing chain.
-        bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
-        if not bitmap_chain:
-            raise se.BitmapDoesNotExist(
-                reason=f"Bitmap does not exist in {vol.volumePath}",
-                bitmap=cfg.bitmap,
-            )
+    try:
+        dom = sdCache.produce_manifest(cfg.sd_id)
+        vol = dom.produceVolume(cfg.img_id, cfg.vol_id)
+        path, format, is_block, using_overlay, bitmap_chain = (
+            _volume_export_config(cfg, vol))
+    except se.StorageDomainDoesNotExist:
+        log.info("Domain %s not in sdCache, trying managed volume DB for vol %s",
+                 cfg.sd_id, cfg.vol_id)
+        path, format, is_block, using_overlay, bitmap_chain = (
+            _managed_volume_export_config(cfg))
 
     _create_rundir()
 
-    # If the bitmap exists in the volume backing chain, we need to
-    # create an overlay exporting the bitmap from the entire chain.
-    using_overlay = cfg.bitmap and len(bitmap_chain) > 1
-
     if using_overlay:
         path = _create_overlay(
-            server_id, vol.volumePath, cfg.bitmap, bitmap_chain
-        )
+            server_id, path, cfg.bitmap, bitmap_chain)
         format = "qcow2"
         is_block = False
-    else:
-        path = vol.volumePath
-        format = sc.fmt2str(vol.getFormat())
-        is_block = vol.is_block()
     try:
         sock = _socket_path(server_id)
 
@@ -169,6 +152,58 @@ def start_server(server_id, config):
     os.chmod(sock, DEFAULT_SOCKET_MODE)
     unix_address = nbdutils.UnixAddress(sock)
     return unix_address.url()
+
+
+def _volume_export_config(cfg, vol):
+    """Resolve path, format, and flags for a volume from sdCache."""
+    if vol.isShared() and not cfg.readonly:
+        raise se.SharedVolumeNonWritable(vol)
+
+    if cfg.bitmap:
+        if vol.getFormat() != sc.COW_FORMAT:
+            raise se.UnsupportedOperation(
+                "Cannot export bitmap from RAW volume")
+        bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
+        if not bitmap_chain:
+            raise se.BitmapDoesNotExist(
+                reason=f"Bitmap does not exist in {vol.volumePath}",
+                bitmap=cfg.bitmap)
+        using_overlay = len(bitmap_chain) > 1
+    else:
+        bitmap_chain = None
+        using_overlay = False
+
+    path = vol.volumePath
+    format = sc.fmt2str(vol.getFormat())
+    is_block = vol.is_block()
+    return (path, format, is_block, using_overlay, bitmap_chain)
+
+
+def _managed_volume_export_config(cfg):
+    """
+    Resolve path for an attached Managed Block Storage volume (not in sdCache).
+    Volume must have been attached via ManagedVolume.attach_volume first.
+    """
+    if cfg.bitmap:
+        raise se.UnsupportedOperation(
+            "Cannot export bitmap from Managed Block Storage volume")
+    from vdsm.storage import managedvolumedb
+    try:
+        db = managedvolumedb.open()
+        with closing(db):
+            vol_info = db.get_volume(cfg.vol_id)
+    except managedvolumedb.NotFound:
+        log.warning("Managed volume %s not in DB (attach may have failed or "
+                    "not run yet)", cfg.vol_id)
+        raise se.StorageDomainDoesNotExist(cfg.sd_id)
+    path = vol_info.get("path")
+    if not path or not os.path.exists(path):
+        log.warning("Managed volume %s has no path or path missing: path=%s",
+                    cfg.vol_id, path)
+        raise se.StorageDomainDoesNotExist(cfg.sd_id)
+    log.info("Using managed volume path for vol %s: %s", cfg.vol_id, path)
+    # MBS volumes are block devices (e.g. iscsi, rbd), raw format, no chain
+    return (path, "raw", True, False, None)
 
 
 def stop_server(server_id):
@@ -499,18 +534,35 @@ def json_uri(config):
     return "json:" + json.dumps(image)
 
 
+# Path prefixes allowed for attached Managed Block Storage volumes
+_MANAGED_VOLUME_PATH_PREFIXES = (
+    "/dev/mapper/",
+    "/dev/rbd/",
+    "/dev/storpool-byid/",
+    "/run/vdsm/managedvolumes/",
+)
+
+
 def _verify_path(path):
     """
     Anyone running as vdsm can invoke nbd_start_transient_service() with
     arbitrary path. Verify the path is in the storage repository, or path is a
-    transient disk with a backing file in the storage repository.
+    transient disk with a backing file in the storage repository, or path is an
+    attached Managed Block Storage volume.
     """
     path = os.path.normpath(path)
+    log.info("_verify_path checking path=%r", path)
 
     if path.startswith(transientdisk.P_TRANSIENT_DISKS):
         path = qemuimg.info(path, format="qcow2")["backing-filename"]
+        log.info("_verify_path resolved transient backing to path=%r", path)
+
+    if any(path.startswith(prefix) for prefix in _MANAGED_VOLUME_PATH_PREFIXES):
+        log.info("_verify_path path %r allowed (managed volume prefix)", path)
+        return
 
     if not path.startswith(sc.REPO_MOUNT_DIR):
+        log.warning("_verify_path rejecting path=%r (repo=%r)", path, sc.REPO_MOUNT_DIR)
         raise InvalidPath(
             "Path {!r} is outside storage repository {!r}".format(
                 path, sc.REPO_MOUNT_DIR

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -25,6 +25,7 @@ from vdsm.common.time import monotonic_time
 from . import constants as sc
 from . import exception as se
 from . import fileUtils
+from . import managedvolume
 from . import qemuimg
 from . import transientdisk
 from .sdc import sdCache
@@ -196,7 +197,12 @@ def _managed_volume_export_config(cfg):
         log.warning("Managed volume %s not in DB (attach may have failed or "
                     "not run yet)", cfg.vol_id)
         raise se.StorageDomainDoesNotExist(cfg.sd_id)
-    path = vol_info.get("path")
+    managed_path = os.path.join(
+        managedvolume.VOLUME_LINK_DIR, f"{cfg.sd_id}_{cfg.vol_id}")
+    if os.path.islink(managed_path):
+        path = managed_path
+    else:
+        path = vol_info.get("path")
     if not path or not os.path.exists(path):
         log.warning("Managed volume %s has no path or path missing: path=%s",
                     cfg.vol_id, path)
@@ -534,14 +540,42 @@ def json_uri(config):
     return "json:" + json.dumps(image)
 
 
-# Path prefixes allowed for attached Managed Block Storage volumes
-_MANAGED_VOLUME_PATH_PREFIXES = (
-    "/dev/mapper/",
-    "/dev/rbd/",
-    "/dev/drbd/",
-    "/dev/storpool-byid/",
-    "/run/vdsm/managedvolumes/",
-)
+def _is_attached_managed_volume_path(path):
+    """
+    Return True if path refers to a volume attached via attach_volume().
+
+    Every attached managed volume has a stable symlink under
+    /run/vdsm/managedvolumes/. Accept either that symlink or the device path
+    it points to, so callers are not tied to vendor-specific device prefixes.
+    """
+    link_dir = managedvolume.VOLUME_LINK_DIR
+    normpath = os.path.normpath(path)
+
+    if normpath.startswith(link_dir) and os.path.islink(normpath):
+        return True
+
+    if not os.path.isdir(link_dir):
+        return False
+
+    try:
+        real_path = os.path.realpath(normpath)
+    except OSError:
+        return False
+
+    try:
+        for name in os.listdir(link_dir):
+            link = os.path.join(link_dir, name)
+            if not os.path.islink(link):
+                continue
+            try:
+                if os.path.realpath(link) == real_path:
+                    return True
+            except OSError:
+                continue
+    except OSError as e:
+        log.debug("Cannot list managed volume links in %s: %s", link_dir, e)
+
+    return False
 
 
 def _verify_path(path):
@@ -552,14 +586,14 @@ def _verify_path(path):
     attached Managed Block Storage volume.
     """
     path = os.path.normpath(path)
-    log.info("_verify_path checking path=%r", path)
+    log.debug("_verify_path checking path=%r", path)
 
     if path.startswith(transientdisk.P_TRANSIENT_DISKS):
         path = qemuimg.info(path, format="qcow2")["backing-filename"]
-        log.info("_verify_path resolved transient backing to path=%r", path)
+        log.debug("_verify_path resolved transient backing to path=%r", path)
 
-    if any(path.startswith(prefix) for prefix in _MANAGED_VOLUME_PATH_PREFIXES):
-        log.info("_verify_path path %r allowed (managed volume prefix)", path)
+    if _is_attached_managed_volume_path(path):
+        log.debug("_verify_path path %r allowed (attached managed volume)", path)
         return
 
     if not path.startswith(sc.REPO_MOUNT_DIR):

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -538,6 +538,7 @@ def json_uri(config):
 _MANAGED_VOLUME_PATH_PREFIXES = (
     "/dev/mapper/",
     "/dev/rbd/",
+    "/dev/drbd/",
     "/dev/storpool-byid/",
     "/run/vdsm/managedvolumes/",
 )

--- a/lib/vdsm/storage/nbd.py
+++ b/lib/vdsm/storage/nbd.py
@@ -102,18 +102,22 @@ def start_server(server_id, config):
         dom = sdCache.produce_manifest(cfg.sd_id)
         vol = dom.produceVolume(cfg.img_id, cfg.vol_id)
         path, format, is_block, using_overlay, bitmap_chain = (
-            _volume_export_config(cfg, vol))
+            _volume_export_config(cfg, vol)
+        )
     except se.StorageDomainDoesNotExist:
-        log.info("Domain %s not in sdCache, trying managed volume DB for vol %s",
-                 cfg.sd_id, cfg.vol_id)
+        log.info(
+            "Domain %s not in sdCache, trying managed volume DB for vol %s",
+            cfg.sd_id,
+            cfg.vol_id,
+        )
         path, format, is_block, using_overlay, bitmap_chain = (
-            _managed_volume_export_config(cfg))
+            _managed_volume_export_config(cfg)
+        )
 
     _create_rundir()
 
     if using_overlay:
-        path = _create_overlay(
-            server_id, path, cfg.bitmap, bitmap_chain)
+        path = _create_overlay(server_id, path, cfg.bitmap, bitmap_chain)
         format = "qcow2"
         is_block = False
     try:
@@ -163,12 +167,14 @@ def _volume_export_config(cfg, vol):
     if cfg.bitmap:
         if vol.getFormat() != sc.COW_FORMAT:
             raise se.UnsupportedOperation(
-                "Cannot export bitmap from RAW volume")
+                "Cannot export bitmap from RAW volume"
+            )
         bitmap_chain = _find_bitmap(vol.volumePath, cfg.bitmap)
         if not bitmap_chain:
             raise se.BitmapDoesNotExist(
                 reason=f"Bitmap does not exist in {vol.volumePath}",
-                bitmap=cfg.bitmap)
+                bitmap=cfg.bitmap,
+            )
         using_overlay = len(bitmap_chain) > 1
     else:
         bitmap_chain = None
@@ -187,25 +193,34 @@ def _managed_volume_export_config(cfg):
     """
     if cfg.bitmap:
         raise se.UnsupportedOperation(
-            "Cannot export bitmap from Managed Block Storage volume")
+            "Cannot export bitmap from Managed Block Storage volume"
+        )
     from vdsm.storage import managedvolumedb
+
     try:
         db = managedvolumedb.open()
         with closing(db):
             vol_info = db.get_volume(cfg.vol_id)
     except managedvolumedb.NotFound:
-        log.warning("Managed volume %s not in DB (attach may have failed or "
-                    "not run yet)", cfg.vol_id)
+        log.warning(
+            "Managed volume %s not in DB (attach may have failed or "
+            "not run yet)",
+            cfg.vol_id,
+        )
         raise se.StorageDomainDoesNotExist(cfg.sd_id)
     managed_path = os.path.join(
-        managedvolume.VOLUME_LINK_DIR, f"{cfg.sd_id}_{cfg.vol_id}")
+        managedvolume.VOLUME_LINK_DIR, f"{cfg.sd_id}_{cfg.vol_id}"
+    )
     if os.path.islink(managed_path):
         path = managed_path
     else:
         path = vol_info.get("path")
     if not path or not os.path.exists(path):
-        log.warning("Managed volume %s has no path or path missing: path=%s",
-                    cfg.vol_id, path)
+        log.warning(
+            "Managed volume %s has no path or path missing: path=%s",
+            cfg.vol_id,
+            path,
+        )
         raise se.StorageDomainDoesNotExist(cfg.sd_id)
     log.info("Using managed volume path for vol %s: %s", cfg.vol_id, path)
     # MBS volumes are block devices (e.g. iscsi, rbd), raw format, no chain
@@ -593,11 +608,15 @@ def _verify_path(path):
         log.debug("_verify_path resolved transient backing to path=%r", path)
 
     if _is_attached_managed_volume_path(path):
-        log.debug("_verify_path path %r allowed (attached managed volume)", path)
+        log.debug(
+            "_verify_path path %r allowed (attached managed volume)", path
+        )
         return
 
     if not path.startswith(sc.REPO_MOUNT_DIR):
-        log.warning("_verify_path rejecting path=%r (repo=%r)", path, sc.REPO_MOUNT_DIR)
+        log.warning(
+            "_verify_path rejecting path=%r (repo=%r)", path, sc.REPO_MOUNT_DIR
+        )
         raise InvalidPath(
             "Path {!r} is outside storage repository {!r}".format(
                 path, sc.REPO_MOUNT_DIR


### PR DESCRIPTION
## Changes introduced with this PR

* Enables uploading disks to Managed Block Storage domains. This change adds the full upload flow for Managed Block Storage using the existing NBD-based transfer path, including connect/attach on the host and cleanup on finish. 

* It was tested with StorPool and Ceph as managed block storage domains

* The changes in this PR highly depend on [ovirt-engine PR](https://github.com/oVirt/ovirt-engine/pull/1125)