### PR TITLE
thinp: Do not extend drives while monitoring is disabled

### DIFF
--- a/lib/vdsm/virt/thinp.py
+++ b/lib/vdsm/virt/thinp.py
@@ -248,6 +248,19 @@ class VolumeMonitor(object):
     def _extend_drive_soon(self, drive):
         if self._dispatch is None:
             return
+        if not self._enabled:
+            # Volume monitoring is disabled, typically during live merge while
+            # the volume chain is being modified and cannot be trusted.
+            # Dispatching an extend now may race with the pivot and query a
+            # stale volume chain. The drive is already marked for extension, so
+            # the periodic monitor will extend it once monitoring is enabled
+            # again, resuming the VM if it paused on ENOSPC.
+            self._log.debug(
+                "Volume monitoring disabled, deferring extension of drive %s "
+                "to the periodic monitor",
+                drive.name,
+            )
+            return
         self._log.debug("Scheduling drive %s extension", drive.name)
         try:
             self._dispatch(
@@ -322,7 +335,17 @@ class VolumeMonitor(object):
             return False
 
         for drive in drives:
-            self._query_block_info(drive, drive.volumeID, block_stats)
+            try:
+                self._query_block_info(drive, drive.volumeID, block_stats)
+            except storage.VolumeNotFound as e:
+                # The drive volume chain changed while we were querying block
+                # stats, typically racing with a live merge pivot. The drive
+                # will be picked up again by the periodic monitor once its
+                # metadata is consistent with libvirt.
+                self._log.warning(
+                    "Cannot update block info for drive %s: %s", drive.name, e
+                )
+                return False
 
         return True
 

--- a/tests/virt/thinp_test.py
+++ b/tests/virt/thinp_test.py
@@ -9,7 +9,7 @@ from vdsm.virt import thinp
 
 from vdsm.common.config import config
 from vdsm.common.units import MiB, GiB
-from vdsm.virt.vmdevices.storage import Drive, BLOCK_THRESHOLD
+from vdsm.virt.vmdevices.storage import Drive, BLOCK_THRESHOLD, VolumeNotFound
 
 EXTEND_TIMEOUT = config.getfloat("thinp", "extend_timeout")
 
@@ -140,6 +140,52 @@ def test_on_enospc():
     assert args == dict(timeout=EXTEND_TIMEOUT, discard=True)
 
 
+def test_on_block_threshold_disabled_defers_extend():
+    # During live merge volume monitoring is disabled. An event must mark the
+    # drive for extension but must not dispatch an immediate extend, which
+    # could race with the pivot and query a stale volume chain.
+    vm = FakeVM()
+    dispatch = FakeDispatch()
+    mon = thinp.VolumeMonitor(vm, vm.log, dispatch=dispatch, enabled=False)
+    vda = make_drive(vm.log, index=0, iface='virtio')
+    vm.drives.append(vda)
+
+    mon.on_block_threshold("vda[1]", vda.path, 512 * MiB, 10 * MiB)
+
+    assert vda.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+    assert len(dispatch.calls) == 0
+
+
+def test_on_enospc_disabled_defers_extend():
+    vm = FakeVM()
+    dispatch = FakeDispatch()
+    mon = thinp.VolumeMonitor(vm, vm.log, dispatch=dispatch, enabled=False)
+    vda = make_drive(vm.log, index=0, iface='virtio')
+    vm.drives.append(vda)
+
+    mon.on_enospc(vda)
+
+    assert vda.threshold_state == BLOCK_THRESHOLD.EXCEEDED
+    assert len(dispatch.calls) == 0
+
+
+def test_update_block_info_volume_not_found():
+    # The volume chain may change while querying block stats, e.g. racing with
+    # a live merge pivot. This must not raise, so the drive can be retried in
+    # the next monitoring cycle.
+    vm = FakeVM()
+    mon = thinp.VolumeMonitor(vm, vm.log)
+    vda = make_drive(vm.log, index=0, iface='virtio')
+    vm.drives.append(vda)
+
+    def query_drive_volume_index(drive, vol_id):
+        raise VolumeNotFound(drive_name=drive.name, vol_id=vol_id)
+
+    vm.query_drive_volume_index = query_drive_volume_index
+
+    assert mon._update_block_info([vda]) is False
+
+
 def test_monitoring_needed():
 
     class FakeDrive:
@@ -184,6 +230,9 @@ class FakeVM(object):
 
     def getDiskDevices(self):
         return self.drives[:]
+
+    def query_block_stats(self):
+        return {"block.count": 0}
 
 
 class FakeDispatch:


### PR DESCRIPTION
The event-driven extend path (on_block_threshold / on_enospc -> _extend_drive_soon -> dispatched _extend_drive) was not gated on the monitor's enabled state, unlike the periodic monitor. Volume monitoring is disabled while the volume chain is being mutated - during live merge pivot, snapshot, and disk replica pivot - or when extension is unsafe (migration destination cannot refresh disks).

When a block threshold or ENOSPC event arrived during such a window, an extend task was still dispatched. During a live merge, the task could block in query_block_stats() until the pivot completed, then look up the old active volume (still in drive.volumeChain) against libvirt's post-pivot chain and raise an unhandled VolumeNotFound. The extend never completed and an ENOSPC-paused VM was left paused.

Gate _extend_drive_soon() on the enabled state so event-driven extends are deferred while monitoring is disabled. The drive is still marked for extension, so once monitoring is re-enabled the periodic monitor extends it and resumes the VM. This is consistent with the intent of every disable() call site, and the added check does not reintroduce the isDomainReadyForCommands() latency that the event path was designed to avoid.

Also make _update_block_info() resilient to VolumeNotFound so a chain change racing with an in-flight extend logs a warning and retries in the next monitoring cycle instead of raising an unhandled exception.