### PR TITLE
gluster: handle bytes/string in safeWrite

### DIFF
--- a/lib/vdsm/gluster/__init__.py
+++ b/lib/vdsm/gluster/__init__.py
@@ -54,8 +54,9 @@ def _shouldPublish(func, gluster_mgmt_enabled):
 
 
 def safeWrite(fileName, content):
+    mode = 'w' if isinstance(content, str) else 'wb'
     with tempfile.NamedTemporaryFile(
-        dir=os.path.dirname(fileName), delete=False
+        mode=mode, dir=os.path.dirname(fileName), delete=False
     ) as tmp:
         tmp.write(content)
         tmpFileName = tmp.name


### PR DESCRIPTION
fix https://github.com/oVirt/vdsm/issues/419

Fix Python 3 str/bytes mismatch in gluster.safeWrite().

NamedTemporaryFile defaults to binary mode. updateGeoRepKeys() passes
authorized_keys content as str, which fails with:

TypeError: a bytes-like object is required, not 'str'

Choose text mode for str content and keep binary mode for bytes content,
preserving the existing hook-data path.
