### PR TITLE
virt: handle vm stuck in powering down state

### DIFF
--- a/lib/vdsm/virt/vm.py
+++ b/lib/vdsm/virt/vm.py
@@ -5890,6 +5890,16 @@ class Vm(object):
                 self.log.warning(
                     "VM '%s' couldn't be destroyed in libvirt: %s", self.id, e
                 )
+            elif (
+                e.get_error_code() == libvirt.VIR_ERR_OPERATION_INVALID
+                and self._is_domain_down()
+            ):
+                # The domain is actually gone, but something went wrong
+                # and we still thought it was up.
+                self.log.info(
+                    "VM '%s' already down (graceful, operation invalid)",
+                    self.id,
+                )
             else:
                 self.log.warning(
                     "Failed to destroy VM '%s' gracefully (error=%i)",
@@ -5910,15 +5920,58 @@ class Vm(object):
         try:
             self._dom.destroy()
         except libvirt.libvirtError as e:
-            self.log.warning(
-                "Failed to destroy VM '%s' forcefully (error=%i)",
-                self.id,
-                e.get_error_code(),
-            )
-            return response.error('destroyErr')
+            if (
+                e.get_error_code() == libvirt.VIR_ERR_OPERATION_INVALID
+                and self._is_domain_down()
+            ):
+                self.log.info(
+                    "VM '%s' already down (forceful, operation invalid)",
+                    self.id,
+                )
+            else:
+                self.log.warning(
+                    "Failed to destroy VM '%s' forcefully (error=%i)",
+                    self.id,
+                    e.get_error_code(),
+                )
+                return response.error('destroyErr')
         except virdomain.NotConnectedError:
             self.log.info("VM already down")
         return response.success()
+
+    def _is_domain_down(self):
+        """
+        Check whether the underlying libvirt domain is actually down.
+
+        This is used to recover from situations where libvirt returns
+        VIR_ERR_OPERATION_INVALID on destroy attempts but the qemu process
+        is already gone.
+
+        Note: this method must only be called from contexts where the domain
+        was already known to be connected (e.g. _destroyVmGraceful /
+        _destroyVmForceful, which are guarded by the `self._dom.connected`
+        check in releaseVm). A NotConnectedError here means the domain
+        disconnected between that check and this call, which is a benign race
+        indicating the domain is going down.
+        """
+        try:
+            state, _ = self._dom.state(0)
+        except virdomain.NotConnectedError:
+            # The domain was connected when releaseVm checked, but it
+            # disconnected since then (e.g. qemu died and _onQemuDeath ran).
+            # This is a benign race: the domain is going down.
+            self.log.info(
+                "VM '%s' domain disconnected during destroy", self.id
+            )
+            return True
+        except libvirt.libvirtError as e:
+            if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
+                return True
+            self.log.warning(
+                "Could not check domain state for VM '%s': %s", self.id, e
+            )
+            return False
+        return state in vmstatus.LIBVIRT_DOWN_STATES
 
     def _deleteVm(self):
         """

--- a/tests/virt/vm_test.py
+++ b/tests/virt/vm_test.py
@@ -761,6 +761,124 @@ class TestVm(XMLTestCase):
                 'forceful': 1,
             }
 
+    @MonkeyPatch(os, 'unlink', lambda _: None)
+    def test_releasevm_graceful_op_invalid_domain_down(self):
+        # When libvirt returns VIR_ERR_OPERATION_INVALID but the domain is
+        # actually down (e.g. qemu died without libvirt emitting a STOPPED
+        # event), releaseVm must succeed instead of getting stuck in
+        # 'Powering down' state.
+        with fake.VM(self.conf) as testvm:
+            testvm.guestAgent = fake.GuestAgent()
+
+            dom = fake.Domain(
+                domState=libvirt.VIR_DOMAIN_SHUTOFF,
+            )
+
+            def graceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_OPERATION_INVALID)
+
+            dom.destroyFlags = graceful
+            testvm._dom = dom
+
+            result = testvm.releaseVm()
+            assert not response.is_error(result)
+
+    @MonkeyPatch(os, 'unlink', lambda _: None)
+    def test_releasevm_graceful_op_invalid_domain_running(self):
+        # When libvirt returns VIR_ERR_OPERATION_INVALID and the domain is
+        # still running, releaseVm must fail so the caller can retry or
+        # escalate to a forceful destroy.
+        with fake.VM(self.conf) as testvm:
+            testvm.guestAgent = fake.GuestAgent()
+
+            dom = fake.Domain(
+                domState=libvirt.VIR_DOMAIN_RUNNING,
+            )
+
+            def graceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_OPERATION_INVALID)
+
+            dom.destroyFlags = graceful
+            testvm._dom = dom
+
+            result = testvm.releaseVm()
+            assert response.is_error(result)
+
+    @MonkeyPatch(os, 'unlink', lambda _: None)
+    def test_releasevm_forceful_op_invalid_domain_down(self):
+        # When libvirt returns VIR_ERR_OPERATION_INVALID on forceful destroy
+        # but the domain is actually down, releaseVm must succeed instead of
+        # getting stuck in 'Powering down' state.
+        with fake.VM(self.conf) as testvm:
+            testvm.guestAgent = fake.GuestAgent()
+
+            dom = fake.Domain(
+                domState=libvirt.VIR_DOMAIN_SHUTOFF,
+            )
+
+            def graceful(*args):
+                # graceful destroy fails with SYSTEM_ERROR to force the
+                # forceful path
+                raise fake.Error(libvirt.VIR_ERR_SYSTEM_ERROR)
+
+            def forceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_OPERATION_INVALID)
+
+            dom.destroyFlags = graceful
+            dom.destroy = forceful
+            testvm._dom = dom
+
+            result = testvm.releaseVm()
+            assert not response.is_error(result)
+
+    @MonkeyPatch(os, 'unlink', lambda _: None)
+    def test_releasevm_forceful_op_invalid_domain_running(self):
+        # When libvirt returns VIR_ERR_OPERATION_INVALID on forceful destroy
+        # and the domain is still running, releaseVm must fail.
+        with fake.VM(self.conf) as testvm:
+            testvm.guestAgent = fake.GuestAgent()
+
+            dom = fake.Domain(
+                domState=libvirt.VIR_DOMAIN_RUNNING,
+            )
+
+            def graceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_SYSTEM_ERROR)
+
+            def forceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_OPERATION_INVALID)
+
+            dom.destroyFlags = graceful
+            dom.destroy = forceful
+            testvm._dom = dom
+
+            result = testvm.releaseVm()
+            assert response.is_error(result)
+
+    @MonkeyPatch(os, 'unlink', lambda _: None)
+    def test_releasevm_graceful_op_invalid_laststatus_down(self):
+        # When VDSM already believes the VM is down (lastStatus == DOWN) and
+        # libvirt returns VIR_ERR_OPERATION_INVALID on graceful destroy,
+        # releaseVm must succeed without re-querying the domain state. This
+        # locks in the pre-existing behaviour of the lastStatus == DOWN
+        # branch that the new domain-down branch sits next to.
+        with fake.VM(self.conf) as testvm:
+            testvm.guestAgent = fake.GuestAgent()
+            testvm.set_last_status(vmstatus.DOWN)
+
+            dom = fake.Domain(
+                domState=libvirt.VIR_DOMAIN_RUNNING,
+            )
+
+            def graceful(*args):
+                raise fake.Error(libvirt.VIR_ERR_OPERATION_INVALID)
+
+            dom.destroyFlags = graceful
+            testvm._dom = dom
+
+            result = testvm.releaseVm()
+            assert not response.is_error(result)
+
     def test_acpi_enabled(self):
         with fake.VM(arch=cpuarch.X86_64, features='<acpi/>') as testvm:
             assert testvm.acpi_enabled()


### PR DESCRIPTION
When we poweroff a vm, and it's doing some actions (for example a blockjob), this can return VIR_ERR_OPERATION_INVALID.

But if in the meantime the VM stopped anyway, then this will not be handled anymore. As from now on destroy on the VM will return VIR_ERR_OPERATION_INVALID (because the vm doesn't exist anymore), which is not handled correctly.

Therefor we check the vm state when VIR_ERR_OPERATION_INVALID is returned. If the VM is down, then we return success for the destroy operation.