### PR TITLE
managedvolume: fix volume re-attach after a host fence-reboot

### DIFF
--- a/lib/vdsm/storage/managedvolume.py
+++ b/lib/vdsm/storage/managedvolume.py
@@ -84,7 +84,7 @@ def attach_volume(sd_id, vol_id, connection_info):
     """
     db = managedvolumedb.open()
     with closing(db):
-        _add_volume(db, vol_id, connection_info)
+        _add_volume(db, sd_id, vol_id, connection_info)
 
         log.debug(
             "Starting attach volume %s connection_info=%s",
@@ -221,9 +221,14 @@ def run_helper(sub_cmd, vol_info=None):
 # Private helpers
 
 
-def _add_volume(db, vol_id, connection_info):
+def _add_volume(db, sd_id, vol_id, connection_info):
     """
-    Add volume to db, verifing existing entry.
+    Add volume to db, verifying existing entry.
+
+    The VDSM database persists across reboots but the run link does
+    not (/run is tmpfs), so an entry without a run link is stale and
+    safe to drop. Checking the device path instead would misdetect
+    drivers that restore their paths during boot (issue #433).
     """
     try:
         db.add_volume(vol_id, connection_info)
@@ -234,10 +239,18 @@ def _add_volume(db, vol_id, connection_info):
                 vol_id, vol_info["connection_info"], connection_info
             )
 
-        if "path" in vol_info and os.path.exists(vol_info["path"]):
+        if _run_link_exists(sd_id, vol_id):
             raise se.ManagedVolumeAlreadyAttached(
                 vol_id, vol_info["path"], vol_info.get('attachment')
             )
+
+        log.warning(
+            "Removing stale DB entry for vol_id=%s (no run link in "
+            "current boot session)",
+            vol_id,
+        )
+        db.remove_volume(vol_id)
+        db.add_volume(vol_id, connection_info)
 
 
 def _resolve_path(vol_id, connection_info, attachment):
@@ -325,6 +338,10 @@ def _add_run_link(sd_id, vol_id, path):
     run_path = _run_link(sd_id, vol_id)
     os.symlink(path, run_path)
     return run_path
+
+
+def _run_link_exists(sd_id, vol_id):
+    return os.path.lexists(_run_link(sd_id, vol_id))
 
 
 def _remove_run_link(sd_id, vol_id):

--- a/tests/storage/managedvolume_test.py
+++ b/tests/storage/managedvolume_test.py
@@ -360,6 +360,34 @@ def test_reattach_volume_other_connection(
 
 @requires_root
 @pytest.mark.root
+def test_reattach_after_fence_reboot_drops_stale_db_entry(
+    monkeypatch, fake_os_brick, tmpdir, tmp_db, fake_lvm, fake_supervdsm
+):
+    monkeypatch.setenv("FAKE_ATTACH_RESULT", "OK")
+    monkeypatch.setattr(managedvolume, "DEV_MAPPER", str(tmpdir))
+    tmpdir.join("fakemultipathid").write("")
+    connection_info = {
+        "driver_volume_type": "iscsi",
+        "data": {"some_info": 26},
+    }
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
+
+    # Simulate a fence-reboot: /run is wiped, the DB row and the device
+    # path survive.
+    os.remove(str(managedvolume._run_link("fake_sd_id", "fake_vol_id")))
+
+    # Re-attach must succeed like a first attach.
+    fake_lvm.devices_invalidated = False
+    managedvolume.attach_volume("fake_sd_id", "fake_vol_id", connection_info)
+
+    assert managedvolume._run_link_exists("fake_sd_id", "fake_vol_id")
+    entries = fake_os_brick.log()
+    actions = [e["action"] for e in entries]
+    assert actions == ["connect_volume", "connect_volume"]
+
+
+@requires_root
+@pytest.mark.root
 def test_detach_volume_iscsi_not_attached(
     monkeypatch, fake_os_brick, tmp_db, fake_lvm, fake_supervdsm
 ):


### PR DESCRIPTION
Fixes #433.

`_add_volume()` now checks the volume run link to decide whether an existing VDSM database entry represents a live attachment. The run link is created on successful attach under `/run/vdsm/managedvolumes`, which is tmpfs, so a database row without a matching run link belongs to a previous boot session. Such rows are dropped with a warning and re-added, and the attach proceeds like a first attach. Live attachments keep their run link across a vdsmd restart, so genuine double attach attempts still raise `ManagedVolumeAlreadyAttached` as before.

Previously the staleness decision was `os.path.exists(path)`. After a host was fenced and rebooted, the database still held the attachment row from before the fence and the storage driver re-created the device path during boot, so the re-attach failed with `ManagedVolumeAlreadyAttached` and the engine could not start or migrate the VM back onto the recovered host until someone edited the database by hand. The guard cannot simply be removed: without it a genuine same-boot re-attach would fall through to `_add_run_link`, hit `FileExistsError`, and the cleanup path would detach a device in use by a running VM.

The check confused "path resolves" with "currently attached" because it predates the run links: the guard shipped in 2018 ([`9646c6dc1`](https://github.com/oVirt/vdsm/commit/9646c6dc1)) when path existence was the only available primitive and the reference backend was krbd, where it is truthful. The run links arrived in 2022 ([`61d09b146`](https://github.com/oVirt/vdsm/commit/61d09b146)) for unrelated reasons, and the drivers added since (`local`, `storpool`, `lightos`) all restore their paths at boot.

Affected `driver_volume_type` values, verified against `os_brick` 5.2.4: `iscsi` (MBS iSCSI, not a classic iSCSI storage domain), `local`, `storpool`, `lightos`. Not affected: Ceph `rbd` in its default configuration (krbd mappings die with the boot).

## Timeline of how we got here

| Date | Event | Consequence |
|---|---|---|
| 2018-11 | [`9646c6dc1`](https://github.com/oVirt/vdsm/commit/9646c6dc1) ships the first `attach_volume` with the `os.path.exists(path)` guard that raises when the volume is already attached. The commit's own test attaches twice and asserts `os_brick` `connect_volume` ran exactly once. | Deliberate, tested guard. Path existence was the only "attached right now" primitive available. Truthful on the launch-era reference backend (Ceph krbd), where device paths die with the boot. |
| 2019-01 | [`754a02d03`](https://github.com/oVirt/vdsm/commit/754a02d03) adds the managedvolume DB (`/var/lib/vdsm/storage/managedvolume.db`). | Host-local bookkeeping for detach and multipath filtering. Persists across reboots by design. |
| 2019+ | MBS ships in oVirt 4.3 as tech preview; rbd and iscsi are the working backends. | `os_brick` sets `node.startup = automatic` on iSCSI logins, so MBS iSCSI paths return at boot. The false positive existed for MBS iSCSI from the start|
| 2022-02 | [`61d09b146`](https://github.com/oVirt/vdsm/commit/61d09b146) adds `/run/vdsm/managedvolumes/` links, for stable device paths for drivers where vdsm cannot construct one (NVMe/TCP). | The correct boot-scoped primitive now exists in the codebase. The 2018 staleness check is not revisited. |
| 2022-05 | [`e0088096d`](https://github.com/oVirt/vdsm/commit/e0088096d) adds `lightos` to `SUPPORTED_DRIVERS`. | Lightbits restores connections at boot from persistent discovery config. Affected population grows. |
| 2023-03 | [`447b8e2df`](https://github.com/oVirt/vdsm/commit/447b8e2df) (PR #387) adds `local` (DRBD/LINSTOR). | The satellite restores resources at boot; affected. |
| 2025-07 | Reported as [#433](https://github.com/oVirt/vdsm/issues/433): cannot migrate a VM back after a host failure. | First field report. The check is now wrong for most of the driver matrix. |
| 2025-10 | [`52488550b`](https://github.com/oVirt/vdsm/commit/52488550b) adds `storpool`. | Attachments are StorPool cluster state, re-established at boot; affected. |
| 2026-05 | LINBIT ships a boot-time cleanup workaround (`linstor-vdsm-db-cleanup.service`) and drafts the upstream patch. | Fence-reboot then re-attach verified end to end on the dev cluster with the workaround. |
| 2026-07-04 | Per-backend verification against `os_brick` 5.2.4; patch rebased onto master [`fd4b0df20`](https://github.com/oVirt/vdsm/commit/fd4b0df20); full test suite green. | 4 of 5 supported drivers confirmed affected. Ready to open the PR. |


## Testing:

- new `test_reattach_after_fence_reboot_drops_stale_db_entry` simulating the tmpfs wipe plus re-attach
- existing attach/detach/reattach tests unchanged and passing (21 passed, 1 pre-existing xfail)
- the fence-reboot then re-attach flow verified end to end on a 3-node EL9 cluster with an MBS domain backed by DRBD/LINSTOR