### PR TITLE
v2v: replace deprecated/removed arguments

### DIFF
--- a/lib/vdsm/v2v.py
+++ b/lib/vdsm/v2v.py
@@ -400,7 +400,8 @@ class V2VCommand(object):
                 raise ValueError('Invalid QCOW2 compat version %r' %
                                  qcow2_compat)
             if 'vdsm-compat-option' in self._v2v_caps:
-                self._base_command.extend(['--vdsm-compat', qcow2_compat])
+                self._base_command.extend(
+                    ['-oo', 'vdsm-compat=%s' % qcow2_compat])
             elif qcow2_compat != '0.10':
                 # Note: qcow2 is only a suggestion from the engine
                 # if virt-v2v doesn't support it we fall back to default
@@ -440,10 +441,10 @@ class V2VCommand(object):
         parameters = []
         for disk in self._vminfo['disks']:
             try:
-                parameters.append('--vdsm-image-uuid')
-                parameters.append(disk['imageID'])
-                parameters.append('--vdsm-vol-uuid')
-                parameters.append(disk['volumeID'])
+                parameters.append('-oo')
+                parameters.append('vdsm-image-uuid=%s' % disk['imageID'])
+                parameters.append('-oo')
+                parameters.append('vdsm-vol-uuid=%s' % disk['volumeID'])
             except KeyError as e:
                 raise InvalidInputError('Job %r missing required property: %s'
                                         % (self._vmid, e))
@@ -564,10 +565,8 @@ class LibvirtCommand(V2VCommand):
         cmd.extend(self._disk_parameters())
         cmd.extend(['--password-file',
                     self._passwd_file,
-                    '--vdsm-vm-uuid',
-                    self._vmid,
-                    '--vdsm-ovf-output',
-                    _V2V_DIR,
+                    '-oo', 'vdsm-vm-uuid=%s' % self._vmid,
+                    '-oo', 'vdsm-ovf-output=%s' % _V2V_DIR,
                     '--machine-readable',
                     '-os',
                     self._get_storage_domain_path(
@@ -592,10 +591,8 @@ class OvaCommand(V2VCommand):
                     '-o', 'vdsm',
                     '-of', self._get_disk_format(),
                     '-oa', self._vminfo.get('allocation', 'sparse').lower(),
-                    '--vdsm-vm-uuid',
-                    self._vmid,
-                    '--vdsm-ovf-output',
-                    _V2V_DIR,
+                    '-oo', 'vdsm-vm-uuid=%s' % self._vmid,
+                    '-oo', 'vdsm-ovf-output=%s' % _V2V_DIR,
                     '--machine-readable',
                     '-os',
                     self._get_storage_domain_path(
@@ -631,10 +628,8 @@ class XenCommand(V2VCommand):
                     '-of', self._get_disk_format(),
                     '-oa', self._vminfo.get('allocation', 'sparse').lower()])
         cmd.extend(self._disk_parameters())
-        cmd.extend(['--vdsm-vm-uuid',
-                    self._vmid,
-                    '--vdsm-ovf-output',
-                    _V2V_DIR,
+        cmd.extend(['-oo', 'vdsm-vm-uuid=%s' % self._vmid,
+                    '-oo', 'vdsm-ovf-output=%s' % _V2V_DIR,
                     '--machine-readable',
                     '-os',
                     self._get_storage_domain_path(

--- a/tests/fake-virt-v2v
+++ b/tests/fake-virt-v2v
@@ -18,16 +18,10 @@ parser.add_argument('-of', dest='outputFormat',
                     help='Set output image format')
 parser.add_argument('-oa', dest='outputAllocation',
                     help='Set output allocation format')
-parser.add_argument('--vdsm-image-uuid', dest='vdsmImageId',
-                    help='Vdsm image UUID', action='append')
-parser.add_argument('--vdsm-vol-uuid', dest='vdsmVolId',
-                    help='Vdsm volume UUID', action='append')
-parser.add_argument('--vdsm-vm-uuid', dest='vdsmVmId',
-                    help='VM UUID')
+parser.add_argument('-oo', dest='outputModeOptions', action='append',
+                    help='Set option for output mode')
 parser.add_argument('--password-file', dest='passwordFile',
                     help='Read connection password from a file')
-parser.add_argument('--vdsm-ovf-output', dest='vdsmOvfOutput',
-                    help='Output directory for ovf output')
 parser.add_argument('-os', dest='outputStorage',
                     help='Output directory for the images')
 parser.add_argument('--machine-readable', dest='machineReadable',
@@ -68,15 +62,18 @@ def write_output(msg):
     sys.stdout.write(msg)
     sys.stdout.flush()
 
+
 def write_trace(msg):
     sys.stderr.write(msg)
     sys.stderr.flush()
+
 
 def write_progress():
     global elapsed_time
     for i in range(101):
         write_output('    (%s/100%%)\r' % str(i))
         elapsed_time = elapsed_time + 1
+
 
 write_output('[   %d.0] Opening the source -i libvirt\n' % elapsed_time)
 elapsed_time = elapsed_time + 1
@@ -90,16 +87,28 @@ if options.libguestfsTrace:
     write_trace("libguestfs: trace: close\n")
     write_trace("libguestfs: closing guestfs handle 0x1e265f0 (state 0)\n")
 
-for i, o in enumerate(options.vdsmImageId):
+vdsmImageUUID = []
+vdsmVolUUID = []
+vdsmVmId = ""
+for o in options.outputModeOptions:
+    key, value = o.split("=", 1)
+    if key == "vdsm-image-uuid":
+        vdsmImageUUID.append(value)
+    elif key == "vdsm-vol-uuid":
+        vdsmVolUUID.append(value)
+    elif key == "vdsm-vm-uuid":
+        vdsmVmId = value
+
+for i, o in enumerate(vdsmImageUUID):
     write_output('[  %d.0] Copying disk %d/2 to %s/%s/images/%s\n' %
-                 (elapsed_time, i+1, options.outputStorage,
-                  options.vdsmVmId, o))
+                 (elapsed_time, i + 1, options.outputStorage,
+                  vdsmVmId, o))
 
     # Immitate some verbose messages
     # NOTE: Most verbose messages go to stderr, but some go to stdout. This can
     # potentialy mess with our parsing routine.
     if options.verbose:
-        write_output("target_file = %s\n" % options.vdsmVolId[i])
+        write_output("target_file = %s\n" % vdsmVolUUID[i])
         write_output("target_format = raw\n")
         write_output("target_estimated_size = 123456789\n")
         write_output("target_overlay = /var/tmp/v2vovl344e53.qcow2\n")

--- a/tests/virt/v2v_test.py
+++ b/tests/virt/v2v_test.py
@@ -473,13 +473,13 @@ class v2vTests(TestCaseBase):
                '-o', 'vdsm',
                '-of', 'raw',
                '-oa', 'sparse',
-               '--vdsm-image-uuid', self.image_id_a,
-               '--vdsm-vol-uuid', self.volume_id_a,
-               '--vdsm-image-uuid', self.image_id_b,
-               '--vdsm-vol-uuid', self.volume_id_b,
+               '-oo', 'vdsm-image-uuid=%s' % self.image_id_a,
+               '-oo', 'vdsm-vol-uuid=%s' % self.volume_id_a,
+               '-oo', 'vdsm-image-uuid=%s' % self.image_id_b,
+               '-oo', 'vdsm-vol-uuid=%s' % self.volume_id_b,
                '--password-file', '/tmp/mypass',
-               '--vdsm-vm-uuid', self.job_id,
-               '--vdsm-ovf-output', '/usr/local/var/run/vdsm/v2v',
+               '-oo', 'vdsm-vm-uuid=%s' % self.job_id,
+               '-oo', 'vdsm-ovf-output=%s' % '/usr/local/var/run/vdsm/v2v',
                '--machine-readable',
                '-os', '/rhev/data-center/%s/%s' % (self.pool_id,
                                                    self.domain_id),
@@ -548,9 +548,9 @@ class v2vTests(TestCaseBase):
 
         # Look for the command line argument
         cmd = v2v.V2VCommand({'qcow2_compat': '1.1'}, None, None)
-        assert '--vdsm-compat' in cmd._base_command
-        i = cmd._base_command.index('--vdsm-compat')
-        assert '1.1' == cmd._base_command[i + 1]
+        assert '-oo' in cmd._base_command
+        i = cmd._base_command.index('-oo')
+        assert 'vdsm-compat=1.1' == cmd._base_command[i + 1]
 
     def test_v2v_error(self):
 


### PR DESCRIPTION
The following virt-v2v options were deprecated a while ago: --vdsm-compat
--vdsm-image-uuid
--vdsm-ovf-flavour
--vdsm-ovf-output
--vdsm-vm-uuid
--vdsm-vol-uuid

And since commit 471607b in virt-v2v, they are removed completely. This commit has already landed in CentOS 9 and CentOS 10, so we need to adjust the virt-v2v options in vdsm in order to keep everything working.

This fixes #1123