### PR TITLE
lvm: scope bootstrap deactivation to vdsm-owned VGs

### DIFF
--- a/lib/vdsm/storage/blockSD.py
+++ b/lib/vdsm/storage/blockSD.py
@@ -52,7 +52,7 @@ from vdsm.storage.volumemetadata import VolumeMetadata
 import vdsm.common.supervdsm as svdsm
 
 
-STORAGE_DOMAIN_TAG = "RHAT_storage_domain"
+STORAGE_DOMAIN_TAG = sc.STORAGE_DOMAIN_TAG
 STORAGE_UNREADY_DOMAIN_TAG = STORAGE_DOMAIN_TAG + "_UNREADY"
 
 MASTERLV = "master"

--- a/lib/vdsm/storage/constants.py
+++ b/lib/vdsm/storage/constants.py
@@ -263,6 +263,9 @@ VOLUME_TAGS = [TAG_PREFIX_PARENT,
                TAG_PREFIX_IMAGE,
                TAG_PREFIX_MD]
 
+# VG tag marking a vdsm-managed block storage domain.
+STORAGE_DOMAIN_TAG = "RHAT_storage_domain"
+
 SUPPORTED_BLOCKSIZE = (512,)
 
 # This is the domain version translation list

--- a/lib/vdsm/storage/lvm.py
+++ b/lib/vdsm/storage/lvm.py
@@ -1145,14 +1145,18 @@ def bootstrap(skiplvs=()):
     """
     Bootstrap lvm module
 
-    This function builds the lvm cache and ensure that all unused lvs are
-    deactivated, expect lvs matching skiplvs.
+    This function builds the lvm cache and ensures that all unused lvs in
+    vdsm-managed storage domain VGs are deactivated, except lvs matching
+    skiplvs. VGs that are not tagged as vdsm storage domains are walked
+    past, leaving any non-vdsm LVs alone.
     """
     _lvminfo.bootstrap()
 
     skiplvs = set(skiplvs)
 
     for vg in _lvminfo.getAllVgs():
+        if sc.STORAGE_DOMAIN_TAG not in vg.tags:
+            continue
         deactivateUnusedLVs(vg.name, skiplvs=skiplvs)
 
 


### PR DESCRIPTION
The bootstrap loop now has ownership scoping. `lvm.bootstrap()` walks storage-domain VGs (those tagged `RHAT_storage_domain`) and skips everything else, leaving non-vdsm LVs alone.

Previously the loop iterated every VG visible through the multipath-scoped device source with no check on whether vdsm created the VG, so VGs belonging to other LVM consumers running on the same multipath PVs (such as third-party MBS backends) had their LVs deactivated at every vdsmd start.

LVM thin pools were particularly susceptible.
dm-thin only sets the open flag on a pool LV once a child thin volume is provisioned, so a freshly-created thin pool sits in the active+unopened state (`twi-a-tz--`) that the deactivation loop previously targeted.

The `RHAT_storage_domain` tag has marked vdsm-owned VGs since the [2011 initial commit](https://github.com/oVirt/vdsm/commit/8e53f0f22f3b52f39f4b47d273c279c9b27f1156). The same tag is already consulted in [`lvmfilter.py:155`](https://github.com/oVirt/vdsm/blob/v4.50.7/lib/vdsm/storage/lvmfilter.py#L155) (`OVIRT_VG_TAG`) for the structurally identical "is this VG mine" decision; this applies the same gate to the bootstrap loop.

Behavior on vdsm-managed storage domains is unchanged: every storage domain VG is still walked and its LVs still subject to the same `skiplvs` / `prepared` / `opened` checks.

Fixes #468

## Verification

Tested on a host carrying a vdsm-managed iSCSI master domain VG (tagged `RHAT_storage_domain`) and a separate non-vdsm-managed LVM VG on multipath PVs (no tag). Both contained an empty thinpool in the bug-trigger state (`twi-a-tz--`) before each `systemctl restart vdsmd supervdsmd`.

With the original code:

```text
$ lvs hyperconverged_vg/test_thinpool -o lv_attr
  twi---tz--   <- deactivated by bootstrap

$ grep "Deactivating lvs" /var/log/vdsm/vdsm.log
INFO (hsm/init) [storage.lvm] Deactivating lvs:
  vg=hyperconverged_vg lvs=['test_thinpool']
```

With the patch applied:

```text
$ lvs hyperconverged_vg/test_thinpool -o lv_attr
  twi-a-tz--   <- preserved

$ grep "Deactivating lvs" /var/log/vdsm/vdsm.log
(no entries for hyperconverged_vg)
```

DEBUG-level log entries confirm bootstrap still walks the storage-domain VG and applies the same per-LV skip logic for every special LV (`ids`, `inbox`, `leases`, `master`, `metadata`, `outbox`, `xleases`):

```text
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=ids
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=inbox
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=leases
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=master
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=metadata
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=outbox
DEBUG (hsm/init) [storage.lvm] Skipping active lv: vg=d8a1b44e-... lv=xleases
```

`vdsmd` HSM init succeeded in 2.52 seconds; both `vdsmd` and `supervdsmd` came up active, no errors.

## Changes introduced with this PR

- `lib/vdsm/storage/lvm.py`: add `SD_VG_TAG` constant mirroring `blockSD.STORAGE_DOMAIN_TAG` (importing from `blockSD` would create a circular import).
- `lib/vdsm/storage/lvm.py`: in `bootstrap()`, `continue` past VGs that do not carry `SD_VG_TAG`.
- `tests/storage/`: cover the new gate.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.