### PR TITLE
Remove obsolete from __future__ imports legacy Python 2

### DIFF
--- a/lib/vdsm/network/configurators/qos.py
+++ b/lib/vdsm/network/configurators/qos.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
 import errno
 
 from vdsm.network import tc

--- a/lib/vdsm/tool/configurators/__init__.py
+++ b/lib/vdsm/tool/configurators/__init__.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
 from vdsm.tool import UsageError
 
 

--- a/lib/vdsm/tool/configurators/bond_defaults.py
+++ b/lib/vdsm/tool/configurators/bond_defaults.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 
 from vdsm import constants

--- a/lib/vdsm/tool/configurators/certificates.py
+++ b/lib/vdsm/tool/configurators/certificates.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 
 from . import YES, NO

--- a/lib/vdsm/tool/configurators/libvirt.py
+++ b/lib/vdsm/tool/configurators/libvirt.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
 import os
 import os.path
 import uuid

--- a/lib/vdsm/tool/configurators/managedvolumedb.py
+++ b/lib/vdsm/tool/configurators/managedvolumedb.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 import sys
 

--- a/lib/vdsm/tool/configurators/multipath.py
+++ b/lib/vdsm/tool/configurators/multipath.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
 import os
 import sys
 

--- a/lib/vdsm/tool/configurators/passwd.py
+++ b/lib/vdsm/tool/configurators/passwd.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
-
 import io
 
 from vdsm.common import cmdutils

--- a/lib/vdsm/tool/configurators/sebool.py
+++ b/lib/vdsm/tool/configurators/sebool.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import absolute_import
-from __future__ import division
-
 import sys
 
 from . import YES, NO, MAYBE


### PR DESCRIPTION
Remove obsolete from __future__ imports from VDSM source code and tests.

* from __future__ import absolute_import
* from __future__ import division

This change cleans up legacy Python 2 compatibility code across the repository.

**Changes:**

* Removed redundant \`__future__\` imports from source
* Minor formatting cleanup caused by import removal

**Impact:**

* No intended functional changes
* Codebase cleanup only
* Reduces legacy Python 2 compatibility noise

continuation https://github.com/oVirt/vdsm/pull/473