### PR TITLE
ci: allow manual CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 env:
   EXPORT_DIR: exported-artifacts
 jobs:

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -17,6 +17,7 @@ on:
       - 'lib/vdsm/common/**'
       - 'tests/network/**'
       - '.github/workflows/network.yml'
+  workflow_dispatch:
   # Build every week on Sunday 02:00 to pick up new container
   schedule:
     - cron:  '0 2 * * 0'


### PR DESCRIPTION
Allow to run CI manually by adding workflow_dispatch in the workflow.