### PR TITLE
lvmdevices: preserve external storage VGs in the devices file

### DIFF
--- a/lib/vdsm/storage/lvmdevices.py
+++ b/lib/vdsm/storage/lvmdevices.py
@@ -22,6 +22,7 @@ import subprocess
 from vdsm import constants
 from vdsm.common import cmdutils
 from vdsm.common import commands
+from vdsm.storage import constants as sc
 from vdsm.storage import fileUtils
 from vdsm.storage import lvmconf
 from vdsm.storage import lvmfilter
@@ -104,22 +105,93 @@ def _configure_devices_file(enable=True):
 
 def _create_system_devices(vgs):
     """
-    Import devices of provided VGs into LVM devices file.
+    Import the VGs in `vgs` (the VGs that back the host's mounts, from
+    lvmfilter.find_lvm_mounts) plus any other VGs already visible to
+    lvm, so external storage VGs are not evicted when vdsm rebuilds
+    the devices file.
     """
-    if not vgs:
-        # Create empty devices file if no VGs are provided.
-        devices_file = _get_devices_file_path()
-        now = datetime.datetime.now()
-        data = (
-            f"# Created by Vdsm pid {os.getpid()} at "
-            f"{now.strftime('%a %b %d %H:%M:%S %Y')}\n"
-        )
+    devices_file = _get_devices_file_path()
 
-        os.makedirs(os.path.dirname(devices_file), exist_ok=True)
-        fileUtils.atomic_write(devices_file, data.encode("utf-8"))
-    else:
-        for vg in vgs:
-            _run_vgimportdevices(vg)
+    existing_vgs = ()
+    if not _devices_file_has_entries(devices_file):
+        # No device entries yet. List visible VGs so external storage
+        # is preserved on the use_devicesfile=1 transition.
+        existing_vgs = _list_all_visible_vgs()
+        if not existing_vgs and not vgs:
+            # No VGs anywhere. Drop a header so lvm does not scan every
+            # device under use_devicesfile=1.
+            now = datetime.datetime.now()
+            data = (
+                f"# Created by Vdsm pid {os.getpid()} at "
+                f"{now.strftime('%a %b %d %H:%M:%S %Y')}\n"
+            )
+            os.makedirs(os.path.dirname(devices_file), exist_ok=True)
+            fileUtils.atomic_write(devices_file, data.encode("utf-8"))
+            return
+
+    # Import visible and requested VGs, filtering out duplicate VGs.
+    for vg in sorted(set(existing_vgs) | set(vgs)):
+        _run_vgimportdevices(vg)
+
+
+def _devices_file_has_entries(devices_file):
+    """
+    Return True if the devices file records at least one device entry
+    (an IDTYPE= line). A missing or empty file, or one holding only
+    comments and bare lvm metadata (VERSION=, PRODUCT_UUID=) with no
+    device entries, counts as no entries.
+    """
+    try:
+        with open(devices_file) as f:
+            for line in f:
+                if line.strip().startswith("IDTYPE="):
+                    return True
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _list_all_visible_vgs():
+    """
+    Return the sorted VG names lvm can see, bypassing the devices file
+    so VGs created while use_devicesfile was off are still surfaced.
+    Skips oVirt SD VGs (sc.STORAGE_DOMAIN_TAG), like
+    lvmfilter.find_lvm_mounts.
+    """
+    cmd = [
+        constants.EXT_LVM,
+        'vgs',
+        '--noheadings',
+        '--readonly',
+        '-o',
+        'vg_name,vg_tags',
+        '--separator',
+        '|',
+        '--config',
+        'devices { use_devicesfile = 0 filter = ["a|.*|"] }',
+    ]
+
+    p = commands.start(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = commands.communicate(p)
+
+    if p.returncode != 0:
+        raise cmdutils.Error(cmd, p.returncode, out, err)
+
+    result = set()
+    for line in out.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # vgs prints "vg_name|tag1,tag2,..." with our --separator.
+        name, _, tags = line.partition("|")
+        name = name.strip()
+        if not name:
+            continue
+        if sc.STORAGE_DOMAIN_TAG in tags.split(","):
+            log.debug("Skipping oVirt-tagged VG %r", name)
+            continue
+        result.add(name)
+    return sorted(result)
 
 
 def _run_vgimportdevices(vg):

--- a/tests/storage/lvmdevices_test.py
+++ b/tests/storage/lvmdevices_test.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: oVirt Developers
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+from unittest import mock
+
+import pytest
+
+from vdsm.storage import lvmdevices
+
+
+@pytest.fixture
+def fake_devices_file(tmpdir, monkeypatch):
+    """Point _get_devices_file_path() at a tmpdir file."""
+    devices_dir = os.path.join(str(tmpdir), "lvm", "devices")
+    devices_file = os.path.join(devices_dir, "system.devices")
+    monkeypatch.setattr(
+        lvmdevices, "_get_devices_file_path", lambda: devices_file
+    )
+    return devices_file
+
+
+@pytest.fixture
+def stub_imports(monkeypatch):
+    """Capture VGs passed to _run_vgimportdevices."""
+    imported = []
+    monkeypatch.setattr(
+        lvmdevices, "_run_vgimportdevices", lambda vg: imported.append(vg)
+    )
+    return imported
+
+
+def _stub_visible_vgs(monkeypatch, vgs):
+    monkeypatch.setattr(lvmdevices, "_list_all_visible_vgs", lambda: list(vgs))
+
+
+def test_create_no_vgs_anywhere_writes_empty_header(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # No VGs anywhere: a header file must still exist so lvm does not
+    # scan every device under use_devicesfile=1.
+    _stub_visible_vgs(monkeypatch, [])
+
+    lvmdevices._create_system_devices(set())
+
+    assert stub_imports == []
+    assert os.path.exists(fake_devices_file)
+    with open(fake_devices_file) as f:
+        header = f.read()
+    assert header.startswith("# Created by Vdsm")
+
+
+def test_create_imports_externally_visible_vg_when_file_missing(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # External VG on disk but not in the missing file must be imported,
+    # not dropped.
+    _stub_visible_vgs(monkeypatch, ["external_vg"])
+
+    lvmdevices._create_system_devices(set())
+
+    assert stub_imports == ["external_vg"]
+
+
+def test_create_combines_external_and_vdsm_vgs(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # A visible external VG plus a VG from the vgs argument.
+    _stub_visible_vgs(monkeypatch, ["external_vg"])
+
+    lvmdevices._create_system_devices({"vg_root"})
+
+    assert stub_imports == ["external_vg", "vg_root"]
+
+
+def test_create_dedups_vg_in_both_lists(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # A VG in both lists is imported once.
+    _stub_visible_vgs(monkeypatch, ["external_vg"])
+
+    lvmdevices._create_system_devices({"external_vg", "vg_root"})
+
+    assert stub_imports == ["external_vg", "vg_root"]
+
+
+def test_create_preserves_populated_existing_file(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # A file that already records devices is authoritative: do not
+    # re-list, only add the VGs from the vgs argument.
+    os.makedirs(os.path.dirname(fake_devices_file), exist_ok=True)
+    with open(fake_devices_file, "w") as f:
+        f.write(
+            "# pre-existing populated file\n"
+            "VERSION=1.1.2\n"
+            "IDTYPE=devname IDNAME=/dev/vdb DEVNAME=/dev/vdb PVID=...\n"
+        )
+    listing = mock.Mock(return_value=[])
+    monkeypatch.setattr(lvmdevices, "_list_all_visible_vgs", listing)
+
+    lvmdevices._create_system_devices({"vg_root"})
+
+    listing.assert_not_called()
+    assert stub_imports == ["vg_root"]
+    with open(fake_devices_file) as f:
+        assert "IDTYPE=devname IDNAME=/dev/vdb" in f.read()
+
+
+def test_create_treats_header_only_file_as_unpopulated(
+    fake_devices_file, stub_imports, monkeypatch
+):
+    # A header-only file has size > 0 but records no devices, so it is
+    # treated as unpopulated.
+    os.makedirs(os.path.dirname(fake_devices_file), exist_ok=True)
+    with open(fake_devices_file, "w") as f:
+        f.write("# Created by Vdsm pid 1234 at Mon Jun 23 12:00:00 2026\n")
+    _stub_visible_vgs(monkeypatch, ["external_vg"])
+
+    lvmdevices._create_system_devices({"vg_root"})
+
+    assert stub_imports == ["external_vg", "vg_root"]
+
+
+def test_devices_file_has_entries_only_counts_device_entries(tmpdir):
+    # Only IDTYPE= device lines count. Comments and bare lvm metadata
+    # (VERSION=, written even when the file has no devices) do not.
+    devices_file = os.path.join(str(tmpdir), "system.devices")
+    with open(devices_file, "w") as f:
+        f.write("# LVM uses devices listed in this file.\n")
+        f.write("VERSION=1.1.2\n")
+    assert lvmdevices._devices_file_has_entries(devices_file) is False
+
+    with open(devices_file, "a") as f:
+        f.write("IDTYPE=devname IDNAME=/dev/vdb DEVNAME=/dev/vdb PVID=x\n")
+    assert lvmdevices._devices_file_has_entries(devices_file) is True
+
+
+def test_devices_file_has_entries_missing_file(tmpdir):
+    missing = os.path.join(str(tmpdir), "nope", "system.devices")
+    assert lvmdevices._devices_file_has_entries(missing) is False
+
+
+def test_list_all_visible_vgs_filters_ovirt_sd_tag(monkeypatch):
+    # VGs tagged RHAT_storage_domain are filtered out, like
+    # find_lvm_mounts.
+    fake_out = (
+        "  external_vg|\n"
+        "  0d504179-2606-4e62-87ee-0e5502dc00da|"
+        "MDT_TYPE=ISCSI,RHAT_storage_domain\n"
+        "  vg_root|\n"
+    ).encode("utf-8")
+
+    monkeypatch.setattr(
+        lvmdevices.commands, "start", lambda *a, **kw: mock.Mock(returncode=0)
+    )
+    monkeypatch.setattr(
+        lvmdevices.commands, "communicate", lambda p: (fake_out, b"")
+    )
+
+    assert lvmdevices._list_all_visible_vgs() == ["external_vg", "vg_root"]


### PR DESCRIPTION
Two commits that together stop `vdsm-tool config-lvm-filter` (and equivalent paths) from evicting pre-existing external-storage VGs from `/etc/lvm/devices/system.devices`.

1. `lvmdevices: preserve external-storage VGs across config-lvm-filter`. List every VG `lvm` currently sees on the host before writing the new devices file, then continue with the additive `vgimportdevices` loop for the mount-backing VGs received in the `vgs` argument. Existing populated devices files are left untouched. Preserves the PR #324 invariant ("file exists when `use_devicesfile=1`"): a host with no VGs anywhere still gets a minimal header file dropped.

2. `lvmdevices: skip oVirt-tagged VGs when listing visible VGs`. Filters VGs carrying the `RHAT_storage_domain` tag out of commit 1's listing, so a stale oVirt SD VG from a prior install isn't pulled back into `system.devices` (which would let sanlock try to acquire leases on a VG the engine no longer references). Mirrors the skip rule in `lvmfilter.find_lvm_mounts`.

Fixes #466

## Changes introduced with this PR

* `lib/vdsm/storage/lvmdevices.py`: `_create_system_devices` lists currently-visible VGs before writing on the missing-or-empty-header path; `_list_all_visible_vgs` queries `vgs -o vg_name,vg_tags --separator |` and skips entries tagged with `lvmfilter.OVIRT_VG_TAG` (`RHAT_storage_domain`).
* `tests/storage/lvmdevices_test.py` (new): five test scenarios.

## Verification

Reproduced and verified on Oracle Linux 9.7:

1. Fresh host, no oVirt yet.
2. `vgcreate drbdpool /dev/vdb`. `vgs` shows `drbdpool`.
3. Run `vdsm-tool config-lvm-filter`.
4. Run `vgs`.

Before this PR: step 4 shows `drbdpool` missing. After this PR: step 4 shows `drbdpool` preserved with physical devices populated in `/etc/lvm/devices/system.devices`:

```
[root@ovirt-2 ~]# cat /etc/lvm/devices/system.devices
# LVM uses devices listed in this file.
# Created by LVM command vgimportdevices pid 23236 at Sat May  2 22:18:30 2026
# HASH=1873244822
PRODUCT_UUID=79eecfca-941b-4391-bb3f-8214ce28bd44
VERSION=1.1.2
IDTYPE=devname IDNAME=/dev/vda3 DEVNAME=/dev/vda3 PVID=4FEsaqkurHXOxzBbcK1drtYtvG9LAt8K PART=3
IDTYPE=devname IDNAME=/dev/vdb DEVNAME=/dev/vdb PVID=0DuKehmrfiPCclNGJVnmCQlDHJMMCjLf
IDTYPE=devname IDNAME=/dev/vdc DEVNAME=/dev/vdc PVID=sX1SQHFomvy8JrxCmjfcfIfdAI5lv9aj
IDTYPE=devname IDNAME=/dev/vdd DEVNAME=/dev/vdd PVID=W6xB7SAOGPf5zIklbTkmManUJC9HYkpK
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
